### PR TITLE
Extract HttpRequest creation to own method

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -102,6 +102,7 @@ Matej Spiller Muys
 Matias Seniquiel
 Michael Howitz
 Michael "Irish" O'Neill
+Mikko Kupsu
 Nils Caspar
 Owen Gong
 Patrick Palacin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * New `docs/security.rst` page mapping each RFC 9700 recommendation to the corresponding setting. The demo IdP
   exposes every gate as an `OAUTH2_PROVIDER_COMPLIANT_BCP_RFC9700_*` environment variable so the Docker image and the
   e2e suite can exercise both gate positions.
+* #1660 Extract the `HttpRequest` creation in `OAuth2Validator.validate_user` into an overridable
+  `build_http_request` method, so subclasses can pass extra attributes through to their authentication backends.
 
 ### Deprecated
 * Using the OAuth 2.0 implicit grant, the resource owner password credentials grant, the PKCE `plain`

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -387,6 +387,27 @@ token, so you will probably want to reuse that::
             claims["color_scheme"] = get_color_scheme(request.user)
             return claims
 
+
+Adding more information to the request object passed to the authentication backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, a new ``HttpRequest`` object is created for the authenticate method
+which does not have all the attributes of the original request.
+
+If you need to add more information to the request object passed to the
+authentication backends, you can override the ``create_a_new_request`` method.
+For example, if you have a multi-tenant middleware that adds a ``tenant_id``
+attribute to the request, you can include it in the request object passed to
+the authentication backends by overriding the ``create_a_new_request`` method::
+
+    class CustomOAuth2Validator(OAuth2Validator):
+
+        def create_a_new_request(self, request):
+            new_request = super().create_a_new_request(request)
+            setattr(new_request, "tenant_id", request.tenant_id)
+            return new_request
+
+
 Customizing the login flow
 ==========================
 

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -391,20 +391,29 @@ token, so you will probably want to reuse that::
 Adding more information to the request object passed to the authentication backends
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-By default, a new ``HttpRequest`` object is created for the authenticate method
-which does not have all the attributes of the original request.
+By default, ``build_http_request`` creates a new Django ``HttpRequest`` for the
+``authenticate()`` call that only carries a subset of the incoming request's
+attributes (path, method, body and headers).
 
-If you need to add more information to the request object passed to the
-authentication backends, you can override the ``create_a_new_request`` method.
-For example, if you have a multi-tenant middleware that adds a ``tenant_id``
-attribute to the request, you can include it in the request object passed to
-the authentication backends by overriding the ``create_a_new_request`` method::
+If your authentication backends need more, override ``build_http_request`` to
+copy the extra attributes onto the Django ``HttpRequest`` it returns.
+
+Note that the ``request`` argument is the oauthlib ``Request``, **not** the
+original Django ``HttpRequest``. Attributes attached to the Django request by
+middleware (for example a ``tenant_id`` set by a multi-tenant middleware) are
+not automatically present on the oauthlib request, so make sure the value you
+need has been made available on it -- or forward it there yourself -- and read
+it with ``getattr`` and a default to avoid an ``AttributeError`` when it is
+missing::
 
     class CustomOAuth2Validator(OAuth2Validator):
 
-        def create_a_new_request(self, request):
-            new_request = super().create_a_new_request(request)
-            setattr(new_request, "tenant_id", request.tenant_id)
+        def build_http_request(self, request):
+            # ``request`` is the oauthlib Request; ``tenant_id`` must already
+            # have been set on it (e.g. by a custom OAuthLibCore that forwards
+            # it from the Django request).
+            new_request = super().build_http_request(request)
+            new_request.tenant_id = getattr(request, "tenant_id", None)
             return new_request
 
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -27,6 +27,7 @@ from django.utils.translation import gettext_lazy as _
 from jwcrypto import jws, jwt
 from jwcrypto.common import JWException
 from jwcrypto.jwt import JWTExpired
+from oauthlib.common import Request as OauthlibRequest
 from oauthlib.oauth2.rfc6749 import errors, utils
 from oauthlib.openid import RequestValidator
 
@@ -1123,12 +1124,10 @@ class OAuth2Validator(RequestValidator):
         for t in tokens:
             t.revoke()
 
-    def create_a_new_request(self, request) -> HttpRequest:
+    def build_http_request(self, request: OauthlibRequest) -> HttpRequest:
         """
-        Copy the request object to a new HttpRequest object.
-        Create one with attributes likely to be used.
-        Override this method to customize the request object which
-        is passed to the authenticate method.
+        Build a Django ``HttpRequest`` from the oauthlib ``Request`` for Django's
+        ``authenticate()``. Override to pass extra attributes to your auth backends.
         """
         http_request = HttpRequest()
         http_request.path = request.uri
@@ -1143,7 +1142,7 @@ class OAuth2Validator(RequestValidator):
         """
         # Passing the optional HttpRequest adds compatibility for backends
         # which depend on its presence.
-        http_request = self.create_a_new_request(request)
+        http_request = self.build_http_request(request)
         u = authenticate(http_request, username=username, password=password)
         if u is not None and u.is_active:
             request.user = u

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1123,18 +1123,27 @@ class OAuth2Validator(RequestValidator):
         for t in tokens:
             t.revoke()
 
-    def validate_user(self, username, password, client, request, *args, **kwargs):
+    def create_a_new_request(self, request) -> HttpRequest:
         """
