### PR TITLE
Use get_device_grant_model() on device-code runtime paths

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -739,7 +739,7 @@ class DeviceCodeResponse:
 def create_device_grant(device_request: DeviceRequest, device_response: DeviceCodeResponse) -> DeviceGrant:
     now = datetime.now(tz=dt_timezone.utc)
 
-    return DeviceGrant.objects.create(
+    return get_device_grant_model().objects.create(
         client_id=device_request.client_id,
         device_code=device_response.device_code,
         user_code=device_response.user_code,

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -15,7 +15,7 @@ from django.views.decorators.debug import sensitive_post_parameters
 from django.views.generic import FormView, View
 from oauthlib.oauth2.rfc8628 import errors as rfc8628_errors
 
-from oauth2_provider.models import DeviceGrant
+from oauth2_provider.models import get_device_grant_model
 
 from ..compat import login_not_required
 from ..exceptions import OAuthToolkitError
@@ -317,9 +317,10 @@ class TokenView(OAuthLibMixin, View):
     def device_flow_token_response(
         self, request: http.HttpRequest, device_code: str, *args, **kwargs
     ) -> http.HttpResponse:
+        device_grant_model = get_device_grant_model()
         try:
-            device = DeviceGrant.objects.get(device_code=device_code)
-        except DeviceGrant.DoesNotExist:
+            device = device_grant_model.objects.get(device_code=device_code)
+        except device_grant_model.DoesNotExist:
             # The RFC does not mention what to return when the device is not found,
             # but to keep it consistent with the other errors, we return the error
             # in json format with an "error" key and the value formatted in the same

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -13,7 +13,6 @@ from oauthlib.oauth2 import DeviceApplicationServer
 from oauth2_provider.compat import login_not_required
 from oauth2_provider.models import (
     DeviceCodeResponse,
-    DeviceGrant,
     DeviceRequest,
     create_device_grant,
     get_device_grant_model,
@@ -57,9 +56,10 @@ class DeviceGrantForm(forms.Form):
         """
         cleaned_data = super().clean()
         user_code: str = cleaned_data["user_code"]
+        device_grant_model = get_device_grant_model()
         try:
-            device_grant: DeviceGrant = get_device_grant_model().objects.get(user_code=user_code)
-        except DeviceGrant.DoesNotExist:
+            device_grant = device_grant_model.objects.get(user_code=user_code)
+        except device_grant_model.DoesNotExist:
             raise ValidationError("Incorrect user code", code="incorrect_user_code")
 
         if device_grant.is_expired():
@@ -106,7 +106,7 @@ class DeviceUserCodeView(LoginRequiredMixin, FormView):
         get_success_url, redirecting to the URL with the URL params pointing
         to the current device.
         """
-        device_grant: DeviceGrant = form.cleaned_data["device_grant"]
+        device_grant = form.cleaned_data["device_grant"]
 
         device_grant.user = self.request.user
         device_grant.save(update_fields=["user"])
@@ -138,11 +138,12 @@ class DeviceConfirmView(LoginRequiredMixin, FormView):
         by the slugs client_id and user_code. Raises Http404 if not found.
         """
         client_id, user_code = self.kwargs.get("client_id"), self.kwargs.get("user_code")
+        device_grant_model = get_device_grant_model()
         return get_object_or_404(
-            DeviceGrant,
+            device_grant_model,
             client_id=client_id,
             user_code=user_code,
-            status=DeviceGrant.AUTHORIZATION_PENDING,
+            status=device_grant_model.AUTHORIZATION_PENDING,
         )
 
     def get_success_url(self):
@@ -188,9 +189,12 @@ class DeviceGrantStatusView(LoginRequiredMixin, DetailView):
     The view to display the status of a DeviceGrant.
     """
 
-    model = DeviceGrant
     template_name = "oauth2_provider/device/device_grant_status.html"
+
+    @property
+    def model(self):
+        return get_device_grant_model()
 
     def get_object(self):
         client_id, user_code = self.kwargs.get("client_id"), self.kwargs.get("user_code")
-        return get_object_or_404(DeviceGrant, client_id=client_id, user_code=user_code)
+        return get_object_or_404(get_device_grant_model(), client_id=client_id, user_code=user_code)


### PR DESCRIPTION
`OAUTH2_PROVIDER_DEVICE_GRANT_MODEL` is documented as swappable, but several device-code runtime paths still referenced the concrete `oauth2_provider.DeviceGrant` class and its `DoesNotExist` attribute directly. That broke the device flow for projects pointing the setting at a swapped model, because creation, lookup, and exception handling targeted the wrong model/table.

This patch routes `create_device_grant`, `DeviceGrantForm.clean_user_code`, `DeviceConfirmView.get_object`, `DeviceGrantStatusView`, and the `device_flow_token_response` lookup through `get_device_grant_model()` so they honor the swap.

Fixes #1683