### PR TITLE
use pk instead of id in clear expired tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release.
 
 ### Fixed
+* #1593 Use `pk` instead of `id` in `clear_expired()` and `RefreshToken.revoke()` so token models with a custom primary key field are supported.
 * #1594 Fix introspection token expiry handling to consistently use UTC and avoid the deprecated
   `datetime.utcfromtimestamp`.
 * #1696 Fix `auth_time` in oauth2 validator when user has never logged in.

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -537,7 +537,7 @@ class AbstractRefreshToken(models.Model):
             self = list(token)[0]
 
             with suppress(access_token_model.DoesNotExist):
-                access_token_model.objects.get(id=self.access_token_id).revoke()
+                access_token_model.objects.get(pk=self.access_token_id).revoke()
 
             self.access_token = None
             self.revoked = timezone.now()

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -818,9 +818,9 @@ def clear_expired():
         current_no = start_no = queryset.count()
 
         while current_no:
-            flat_queryset = queryset.values_list("id", flat=True)[:CLEAR_EXPIRED_TOKENS_BATCH_SIZE]
+            flat_queryset = queryset.values_list("pk", flat=True)[:CLEAR_EXPIRED_TOKENS_BATCH_SIZE]
             batch_length = flat_queryset.count()
-            queryset.model.objects.filter(id__in=list(flat_queryset)).delete()
+            queryset.model.objects.filter(pk__in=list(flat_queryset)).delete()
             logger.debug(f"{batch_length} tokens deleted, {current_no - batch_length} left")
             queryset = queryset.model.objects.filter(query)
             time.sleep(CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL)