-        Check username and password correspond to a valid and active User
+        Copy the request object to a new HttpRequest object.
+        Create one with attributes likely to be used.
+        Override this method to customize the request object which
+        is passed to the authenticate method.
         """
-        # Passing the optional HttpRequest adds compatibility for backends
-        # which depend on its presence. Create one with attributes likely
-        # to be used.
         http_request = HttpRequest()
         http_request.path = request.uri
         http_request.method = request.http_method
         getattr(http_request, request.http_method).update(dict(request.decoded_body))
         http_request.META = request.headers
+        return http_request
+
+    def validate_user(self, username, password, client, request, *args, **kwargs):
+        """
+        Check username and password correspond to a valid and active User
+        """
+        # Passing the optional HttpRequest adds compatibility for backends
+        # which depend on its presence.
+        http_request = self.create_a_new_request(request)
         u = authenticate(http_request, username=username, password=password)
         if u is not None and u.is_active:
             request.user = u

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -1,11 +1,13 @@
 import contextlib
 import datetime
 import json
+import secrets
 
 import pytest
 import requests
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
+from django.http import HttpRequest
 from django.utils import timezone
 from jwcrypto import jwt
 from oauthlib.common import Request
@@ -518,6 +520,47 @@ class TestOAuth2Validator(TransactionTestCase):
 
         self.assertIsNotNone(user)
         self.assertEqual(content["username"], user.username)
+
+    def test_validate_user_uses_default_create_a_new_request(self):
+        password = secrets.token_hex(16)
+        request = mock.MagicMock(
+            wraps=Request,
+            uri="/",
+            http_method="POST",
+            decoded_body=[("username", self.user.username), ("password", password)],
+            headers={"Authorization": "Basic 123456"},
+        )
+        with mock.patch("oauth2_provider.oauth2_validators.authenticate") as mock_authenticate:
+            mock_authenticate.return_value = self.user
+            success = self.validator.validate_user(self.user.username, password, self.application, request)
+        self.assertTrue(success)
+        self.assertEqual(request.user, self.user, "Successfully authenticated user is set to the request")
+        call_with_original_request = mock.call(request, username="user", password=password)
+        self.assertNotIn(
+            call_with_original_request,
+            mock_authenticate.mock_calls,
+            "The request should not be passed directly to the authenticate method",
+        )
+
+    def test_validate_user_with_overridden_create_a_new_request(self):
+        copy_of_request = mock.MagicMock(wraps=HttpRequest)
+
+        class TestOAuth2Validator(OAuth2Validator):
+            def create_a_new_request(self, request):
+                return copy_of_request
+
+        validator = TestOAuth2Validator()
+        password = secrets.token_hex(16)
+        request = mock.MagicMock(wraps=Request)
+        with mock.patch("oauth2_provider.oauth2_validators.authenticate") as mock_authenticate:
+            mock_authenticate.return_value = self.user
+            success = validator.validate_user(self.user.username, password, self.application, request)
+        self.assertTrue(success)
+        self.assertEqual(request.user, self.user, "Successfully authenticated user is set to the request")
+        # Check that overridden method is called and the request is passed to the authenticate method
+        mock_authenticate.assert_called_once_with(
+            copy_of_request, username=self.user.username, password=password
+        )
 
 
 class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -521,7 +521,7 @@ class TestOAuth2Validator(TransactionTestCase):
         self.assertIsNotNone(user)
         self.assertEqual(content["username"], user.username)
 
-    def test_validate_user_uses_default_create_a_new_request(self):
+    def test_validate_user_uses_default_build_http_request(self):
         password = secrets.token_hex(16)
         request = mock.MagicMock(
             wraps=Request,
@@ -535,18 +535,25 @@ class TestOAuth2Validator(TransactionTestCase):
             success = self.validator.validate_user(self.user.username, password, self.application, request)
         self.assertTrue(success)
         self.assertEqual(request.user, self.user, "Successfully authenticated user is set to the request")
-        call_with_original_request = mock.call(request, username="user", password=password)
+        # authenticate() should receive a Django HttpRequest built from the oauthlib
+        # request, with the key attributes copied over.
+        built_request = mock_authenticate.call_args.args[0]
+        self.assertIsInstance(built_request, HttpRequest)
+        self.assertEqual(built_request.path, request.uri)
+        self.assertEqual(built_request.method, request.http_method)
+        self.assertEqual(built_request.META, request.headers)
+        call_with_original_request = mock.call(request, username=self.user.username, password=password)
         self.assertNotIn(
             call_with_original_request,
             mock_authenticate.mock_calls,
             "The request should not be passed directly to the authenticate method",
         )
 
-    def test_validate_user_with_overridden_create_a_new_request(self):
-        copy_of_request = mock.MagicMock(wraps=HttpRequest)
+    def test_validate_user_with_overridden_build_http_request(self):
+        copy_of_request = HttpRequest()
 
         class TestOAuth2Validator(OAuth2Validator):
-            def create_a_new_request(self, request):
+            def build_http_request(self, request):
                 return copy_of_request
 
         validator = TestOAuth2Validator()


### PR DESCRIPTION
## Description of the Change

Current `OAuthValidator` class creates a new `HttpRequest` and passes it to authentication backend. This approach copies just subset of input properties and in some cases properties set to request, for example by custom middleware, is lost.

This change extracts `HttpRequest` creation to a separate method which allows overriding just this part and allows copying and passing additional properties to the authentication backends.

My use case is a multi-tenant system where a middleware set tenant identifier property to the request. I would like pass this property to my authentication backend so that I can make sure that correct tenant is accessed all the time. I would prefer not to override the whole `validate_user` method and just relevant part, which is the request creation.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] author name in `AUTHORS`
