### PR TITLE
Add threshold check to add token migration

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -138,3 +138,4 @@ Miriam Forner
 Alex Kerkum
 Tuhin Mitra
 q0w
+Wojciech Węgrzyn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,7 @@ The project is now hosted in the django-oauth organization.
 ### WARNING - POTENTIAL BREAKING CHANGES
 * Changes to the `AbstractAccessToken` model require doing a `manage.py migrate` after upgrading.
 * If you use swappable models you will need to make sure your custom models are also updated (usually `manage.py makemigrations`).
-* This migration won't run, if application has over 50000 objects to update, as it would lead to the app downtime. Clear up your
-* old tokens or update them before applying the migration.
+* The `0012_add_token_checksum` migration will fail if there are over 50,000 access tokens to prevent database locking and downtime. To apply this update, either clean up your old tokens first or manually edit the migration to use a larger `THRESHOLD` value.
 * Old Django versions below 4.2 are no longer supported.
 * A few deprecations warned about in 2.4.0 (#1345) have been removed. See below.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ The project is now hosted in the django-oauth organization.
 ### WARNING - POTENTIAL BREAKING CHANGES
 * Changes to the `AbstractAccessToken` model require doing a `manage.py migrate` after upgrading.
 * If you use swappable models you will need to make sure your custom models are also updated (usually `manage.py makemigrations`).
+* This migration won't run, if application has over 50000 objects to update, as it would lead to the app downtime. Clear up your
+* old tokens or update them before applying the migration.
 * Old Django versions below 4.2 are no longer supported.
 * A few deprecations warned about in 2.4.0 (#1345) have been removed. See below.
 

--- a/oauth2_provider/migrations/0012_add_token_checksum.py
+++ b/oauth2_provider/migrations/0012_add_token_checksum.py
@@ -12,14 +12,13 @@ def forwards_func(apps, schema_editor):
     
     # Arbitrary value
     THRESHOLD = 50000
-    count = AccessToken.objects.count()
+    is_over_threshold = AccessToken._default_manager.all()[THRESHOLD:THRESHOLD+1].exists()
 
-    if count > THRESHOLD:
-        raise CommandError(
+    if is_over_threshold:
+        raise RuntimeError(
             f"Migration aborted: {count} AccessTokens found. "
             f"Updating more than {THRESHOLD} rows via RunPython is too slow. "
-            "Please run the data update via a background task/management command "
-            "before applying this migration."
+            "Please delete stale AccessToken objects manually before applying this migration."
         )
 
     # If under threshold, proceed with the update

--- a/oauth2_provider/migrations/0012_add_token_checksum.py
+++ b/oauth2_provider/migrations/0012_add_token_checksum.py
@@ -16,7 +16,7 @@ def forwards_func(apps, schema_editor):
 
     if is_over_threshold:
         raise RuntimeError(
-            f"Migration aborted: {count} AccessTokens found. "
+            f"Migration aborted: found too many AccessTokens. "
             f"Updating more than {THRESHOLD} rows via RunPython is too slow. "
             "Please delete stale AccessToken objects manually before applying this migration."
         )


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes slow migration when AccessTokens are not cleaned up. This is way safer approach than going with migration.

## Description of the Change

For the 0012 migration, add CommandError that prevents it running if too much AccessTokens are about to update. I have set the arbitrary threshold value.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
	- Not applicable 	
- [ ] documentation updated
	- Not applicable 	
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
	- Not applicable 	
- [ ] tests/app/rp updated to demonstrate new feature
	- Not applicable 	