--- a/tests/migrations/0009_custompkaccesstoken_and_more.py
+++ b/tests/migrations/0009_custompkaccesstoken_and_more.py
@@ -1,0 +1,114 @@
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+import oauth2_provider.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        migrations.swappable_dependency(settings.OAUTH2_PROVIDER_APPLICATION_MODEL),
+        ("tests", "0008_sampledevicegrant"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="CustomPkAccessToken",
+            fields=[
+                ("token", models.TextField()),
+                (
+                    "token_checksum",
+                    oauth2_provider.models.TokenChecksumField(db_index=True, max_length=64, unique=True),
+                ),
+                ("expires", models.DateTimeField()),
+                ("scope", models.TextField(blank=True)),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("updated", models.DateTimeField(auto_now=True)),
+                (
+                    "custom_pk",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "application",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(app_label)s_%(class)s",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.CreateModel(
+            name="CustomPkRefreshToken",
+            fields=[
+                ("token", models.CharField(max_length=255)),
+                (
+                    "token_family",
+                    models.UUIDField(blank=True, editable=False, null=True),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                ("updated", models.DateTimeField(auto_now=True)),
+                ("revoked", models.DateTimeField(null=True)),
+                (
+                    "custom_pk",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "access_token",
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="refresh_token",
+                        to="tests.custompkaccesstoken",
+                    ),
+                ),
+                (
+                    "application",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to=settings.OAUTH2_PROVIDER_APPLICATION_MODEL,
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(app_label)s_%(class)s",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "unique_together": {("token", "revoked")},
+            },
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.db import models
 
 from oauth2_provider.models import (
@@ -69,3 +71,31 @@ class LocalIDToken(AbstractIDToken):
     """Exists to be improperly configured for multiple databases."""
 
     # The other token types will be in 'alpha' database.
+
+
+class CustomPkAccessToken(AbstractAccessToken):
+    """AccessToken with a custom (non-``id``) primary key.
+
+    Used to verify that ``clear_expired()`` and ``RefreshToken.revoke()`` do
+    not assume the primary key field is named ``id``.
+    See https://github.com/django-oauth/django-oauth-toolkit/pull/1593
+    """
+
+    id = None
+    source_refresh_token = None
+    id_token = None
+    custom_pk = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+
+class CustomPkRefreshToken(AbstractRefreshToken):
+    """RefreshToken with a custom (non-``id``) primary key."""
+
+    id = None
+    custom_pk = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    access_token = models.OneToOneField(
+        CustomPkAccessToken,
+        on_delete=models.SET_NULL,
+        blank=True,
+        null=True,
+        related_name="refresh_token",
+    )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,7 @@
 import hashlib
 import secrets
 from datetime import timedelta
+from unittest import mock
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -9,6 +10,7 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.test.utils import override_settings
 from django.utils import timezone
 
+from oauth2_provider import models as oauth2_models
 from oauth2_provider.models import (
     clear_expired,
     get_access_token_model,
@@ -21,6 +23,7 @@ from oauth2_provider.models import (
 
 from . import presets
 from .common_testing import OAuth2ProviderTestCase as TestCase
+from .models import CustomPkAccessToken, CustomPkRefreshToken
 
 
 CLEARTEXT_SECRET = "1234567890abcdefghijklmnopqrstuvwxyz"
@@ -481,6 +484,74 @@ class TestClearExpired(BaseTestModels):
         )
         remaining_gt_count = Grant.objects.count()
         assert remaining_gt_count == initial_gt_count // 2, "half the remaining grants should still exist."
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class TestCustomPrimaryKeyTokens(BaseTestModels):
+    """
+    Regression tests for token models that use a custom primary key field
+    (i.e. not named ``id``).
+
+    ``tests.CustomPkAccessToken`` and ``tests.CustomPkRefreshToken`` use a
+    ``UUIDField`` primary key named ``custom_pk``. The model getters are patched
+    so that ``clear_expired()`` and ``RefreshToken.revoke()`` operate on these
+    models, exercising the code paths that previously hard-coded ``id``.
+
+    See https://github.com/django-oauth/django-oauth-toolkit/pull/1593
+    """
+
+    def test_clear_expired_with_custom_pk(self):
+        """clear_expired() must work when the access token uses a custom pk."""
+        now = timezone.now()
+        expired = now - timedelta(seconds=3600)
+        later = now + timedelta(seconds=3600)
+        for i in range(3):
+            CustomPkAccessToken.objects.create(token=f"expired {i}", expires=expired)
+        for i in range(2):
+            CustomPkAccessToken.objects.create(token=f"current {i}", expires=later)
+
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
+        with (
+            mock.patch.object(oauth2_models, "get_access_token_model", return_value=CustomPkAccessToken),
+            mock.patch.object(oauth2_models, "get_refresh_token_model", return_value=CustomPkRefreshToken),
+        ):
+            clear_expired()
+
+        assert CustomPkAccessToken.objects.count() == 2, "expired access tokens should be deleted."
+        assert not CustomPkAccessToken.objects.filter(expires__lt=now).exists()
+
+    def test_refresh_token_revoke_with_custom_pk(self):
+        """RefreshToken.revoke() must work when tokens use a custom pk."""
+        application = Application.objects.create(
+            name="test_app",
+            redirect_uris="http://localhost",
+            user=self.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = CustomPkAccessToken.objects.create(
+            token="test_token",
+            expires=timezone.now() + timedelta(hours=1),
+        )
+        refresh_token = CustomPkRefreshToken.objects.create(
+            token="test_refresh_token",
+            user=self.user,
+            application=application,
+            access_token=access_token,
+        )
+
+        with (
+            mock.patch.object(oauth2_models, "get_access_token_model", return_value=CustomPkAccessToken),
+            mock.patch.object(oauth2_models, "get_refresh_token_model", return_value=CustomPkRefreshToken),
+        ):
+            refresh_token.revoke()
+
+        refresh_token.refresh_from_db()
+        assert refresh_token.revoked is not None
+        assert refresh_token.access_token_id is None
+        assert not CustomPkAccessToken.objects.filter(pk=access_token.pk).exists(), (
+            "the related access token should have been revoked."
+        )
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Fixing error in clearing expired tokens when custom pk used.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
