### PR TITLE
Fix multi-db tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -229,9 +229,7 @@ jobs:
       - sphinxlint
       - migrations
       - migrate_swapped
-      # nees to fix multidb tests, not blocking success for now 
-      # so we can get the lint and migrations checks in place. 
-      # - multi-db
+      - multi-db
     runs-on: ubuntu-latest
     name: Test successful
     steps:

--- a/tests/multi_db_settings.py
+++ b/tests/multi_db_settings.py
@@ -12,8 +12,13 @@ DATABASES = {
         "ENGINE": "django.db.backends.sqlite3",
         "NAME": ":memory:",
     },
-    # As https://docs.djangoproject.com/en/4.2/topics/db/multi-db/#defining-your-databases
-    # indicates, it is ok to have no default database.
-    "default": {},
+    # A usable default is required for Django's test infrastructure (TestCase
+    # flush/rollback).  The DATABASE_ROUTERS below ensure that no application
+    # data is ever written here; ``default`` exists solely so the test runner
+    # can create cursors and manage transactions on it without crashing.
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    },
 }
 DATABASE_ROUTERS = ["tests.db_router.AlphaRouter", "tests.db_router.BetaRouter"]

--- a/tests/test_oauth2_provider_middleware.py
+++ b/tests/test_oauth2_provider_middleware.py
@@ -14,6 +14,8 @@ User = get_user_model()
 
 
 class TestOAuth2ExtraTokenMiddleware(TestCase):
+    databases = "__all__"
+
     def setUp(self):
         self.factory = RequestFactory()
         self.middleware = OAuth2ExtraTokenMiddleware(lambda r: None)

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -648,7 +648,7 @@ def test_validate_id_token_bad_token_no_aud(oauth2_settings, mocker, oidc_key):
     assert status is False
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_invalidate_authorization_token_returns_invalid_grant_error_when_grant_does_not_exist():
     client_id = "123"
     code = "12345"

--- a/tests/test_ui_locales.py
+++ b/tests/test_ui_locales.py
@@ -19,6 +19,8 @@ Application = get_application_model()
     }
 )
 class TestUILocalesParam(TestCase):
+    databases = "__all__"
+
     @classmethod
     def setUpTestData(cls):
         cls.application = Application.objects.create(


### PR DESCRIPTION
Fixes #1681

## Description of the Change

The multi-db test settings used a dummy `default` database backend (`"default": {}`), which caused Django's test infrastructure (TestCase flush/rollback) to crash. This gives `default` a real SQLite backend so the test runner can manage transactions on it, while the routers still direct all application queries to `alpha`/`beta`. Three test classes also needed `databases = "__all__"` so Django allows queries routed to non-default databases.

Adds a `test-multi-db` CI job as a required check in the success gate.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features