### PR TITLE
fix: support swapped DeviceGrant models in device flow

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,6 +47,7 @@ David Smith
 David Uzumaki
 Dawid Wolski
 Diego Garcia
+Diego Pasqualin
 Dominik George
 Dulmandakh Sukhbaatar
 Dylan Giesler

--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ David Smith
 David Uzumaki
 Dawid Wolski
 Diego Garcia
+Diego Pasqualin
 Dominik George
 Dulmandakh Sukhbaatar
 Dylan Giesler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * #1628 Fix inaccurate help_text on client_secret field of Application model
 * #1674 Add `list_select_related` to `RefreshTokenAdmin` to avoid unbounded `JOIN` queries on the changelist
+* #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1628 Fix inaccurate help_text on client_secret field of Application model
 * #1674 Add `list_select_related` to `RefreshTokenAdmin` to avoid unbounded `JOIN` queries on the changelist
 * #1621 Fix device code tokens getting the wrong scope.
+* #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow
 * #1689 Fix invalid `Cache-Control` header value on the OIDC JWKS endpoint
 * #1692 Fix consent violation and scope escalation.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -476,6 +476,12 @@ The import string of the class (model) representing your OAuth2 grants.
 Overwrite this value if you wrote your own implementation (subclass of
 ``oauth2_provider.models.Grant``).
 
+OAUTH2_PROVIDER_DEVICE_GRANT_MODEL
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The import string of the class (model) representing your OAuth2 device grants.
+Overwrite this value if you wrote your own implementation (subclass of
+``oauth2_provider.models.AbstractDeviceGrant``).
+
 OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The import string of the class (model) representing your refresh tokens.

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -736,10 +736,12 @@ class DeviceCodeResponse:
     verification_uri_complete: Optional[Union[str, Callable]] = None
 
 
-def create_device_grant(device_request: DeviceRequest, device_response: DeviceCodeResponse) -> DeviceGrant:
+def create_device_grant(
+    device_request: DeviceRequest, device_response: DeviceCodeResponse
+) -> AbstractDeviceGrant:
     now = datetime.now(tz=dt_timezone.utc)
 
