### PR TITLE
Fix duplicate unique constraint for device_code (#1656)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -59,6 +59,7 @@ Eduardo Oliveira
 Egor Poderiagin
 Emanuele Palazzetti
 Fazeel Ghafoor
+Febin Micheal Antony
 Federico Dolce
 Florian Demmer
 Frederico Vieira

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 * #1628 Fix inaccurate help_text on client_secret field of Application model
+* #1656 Fix duplicate unique constraint for device_code on Oracle 19c
 * #1674 Add `list_select_related` to `RefreshTokenAdmin` to avoid unbounded `JOIN` queries on the changelist
 * #1621 Fix device code tokens getting the wrong scope.
 * #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow

--- a/oauth2_provider/migrations/0013_alter_application_authorization_grant_type_device.py
+++ b/oauth2_provider/migrations/0013_alter_application_authorization_grant_type_device.py
@@ -35,7 +35,6 @@ class Migration(migrations.Migration):
             options={
                 'abstract': False,
                 'swappable': 'OAUTH2_PROVIDER_DEVICE_GRANT_MODEL',
-                'constraints': [models.UniqueConstraint(fields=('device_code',), name='oauth2_provider_devicegrant_unique_device_code')],
             },
         ),
     ]

--- a/oauth2_provider/migrations/0015_remove_duplicate_devicegrant_constraint.py
+++ b/oauth2_provider/migrations/0015_remove_duplicate_devicegrant_constraint.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+DUPLICATE_DEVICE_CODE_CONSTRAINT = "oauth2_provider_devicegrant_unique_device_code"
+
+
+def remove_duplicate_device_code_constraint(apps, schema_editor):
+    try:
+        DeviceGrant = apps.get_model("oauth2_provider", "DeviceGrant")
+    except LookupError:
+        return
+
+    if DeviceGrant._meta.swapped:
+        return
+
+    with schema_editor.connection.cursor() as cursor:
+        constraints = schema_editor.connection.introspection.get_constraints(
+            cursor,
+            DeviceGrant._meta.db_table,
+        )
+
+    if DUPLICATE_DEVICE_CODE_CONSTRAINT not in constraints:
+        return
+
+    schema_editor.remove_constraint(
+        DeviceGrant,
+        models.UniqueConstraint(
+            fields=["device_code"],
+            name=DUPLICATE_DEVICE_CODE_CONSTRAINT,
+        ),
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oauth2_provider", "0014_alter_help_text"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_duplicate_device_code_constraint, migrations.RunPython.noop),
+    ]

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -659,12 +659,6 @@ class IDToken(AbstractIDToken):
 class AbstractDeviceGrant(models.Model):
     class Meta:
         abstract = True
-        constraints = [
-            models.UniqueConstraint(
-                fields=["device_code"],
-                name="%(app_label)s_%(class)s_unique_device_code",
-            ),
-        ]
 
     AUTHORIZED = "authorized"
     AUTHORIZATION_PENDING = "authorization-pending"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1203,3 +1203,45 @@ class TestDeviceGrantUniqueConstraint(DeviceFlowBaseTestCase):
 
         assert device_code_field.unique is True
         assert create_model_operation.options.get("constraints", []) == []
