### PR TITLE
Adds the ability to define how to store a user

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -60,6 +60,7 @@ Hasan Ramezani
 Hiroki Kiyohara
 Hossein Shakiba
 Islam Kamel
+Ivan Lukyanets
 Jadiel Teófilo
 Jens Timmerman
 Jerome Leclanche

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1337 Gracefully handle expired or deleted refresh tokens, in `validate_user`.
 * #1350 Support Python 3.12 and Django 5.0
 * #1249 Add code_challenge_methods_supported property to auto discovery information, per [RFC 8414 section 2](https://www.rfc-editor.org/rfc/rfc8414.html#page-7)
+* #1328 Adds the ability to define how to store a user profile
 
 
 ### Fixed

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -404,6 +404,17 @@ In the docs below, it assumes that you have mounted the
 the URLs accordingly.
 
 
+Define where to store the profile
+=================================
+
+.. py:function:: OAuth2Validator.get_or_create_user_from_content(content)
+
+An optional layer to define where to store the profile in ``UserModel`` or a separate model. For example ``UserOAuth``, where ``user = models.OneToOneField(UserModel)``.
+
+The function is called after checking that the username is present in the content.
+
+:return: An instance of the ``UserModel`` representing the user fetched or created.
+
 ConnectDiscoveryInfoView
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -341,9 +341,7 @@ class OAuth2Validator(RequestValidator):
 
         Returns an UserModel instance;
         """
-        user, _ = UserModel.objects.get_or_create(
-            **{UserModel.USERNAME_FIELD: content["username"]}
-        )
+        user, _ = UserModel.objects.get_or_create(**{UserModel.USERNAME_FIELD: content["username"]})
         return user
 
     def _get_token_from_authentication_server(

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -336,9 +336,7 @@ class TestOAuth2Validator(TransactionTestCase):
         assert create_refresh_token_mock.call_count == 1
 
     def test_get_or_create_user_from_content(self):
-        content = {
-            "username": "test_user"
-        }
+        content = {"username": "test_user"}
         UserModel.objects.filter(username=content["username"]).delete()
         user = self.validator.get_or_create_user_from_content(content)
 

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -335,6 +335,16 @@ class TestOAuth2Validator(TransactionTestCase):
         assert create_access_token_mock.call_count == 1
         assert create_refresh_token_mock.call_count == 1
 
+    def test_get_or_create_user_from_content(self):
+        content = {
+            "username": "test_user"
+        }
+        UserModel.objects.filter(username=content["username"]).delete()
+        user = self.validator.get_or_create_user_from_content(content)
+
+        self.assertIsNotNone(user)
+        self.assertEqual(content["username"], user.username)
+
 
 class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):
     """These test cases check that the recommended error codes are returned


### PR DESCRIPTION
## Description of the Change
Faced a problem that it is not possible now to specify the user's storage location in the validator. This functionality is now a separate public method that can be easily reused. If you agree with me, I will implement the rest of the checklist items (tests, docs, etc.).

## Checklist
- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