-    return DeviceGrant.objects.create(
+    return get_device_grant_model().objects.create(
         client_id=device_request.client_id,
         device_code=device_response.device_code,
         user_code=device_response.user_code,

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -96,7 +96,9 @@ def set_oauthlib_user_to_device_request_user(request: Request) -> None:
     """
     # Since this function is used in the settings module, it will lead to circular imports
     # since django isn't fully initialised yet when settings run
-    from oauth2_provider.models import DeviceGrant, get_device_grant_model
+    from oauth2_provider.models import AbstractDeviceGrant, get_device_grant_model
 
-    device: DeviceGrant = get_device_grant_model().objects.get(device_code=request._params["device_code"])
+    device: AbstractDeviceGrant = get_device_grant_model().objects.get(
+        device_code=request._params["device_code"]
+    )
     request.user = device.user

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -96,8 +96,10 @@ def set_oauthlib_user_to_device_request_user(request: Request) -> None:
     """
     # Since this function is used in the settings module, it will lead to circular imports
     # since django isn't fully initialised yet when settings run
-    from oauth2_provider.models import DeviceGrant, get_device_grant_model
+    from oauth2_provider.models import AbstractDeviceGrant, get_device_grant_model
 
-    device: DeviceGrant = get_device_grant_model().objects.get(device_code=request._params["device_code"])
+    device: AbstractDeviceGrant = get_device_grant_model().objects.get(
+        device_code=request._params["device_code"]
+    )
     request.user = device.user
     request.scopes = device.scope.split() if device.scope else []

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -15,13 +15,11 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import FormView, View
 from oauthlib.oauth2.rfc8628 import errors as rfc8628_errors
 
-from oauth2_provider.models import DeviceGrant
-
 from ..compat import login_not_required
 from ..exceptions import OAuthToolkitError
 from ..forms import AllowForm
 from ..http import OAuth2ResponseRedirect
-from ..models import get_access_token_model, get_application_model
+from ..models import get_access_token_model, get_application_model, get_device_grant_model
 from ..scopes import get_scopes_backend
 from ..settings import oauth2_settings
 from ..signals import app_authorized
@@ -317,9 +315,10 @@ class TokenView(OAuthLibMixin, View):
     def device_flow_token_response(
         self, request: http.HttpRequest, device_code: str, *args, **kwargs
     ) -> http.HttpResponse:
+        device_grant_model = get_device_grant_model()
         try:
-            device = DeviceGrant.objects.get(device_code=device_code)
-        except DeviceGrant.DoesNotExist:
+            device = device_grant_model.objects.get(device_code=device_code)
+        except device_grant_model.DoesNotExist:
             # The RFC does not mention what to return when the device is not found,
             # but to keep it consistent with the other errors, we return the error
             # in json format with an "error" key and the value formatted in the same

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -12,8 +12,8 @@ from oauthlib.oauth2 import DeviceApplicationServer
 
 from oauth2_provider.compat import login_not_required
 from oauth2_provider.models import (
+    AbstractDeviceGrant,
     DeviceCodeResponse,
-    DeviceGrant,
     DeviceRequest,
     create_device_grant,
     get_device_grant_model,
@@ -57,9 +57,10 @@ class DeviceGrantForm(forms.Form):
         """
         cleaned_data = super().clean()
         user_code: str = cleaned_data["user_code"]
+        device_grant_model = get_device_grant_model()
         try:
-            device_grant: DeviceGrant = get_device_grant_model().objects.get(user_code=user_code)
-        except DeviceGrant.DoesNotExist:
+            device_grant: AbstractDeviceGrant = device_grant_model.objects.get(user_code=user_code)
+        except device_grant_model.DoesNotExist:
             raise ValidationError("Incorrect user code", code="incorrect_user_code")
 
         if device_grant.is_expired():
@@ -106,7 +107,7 @@ class DeviceUserCodeView(LoginRequiredMixin, FormView):
         get_success_url, redirecting to the URL with the URL params pointing
         to the current device.
         """
-        device_grant: DeviceGrant = form.cleaned_data["device_grant"]
+        device_grant: AbstractDeviceGrant = form.cleaned_data["device_grant"]
 
         device_grant.user = self.request.user
         device_grant.save(update_fields=["user"])
@@ -138,11 +139,12 @@ class DeviceConfirmView(LoginRequiredMixin, FormView):
         by the slugs client_id and user_code. Raises Http404 if not found.
         """
         client_id, user_code = self.kwargs.get("client_id"), self.kwargs.get("user_code")
+        device_grant_model = get_device_grant_model()
         return get_object_or_404(
-            DeviceGrant,
+            device_grant_model,
             client_id=client_id,
             user_code=user_code,
-            status=DeviceGrant.AUTHORIZATION_PENDING,
+            status=device_grant_model.AUTHORIZATION_PENDING,
         )
 
     def get_success_url(self):
@@ -188,9 +190,11 @@ class DeviceGrantStatusView(LoginRequiredMixin, DetailView):
     The view to display the status of a DeviceGrant.
     """
 
-    model = DeviceGrant
     template_name = "oauth2_provider/device/device_grant_status.html"
+
+    def get_queryset(self):
+        return get_device_grant_model().objects.all()
 
     def get_object(self):
         client_id, user_code = self.kwargs.get("client_id"), self.kwargs.get("user_code")
-        return get_object_or_404(DeviceGrant, client_id=client_id, user_code=user_code)
+        return get_object_or_404(self.get_queryset(), client_id=client_id, user_code=user_code)

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -14,8 +14,8 @@ from oauthlib.oauth2 import DeviceApplicationServer
 
 from oauth2_provider.compat import login_not_required
 from oauth2_provider.models import (
+    AbstractDeviceGrant,
     DeviceCodeResponse,
-    DeviceGrant,
     DeviceRequest,
     create_device_grant,
     get_application_model,
@@ -85,9 +85,10 @@ class DeviceGrantForm(forms.Form):
         """
         cleaned_data = super().clean()
         user_code: str = cleaned_data["user_code"]
+        device_grant_model = get_device_grant_model()
         try:
-            device_grant: DeviceGrant = get_device_grant_model().objects.get(user_code=user_code)
-        except DeviceGrant.DoesNotExist:
+            device_grant: AbstractDeviceGrant = device_grant_model.objects.get(user_code=user_code)
+        except device_grant_model.DoesNotExist:
             raise ValidationError("Incorrect user code", code="incorrect_user_code")
 
         if device_grant.is_expired():
@@ -134,7 +135,7 @@ class DeviceUserCodeView(LoginRequiredMixin, FormView):
         get_success_url, redirecting to the URL with the URL params pointing
         to the current device.
         """
-        device_grant: DeviceGrant = form.cleaned_data["device_grant"]
+        device_grant: AbstractDeviceGrant = form.cleaned_data["device_grant"]
 
         device_grant.user = self.request.user
         device_grant.save(update_fields=["user"])
@@ -235,9 +236,11 @@ class DeviceGrantStatusView(LoginRequiredMixin, DetailView):
     The view to display the status of a DeviceGrant.
     """
 
-    model = DeviceGrant
     template_name = "oauth2_provider/device/device_grant_status.html"
+
+    def get_queryset(self):
+        return get_device_grant_model().objects.all()
 
     def get_object(self):
         client_id, user_code = self.kwargs.get("client_id"), self.kwargs.get("user_code")
-        return get_object_or_404(DeviceGrant, client_id=client_id, user_code=user_code)
+        return get_object_or_404(self.get_queryset(), client_id=client_id, user_code=user_code)

--- a/tests/migrations/0008_sampledevicegrant.py
+++ b/tests/migrations/0008_sampledevicegrant.py
@@ -1,0 +1,61 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ("tests", "0007_add_localidtoken"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="SampleDeviceGrant",
+            fields=[
+                ("id", models.BigAutoField(primary_key=True, serialize=False)),
+                ("device_code", models.CharField(max_length=100, unique=True)),
+                ("user_code", models.CharField(max_length=100)),
+                ("scope", models.CharField(max_length=64, null=True)),
+                ("interval", models.IntegerField(default=5)),
+                ("expires", models.DateTimeField()),
+                (
+                    "status",
+                    models.CharField(
+                        blank=True,
+                        choices=[
+                            ("authorized", "Authorized"),
+                            ("authorization-pending", "Authorization pending"),
+                            ("expired", "Expired"),
+                            ("denied", "Denied"),
+                        ],
+                        default="authorization-pending",
+                        max_length=64,
+                    ),
+                ),
+                ("client_id", models.CharField(db_index=True, max_length=100)),
+                ("last_checked", models.DateTimeField(auto_now=True)),
+                ("custom_field", models.CharField(blank=True, default="", max_length=255)),
+                (
+                    "user",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="%(app_label)s_%(class)s",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+                "swappable": "OAUTH2_PROVIDER_DEVICE_GRANT_MODEL",
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("device_code",),
+                        name="tests_sampledevicegrant_unique_device_code",
+                    )
+                ],
+            },
+        ),
+    ]

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from oauth2_provider.models import (
     AbstractAccessToken,
     AbstractApplication,
+    AbstractDeviceGrant,
     AbstractGrant,
     AbstractIDToken,
     AbstractRefreshToken,
@@ -55,6 +56,13 @@ class SampleRefreshToken(AbstractRefreshToken):
 
 class SampleGrant(AbstractGrant):
     custom_field = models.CharField(max_length=255)
+
+
+class SampleDeviceGrant(AbstractDeviceGrant):
+    custom_field = models.CharField(blank=True, default="", max_length=255)
+
+    class Meta(AbstractDeviceGrant.Meta):
+        swappable = "OAUTH2_PROVIDER_DEVICE_GRANT_MODEL"
 
 
 class LocalIDToken(AbstractIDToken):

--- a/tests/settings_swapped.py
+++ b/tests/settings_swapped.py
@@ -3,4 +3,5 @@ from .settings import *  # noqa
 
 OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL = "tests.SampleAccessToken"
 OAUTH2_PROVIDER_APPLICATION_MODEL = "tests.SampleApplication"
+OAUTH2_PROVIDER_DEVICE_GRANT_MODEL = "tests.SampleDeviceGrant"
 OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL = "tests.SampleRefreshToken"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -767,3 +767,106 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
 
         assert is_expired
         assert device.status == device.EXPIRED
+
+
+class TestDeviceFlowWithSwappedDeviceGrantModel(DeviceFlowBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.oauth2_settings.DEVICE_GRANT_MODEL = "tests.SampleDeviceGrant"
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "abc",
+    )
+    def test_full_device_flow_uses_swapped_device_grant_model(self):
+        self.oauth2_settings.OAUTH_DEVICE_VERIFICATION_URI = "example.com/device"
+        self.oauth2_settings.OAUTH_DEVICE_USER_CODE_GENERATOR = lambda: "xyz"
+        self.oauth2_settings.OAUTH_PRE_TOKEN_VALIDATION = [set_oauthlib_user_to_device_request_user]
+
+        device_model = get_device_grant_model()
+        assert device_model._meta.label == "tests.SampleDeviceGrant"
+
+        device_authorization_response: http.response.JsonResponse = self.client.post(
+            reverse("oauth2_provider:device-authorization"),
+            data=urlencode({"client_id": self.application.client_id}),
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        assert device_authorization_response.status_code == 200
+        assert device_model.objects.get(device_code="abc").status == device_model.AUTHORIZATION_PENDING
+        if not oauth2_provider.models.DeviceGrant._meta.swapped:
+            assert not oauth2_provider.models.DeviceGrant.objects.filter(device_code="abc").exists()
+
+        token_payload = {
+            "device_code": "abc",
+            "client_id": self.application.client_id,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        }
+        pending_response = self.client.post(
+            "/o/token/",
+            data=urlencode(token_payload),
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertJSONEqual(
+            raw=pending_response.content,
+            expected_data={"error": "authorization_pending"},
+        )
+
+        UserModel.objects.create_user(
+            username="test_user_swapped_device_flow",
+            email="test_swapped_device@example.com",
+            password="password123",
+        )
+        self.client.login(username="test_user_swapped_device_flow", password="password123")
+
+        device_confirm_url = reverse(
+            "oauth2_provider:device-confirm",
+            kwargs={"user_code": "xyz", "client_id": self.application.client_id},
+        )
+        device_grant_status_url = reverse(
+            "oauth2_provider:device-grant-status",
+            kwargs={"user_code": "xyz", "client_id": self.application.client_id},
+        )
+
+        self.assertRedirects(
+            response=self.client.post(reverse("oauth2_provider:device"), data={"user_code": "xyz"}),
+            expected_url=device_confirm_url,
+        )
+        self.assertRedirects(
+            response=self.client.post(device_confirm_url, data={"action": "accept"}),
+            expected_url=device_grant_status_url,
+        )
+        self.assertContains(
+            response=self.client.get(device_grant_status_url),
+            text="Device Authorized",
+            count=1,
+        )
+
+        token_response = self.client.post(
+            "/o/token/",
+            data=urlencode(token_payload),
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert token_response.status_code == 200
+        assert token_response.json() == {
+            "access_token": mock.ANY,
+            "expires_in": 36000,
+            "token_type": "Bearer",
+            "scope": "read write",
+            "refresh_token": mock.ANY,
+        }
+
+    def test_invalid_user_code_returns_form_error_with_swapped_device_model(self):
+        UserModel.objects.create_user(
+            username="test_user_swapped_invalid_code",
+            email="test_swapped_invalid_code@example.com",
+            password="password123",
+        )
+        self.client.login(username="test_user_swapped_invalid_code", password="password123")
+
+        self.assertContains(
+            response=self.client.post(reverse("oauth2_provider:device"), data={"user_code": "invalid_code"}),
+            status_code=200,
+            text="Incorrect user code",
+            count=1,
+        )

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1008,7 +1008,13 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
 class TestDeviceFlowWithSwappedDeviceGrantModel(DeviceFlowBaseTestCase):
     def setUp(self):
         super().setUp()
+        self._original_device_grant_model = self.oauth2_settings.DEVICE_GRANT_MODEL
         self.oauth2_settings.DEVICE_GRANT_MODEL = "tests.SampleDeviceGrant"
+
+    def tearDown(self):
+        get_device_grant_model().objects.all().delete()
+        self.oauth2_settings.DEVICE_GRANT_MODEL = self._original_device_grant_model
+        super().tearDown()
 
     @mock.patch(
         "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1003,3 +1003,106 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
 
         assert response.status_code == 401
         assert response.json()["error"] == "invalid_client"
+
+
+class TestDeviceFlowWithSwappedDeviceGrantModel(DeviceFlowBaseTestCase):
+    def setUp(self):
+        super().setUp()
+        self.oauth2_settings.DEVICE_GRANT_MODEL = "tests.SampleDeviceGrant"
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "abc",
+    )
+    def test_full_device_flow_uses_swapped_device_grant_model(self):
+        self.oauth2_settings.OAUTH_DEVICE_VERIFICATION_URI = "example.com/device"
+        self.oauth2_settings.OAUTH_DEVICE_USER_CODE_GENERATOR = lambda: "xyz"
+        self.oauth2_settings.OAUTH_PRE_TOKEN_VALIDATION = [set_oauthlib_user_to_device_request_user]
+
+        device_model = get_device_grant_model()
+        assert device_model._meta.label == "tests.SampleDeviceGrant"
+
+        device_authorization_response: http.response.JsonResponse = self.client.post(
+            reverse("oauth2_provider:device-authorization"),
+            data=urlencode({"client_id": self.application.client_id}),
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        assert device_authorization_response.status_code == 200
+        assert device_model.objects.get(device_code="abc").status == device_model.AUTHORIZATION_PENDING
+        if not oauth2_provider.models.DeviceGrant._meta.swapped:
+            assert not oauth2_provider.models.DeviceGrant.objects.filter(device_code="abc").exists()
+
+        token_payload = {
+            "device_code": "abc",
+            "client_id": self.application.client_id,
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        }
+        pending_response = self.client.post(
+            "/o/token/",
+            data=urlencode(token_payload),
+            content_type="application/x-www-form-urlencoded",
+        )
+        self.assertJSONEqual(
+            raw=pending_response.content,
+            expected_data={"error": "authorization_pending"},
+        )
+
+        UserModel.objects.create_user(
+            username="test_user_swapped_device_flow",
+            email="test_swapped_device@example.com",
+            password="password123",
+        )
+        self.client.login(username="test_user_swapped_device_flow", password="password123")
+
+        device_confirm_url = reverse(
+            "oauth2_provider:device-confirm",
+            kwargs={"user_code": "xyz", "client_id": self.application.client_id},
+        )
+        device_grant_status_url = reverse(
+            "oauth2_provider:device-grant-status",
+            kwargs={"user_code": "xyz", "client_id": self.application.client_id},
+        )
+
+        self.assertRedirects(
+            response=self.client.post(reverse("oauth2_provider:device"), data={"user_code": "xyz"}),
+            expected_url=device_confirm_url,
+        )
+        self.assertRedirects(
+            response=self.client.post(device_confirm_url, data={"action": "accept"}),
+            expected_url=device_grant_status_url,
+        )
+        self.assertContains(
+            response=self.client.get(device_grant_status_url),
+            text="Device Authorized",
+            count=1,
+        )
+
+        token_response = self.client.post(
+            "/o/token/",
+            data=urlencode(token_payload),
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert token_response.status_code == 200
+        assert token_response.json() == {
+            "access_token": mock.ANY,
+            "expires_in": 36000,
+            "token_type": "Bearer",
+            "scope": "read write",
+            "refresh_token": mock.ANY,
+        }
+
+    def test_invalid_user_code_returns_form_error_with_swapped_device_model(self):
+        UserModel.objects.create_user(
+            username="test_user_swapped_invalid_code",
+            email="test_swapped_invalid_code@example.com",
+            password="password123",
+        )
+        self.client.login(username="test_user_swapped_invalid_code", password="password123")
+
+        self.assertContains(
+            response=self.client.post(reverse("oauth2_provider:device"), data={"user_code": "invalid_code"}),
+            status_code=200,
+            text="Incorrect user code",
+            count=1,
+        )


### PR DESCRIPTION
Use get_device_grant_model() consistently across device grant creation, polling, and browser confirmation/status flows so custom DeviceGrant models work end to end. Add swapped-model regression coverage plus the related docs, changelog, and AUTHORS updates required for an upstream PR.

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1683

## Description of the Change

This PR fixes incomplete support for swapped `DeviceGrant` models in the device authorization flow.

DOT already exposes `get_device_grant_model()`, but some runtime paths still referenced the concrete `oauth2_provider.DeviceGrant` model directly. That caused swapped `DeviceGrant` implementations to break during device grant creation, token polling, and parts of the browser-based confirmation/status flow.

This change updates those paths to consistently resolve the active model via `get_device_grant_model()` and aligns related type hints with `AbstractDeviceGrant`.

It also adds regression coverage for a swapped `DeviceGrant` model by:
- adding `tests.SampleDeviceGrant`
- adding the corresponding test migration
- enabling the swapped model in `tests/settings_swapped.py`
- extending `tests/test_device.py` with end-to-end coverage for the swapped-model device flow, including invalid user-code handling

For the upstream PR requirements, this branch also updates:
- `docs/settings.rst` to document `OAUTH2_PROVIDER_DEVICE_GRANT_MODEL`
- `CHANGELOG.md` with a `Fixed` entry
- `AUTHORS`

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features