+
+
+class TestDeviceGrantConstraintCleanupMigration:
+    def test_cleanup_migration_removes_legacy_constraint_when_present(self):
+        migration_module = import_module(
+            "oauth2_provider.migrations.0015_remove_duplicate_devicegrant_constraint"
+        )
+        apps = mock.Mock()
+        schema_editor = mock.Mock()
+        device_grant_model = mock.Mock()
+        device_grant_model._meta.swapped = None
+        device_grant_model._meta.db_table = "oauth2_provider_devicegrant"
+        apps.get_model.return_value = device_grant_model
+        schema_editor.connection.cursor.return_value = mock.MagicMock()
+        schema_editor.connection.introspection.get_constraints.return_value = {
+            migration_module.DUPLICATE_DEVICE_CODE_CONSTRAINT: {"unique": True}
+        }
+
+        migration_module.remove_duplicate_device_code_constraint(apps, schema_editor)
+
+        schema_editor.remove_constraint.assert_called_once()
+        model, constraint = schema_editor.remove_constraint.call_args.args
+        assert model is device_grant_model
+        assert constraint.name == migration_module.DUPLICATE_DEVICE_CODE_CONSTRAINT
+        assert constraint.fields == ("device_code",)
+
+    def test_cleanup_migration_skips_when_legacy_constraint_is_absent(self):
+        migration_module = import_module(
+            "oauth2_provider.migrations.0015_remove_duplicate_devicegrant_constraint"
+        )
+        apps = mock.Mock()
+        schema_editor = mock.Mock()
+        device_grant_model = mock.Mock()
+        device_grant_model._meta.swapped = None
+        device_grant_model._meta.db_table = "oauth2_provider_devicegrant"
+        apps.get_model.return_value = device_grant_model
+        schema_editor.connection.cursor.return_value = mock.MagicMock()
+        schema_editor.connection.introspection.get_constraints.return_value = {}
+
+        migration_module.remove_duplicate_device_code_constraint(apps, schema_editor)
+
+        schema_editor.remove_constraint.assert_not_called()

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+from importlib import import_module
 from unittest import mock
 from urllib.parse import urlencode
 
@@ -1151,3 +1152,54 @@ class TestDeviceFlowWithSwappedDeviceGrantModel(DeviceFlowBaseTestCase):
             text="Incorrect user code",
             count=1,
         )
+
+
+class TestDeviceGrantUniqueConstraint(DeviceFlowBaseTestCase):
+    def test_device_code_unique_at_db_level(self):
+        # Regression for #1656: field-level unique=True must enforce uniqueness
+        # even without a Meta.constraints UniqueConstraint.
+        from django.db import IntegrityError, transaction
+
+        expires = datetime.now(timezone.utc) + timedelta(hours=1)
+        DeviceModel.objects.create(
+            client_id=self.application.client_id,
+            device_code="duplicate_code",
+            user_code="AAAA-1111",
+            expires=expires,
+        )
+        # Wrap in a savepoint so the IntegrityError doesn't break the outer test transaction.
+        with transaction.atomic():
+            with pytest.raises(IntegrityError):
+                DeviceModel.objects.create(
+                    client_id=self.application.client_id,
+                    device_code="duplicate_code",
+                    user_code="BBBB-2222",
+                    expires=expires,
+                )
+
+    def test_no_duplicate_uniqueness_definition_in_meta(self):
+        # Regression for #1656: Meta.constraints must be empty so a duplicate
+        # UniqueConstraint on device_code cannot be silently re-introduced (breaks Oracle).
+        constraints = DeviceModel._meta.constraints
+        assert constraints == [], (
+            f"DeviceGrant has unexpected Meta.constraints: {constraints}. "
+            "Remove any UniqueConstraint on device_code to avoid a duplicate constraint on Oracle."
+        )
+
+    def test_migration_defines_only_field_level_uniqueness_for_device_code(self):
+        # Regression for #1656: migration 0013 must not define a second uniqueness
+        # rule for device_code in CreateModel.options.
+        migration_module = import_module(
+            "oauth2_provider.migrations.0013_alter_application_authorization_grant_type_device"
+        )
+        create_model_operation = next(
+            operation
+            for operation in migration_module.Migration.operations
+            if operation.__class__.__name__ == "CreateModel" and operation.name == "DeviceGrant"
+        )
+        device_code_field = next(
+            field for name, field in create_model_operation.fields if name == "device_code"
+        )
+
+        assert device_code_field.unique is True
+        assert create_model_operation.options.get("constraints", []) == []


### PR DESCRIPTION
Fixes #1656

## Description of the Change
This PR fixes issue #1656 by removing the second `UniqueConstraint` definition from `DeviceGrant` that causes `ORA-02261` on Oracle 19c deployments. Verified locally that this doesn't break PostgreSQL logic and added tests passing.
Also added febin-micheal to authors and #1656 to changelog.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features