### PR TITLE
Remove duplicate OAuthLibMixin from base classes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Eduardo Oliveira
 Egor Poderiagin
 Emanuele Palazzetti
 Federico Dolce
+Florian Demmer
 Frederico Vieira
 Gaël Utard
 Hasan Ramezani

--- a/oauth2_provider/views/generic.py
+++ b/oauth2_provider/views/generic.py
@@ -2,14 +2,13 @@ from django.views.generic import View
 
 from .mixins import (
     ClientProtectedResourceMixin,
-    OAuthLibMixin,
     ProtectedResourceMixin,
     ReadWriteScopedResourceMixin,
     ScopedResourceMixin,
 )
 
 
-class ProtectedResourceView(ProtectedResourceMixin, OAuthLibMixin, View):
+class ProtectedResourceView(ProtectedResourceMixin, View):
     """
     Generic view protecting resources by providing OAuth2 authentication out of the box
     """
@@ -35,7 +34,7 @@ class ReadWriteScopedResourceView(ReadWriteScopedResourceMixin, ProtectedResourc
     pass
 
 
-class ClientProtectedResourceView(ClientProtectedResourceMixin, OAuthLibMixin, View):
+class ClientProtectedResourceView(ClientProtectedResourceMixin, View):
 
     """View for protecting a resource with client-credentials method.
     This involves allowing access tokens, Basic Auth and plain credentials in request body.


### PR DESCRIPTION
## Description of the Change

The generic view classes `ProtectedResourceView` and `ClientProtectedResourceView` inherit from `ProtectedResourceMixin` and `ClientProtectedResourceMixin` respectively, which both inherit `OAuthLibMixin` already.

It seems redundant to me to have the views inherit `OAuthLibMixin` again.

If there is no reason I am missing, this PR fixes that.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
