### PR TITLE
Pre-fill user_code by making use of verification_uri_complete

### DIFF
--- a/docs/tutorial/tutorial_06.rst
+++ b/docs/tutorial/tutorial_06.rst
@@ -29,6 +29,8 @@ but generally, it is assumed the device is unable to safely store the client sec
 
 Ensure the setting ``OAUTH_DEVICE_VERIFICATION_URI`` is set to a URI you want to return in the
 `verification_uri` key in the response. This is what the device will display to the user.
+Optionally, configure ``OAUTH_DEVICE_VERIFICATION_URI_COMPLETE`` to something like
+``http://127.0.0.1:8000/o/device?user_code={user_code}``.
 
 1. Navigate to the tests/app/idp directory:
 

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -128,6 +128,11 @@ class DeviceUserCodeView(LoginRequiredMixin, FormView):
             },
         )
 
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["user_code"] = self.request.GET.get("user_code", "")
+        return initial
+
     def form_valid(self, form):
         """
         Sets the device_grant on the instance so that it can be accessed

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -300,6 +300,45 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
         )
         assert refresh_token.user == device.user
 
+    def test_device_user_code_view_get_prefills_form_from_query_param(self):
+        """
+        A GET to the device user-code view with ?user_code=... should render a form
+        whose initial value for user_code is pre-populated from the query parameter.
+        """
+        UserModel.objects.create_user(
+            username="test_user_device_flow",
+            email="test_device@example.com",
+            password="password123",
+        )
+        self.client.login(username="test_user_device_flow", password="password123")
+
+        response = self.client.get(reverse("oauth2_provider:device"), data={"user_code": "WDJB-MJHT"})
+
+        assert response.status_code == 200
+        assert "form" in response.context
+        assert response.context["form"].initial.get("user_code") == "WDJB-MJHT"
+        assert b'value="WDJB-MJHT"' in response.content
+
+    def test_device_user_code_view_get_without_query_param_has_empty_initial(self):
+        """
+        A GET to the device user-code view without a user_code query parameter should
+        render a form with an empty initial value for user_code.
+        """
+        UserModel.objects.create_user(
+            username="test_user_device_flow",
+            email="test_device@example.com",
+            password="password123",
+        )
+        self.client.login(username="test_user_device_flow", password="password123")
+
+        response = self.client.get(reverse("oauth2_provider:device"))
+
+        assert response.status_code == 200
+        assert "form" in response.context
+        assert response.context["form"].initial.get("user_code", "") == ""
+        assert b'name="user_code"' in response.content
+        assert b'value="WDJB-MJHT"' not in response.content
+
     @mock.patch(
         "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
         lambda: "abc",


### PR DESCRIPTION
Fixes #1657 

## Description of the Change

While it was possible to configure `OAUTH_DEVICE_VERIFICATION_URI_COMPLETE` before, it did not make sense, because one still had to manually type the user code.
With my change the form is pre-filled with the value of the GET parameter `user_code`.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
