### PR TITLE
Cache loading of JWK object from OIDC private key

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,6 +29,7 @@ Bart Merenda
 Bas van Oostveen
 Brian Helba
 Carl Schwan
+Daniel Golding
 Daniel 'Vector' Kerr
 Darrel O'Pry
 Dave Burkholder

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
   -->
 
+## [unreleased]
+
+### Added
+* #1273 Add caching of loading of OIDC private key.
+
 ## [2.3.0] 2023-05-31
 
 ### WARNING

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -19,6 +19,7 @@ from oauthlib.oauth2.rfc6749 import errors
 from .generators import generate_client_id, generate_client_secret
 from .scopes import get_scopes_backend
 from .settings import oauth2_settings
+from .utils import jwk_from_pem
 from .validators import RedirectURIValidator, WildcardSet
 
 
@@ -234,7 +235,7 @@ class AbstractApplication(models.Model):
         if self.algorithm == AbstractApplication.RS256_ALGORITHM:
             if not oauth2_settings.OIDC_RSA_PRIVATE_KEY:
                 raise ImproperlyConfigured("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm")
-            return jwk.JWK.from_pem(oauth2_settings.OIDC_RSA_PRIVATE_KEY.encode("utf8"))
+            return jwk_from_pem(oauth2_settings.OIDC_RSA_PRIVATE_KEY)
         elif self.algorithm == AbstractApplication.HS256_ALGORITHM:
             return jwk.JWK(kty="oct", k=base64url_encode(self.client_secret))
         raise ImproperlyConfigured("This application does not support signed tokens")

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -1,0 +1,12 @@
+import functools
+
+from jwcrypto import jwk
+
+
+@functools.lru_cache()
+def jwk_from_pem(pem_string):
+    """
+    A cached version of jwcrypto.JWK.from_pem.
+    Converting from PEM is expensive for large keys such as those using RSA.
+    """
+    return jwk.JWK.from_pem(pem_string.encode("utf-8"))

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import FormView, View
-from jwcrypto import jwk, jwt
+from jwcrypto import jwt
 from jwcrypto.common import JWException
 from jwcrypto.jws import InvalidJWSObject
 from jwcrypto.jwt import JWTExpired
@@ -30,6 +30,7 @@ from ..models import (
     get_refresh_token_model,
 )
 from ..settings import oauth2_settings
+from ..utils import jwk_from_pem
 from .mixins import OAuthLibMixin, OIDCLogoutOnlyMixin, OIDCOnlyMixin
 
 
@@ -114,7 +115,7 @@ class JwksInfoView(OIDCOnlyMixin, View):
                 oauth2_settings.OIDC_RSA_PRIVATE_KEY,
                 *oauth2_settings.OIDC_RSA_PRIVATE_KEYS_INACTIVE,
             ]:
-                key = jwk.JWK.from_pem(pem.encode("utf8"))
+                key = jwk_from_pem(pem)
                 data = {"alg": "RS256", "use": "sig", "kid": key.thumbprint()}
                 data.update(json.loads(key.export_public()))
                 keys.append(data)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,27 @@
+from oauth2_provider import utils
+
+
+def test_jwk_from_pem_caches_jwk():
+    a_tiny_rsa_key = """-----BEGIN RSA PRIVATE KEY-----
+MGQCAQACEQCxqYaL6GtPooVMhVwcZrCfAgMBAAECECyNmdsuHvMqIEl9/Fex27kC
+CQDlc0deuSVrtQIJAMY4MTw2eCeDAgkA5VzfMykQ5yECCQCgkF4Zl0nHPwIJALPv
++IAFUPv3
+-----END RSA PRIVATE KEY-----"""
+
+    # For the same private key we expect the same object to be returned
+
+    jwk1 = utils.jwk_from_pem(a_tiny_rsa_key)
+    jwk2 = utils.jwk_from_pem(a_tiny_rsa_key)
+
+    assert jwk1 is jwk2
+
+    a_different_tiny_rsa_key = """-----BEGIN RSA PRIVATE KEY-----
+MGMCAQACEQCvyNNNw4J201yzFVogcfgnAgMBAAECEE3oXe5bNlle+xU4EVHTUIEC
+CQDpSvwIvDMSIQIJAMDk47DzG9FHAghtvg1TWpy3oQIJAL6NHlS+RBufAgkA6QLA
+2GK4aDc=
+-----END RSA PRIVATE KEY-----"""
+
+    # But for a different key, a different object
+    jwk3 = utils.jwk_from_pem(a_different_tiny_rsa_key)
+
+    assert jwk3 is not jwk1


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1263

## Description of the Change

This adds caching so that the OIDC private key is only loaded once.

Testing via the repro instructions in the referenced issue, on my machine the request time for the code-for-token exchange reduces from 1.5s to 150ms from the second request onwards (the first request take 820ms due to needing to load from the PEM the first time).

I'm not super happy with adding a `utils` module but I was unable to determine a good place to put the cached function.

The implementation uses [`functools.lru_cache`](https://docs.python.org/3.7/library/functools.html#functools.lru_cache) - which seems like a good option with the limitation of being restricted to what is available in python 3.7.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`

~Since there is no functional change, I feel the existing unit tests already cover the changes sufficiently but I'm happy to hear suggestions.~ _now tested_