### PR TITLE
Fix: Handle AttributeError in IntrospectTokenView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1512 client_secret not marked sensitive
 * #1521 Fix 0012 migration loading access token table into memory
 * #1584 Fix IDP container in docker compose environment could not find templates and static files.
+* #1562 Fix: Handle AttributeError in IntrospectTokenView
 <!--
 ### Security
 -->

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -2,7 +2,7 @@ import calendar
 import hashlib
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import HttpResponseBadRequest, JsonResponse
+from django.http import JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -2,7 +2,7 @@ import calendar
 import hashlib
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import JsonResponse, HttpResponseBadRequest
+from django.http import HttpResponseBadRequest, JsonResponse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -33,7 +33,7 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
                 .objects.select_related("user", "application")
                 .get(token_checksum=token_checksum)
             )
-        except ObjectDoesNotExist:
+        except (AttributeError, ObjectDoesNotExist):
             return JsonResponse({"active": False}, status=200)
         else:
             if token.is_valid():

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -2,7 +2,7 @@ import calendar
 import hashlib
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponseBadRequest
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
@@ -33,8 +33,12 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
                 .objects.select_related("user", "application")
                 .get(token_checksum=token_checksum)
             )
-        except (AttributeError, ObjectDoesNotExist):
+        except ObjectDoesNotExist:
             return JsonResponse({"active": False}, status=200)
+        except AttributeError:
+            return HttpResponseBadRequest(
+                {"error": "invalid_request", "error_description": "Token parameter is missing."}
+            )
         else:
             if token.is_valid():
                 data = {

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -36,8 +36,9 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
         except ObjectDoesNotExist:
             return JsonResponse({"active": False}, status=200)
         except AttributeError:
-            return HttpResponseBadRequest(
-                {"error": "invalid_request", "error_description": "Token parameter is missing."}
+            return JsonResponse(
+                {"error": "invalid_request", "error_description": "Token parameter is missing."},
+                status=400,
             )
         else:
             if token.is_valid():

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -26,6 +26,11 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
 
     @staticmethod
     def get_token_response(token_value=None):
+        if token_value is None:
+            return JsonResponse(
+                {"error": "invalid_request", "error_description": "Token parameter is missing."},
+                status=400,
+            )
         try:
             token_checksum = hashlib.sha256(token_value.encode("utf-8")).hexdigest()
             token = (
@@ -35,11 +40,6 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
             )
         except ObjectDoesNotExist:
             return JsonResponse({"active": False}, status=200)
-        except AttributeError:
-            return JsonResponse(
-                {"error": "invalid_request", "error_description": "Token parameter is missing."},
-                status=400,
-            )
         else:
             if token.is_valid():
                 data = {

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -278,6 +278,28 @@ class TestTokenIntrospectionViews(TestCase):
                 "active": False,
             },
         )
+    
+    def test_view_post_no_token(self):
+        """
+        Test that when you pass an empty token as form parameter,
+        a json with an inactive token state is provided
+        """
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
+        }
+        response = self.client.post(
+            reverse("oauth2_provider:introspect"), **auth_headers
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
+        self.assertIsInstance(content, dict)
+        self.assertDictEqual(
+            content,
+            {
+                "active": False,
+            },
+        )
 
     def test_view_post_valid_client_creds_basic_auth(self):
         """Test HTTP basic auth working"""

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -278,7 +278,7 @@ class TestTokenIntrospectionViews(TestCase):
                 "active": False,
             },
         )
-    
+
     def test_view_post_no_token(self):
         """
         Test that when you pass an empty token as form parameter,
@@ -287,9 +287,7 @@ class TestTokenIntrospectionViews(TestCase):
         auth_headers = {
             "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
         }
-        response = self.client.post(
-            reverse("oauth2_provider:introspect"), **auth_headers
-        )
+        response = self.client.post(reverse("oauth2_provider:introspect"), **auth_headers)
 
         self.assertEqual(response.status_code, 200)
         content = response.json()

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -281,23 +281,17 @@ class TestTokenIntrospectionViews(TestCase):
 
     def test_view_post_no_token(self):
         """
-        Test that when you pass an empty token as form parameter,
-        a json with an inactive token state is provided
+        Test that when you pass no token HTTP 400 is returned
         """
         auth_headers = {
             "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
         }
         response = self.client.post(reverse("oauth2_provider:introspect"), **auth_headers)
 
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         content = response.json()
         self.assertIsInstance(content, dict)
-        self.assertDictEqual(
-            content,
-            {
-                "active": False,
-            },
-        )
+        self.assertEqual(content["error"], "invalid_request")
 
     def test_view_post_valid_client_creds_basic_auth(self):
         """Test HTTP basic auth working"""

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,10 @@ envlist =
     docs,
     lint,
     sphinxlint,
-    py{38,39,310,311,312}-dj42,
-    py{310,311,312}-dj50,
-    py{310,311,312}-dj51,
-    py{310,311,312}-djmain,
+    py{38,39,310,311,312,313}-dj42,
+    py{310,311,312,313}-dj50,
+    py{310,311,312,313}-dj51,
+    py{310,311,312,313}-djmain,
     py39-multi-db-dj-42
 
 [gh-actions]
@@ -18,6 +18,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 DJANGO =
@@ -54,7 +55,7 @@ deps =
 passenv =
     PYTEST_ADDOPTS
 
-[testenv:py{310,311,312}-djmain]
+[testenv:py{310,311,312,313}-djmain]
 ignore_errors = true
 ignore_outcome = true
 


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change

Handle `AttributeError` in `get_token_response`. If there is no `token` parameter in introspect endpoints they raise `AttributeError`.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
