### PR TITLE
Clean up revoked refresh tokens with cleartokens

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -121,6 +121,7 @@ Spencer Carroll
 Stéphane Raimbault
 Thales Barbosa Bento
 Tom Evans
+Torstein Hegge
 Vinay Karanam
 Víðir Valberg Guðmundsson
 Will Beaufoy

--- a/AUTHORS
+++ b/AUTHORS
@@ -127,6 +127,7 @@ Spencer Carroll
 Stéphane Raimbault
 Thales Barbosa Bento
 Tom Evans
+Torstein Hegge
 Vinay Karanam
 Víðir Valberg Guðmundsson
 Will Beaufoy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unique constraint.
 
 ### Changed
+* #1688 `cleartokens` now removes revoked refresh tokens once `REFRESH_TOKEN_GRACE_PERIOD_SECONDS`
+  has passed, instead of keeping them until `REFRESH_TOKEN_EXPIRE_SECONDS`. When
+  `REFRESH_TOKEN_REUSE_PROTECTION` is enabled, revoked tokens are still kept until they expire so
+  that token reuse can be detected.
 * #1601 `RefreshToken.token` is now a `TextField` and lookups use a new SHA-256 `token_checksum`
   field, removing the 255 character limit so long refresh tokens (e.g. Microsoft's JWT refresh
   tokens) are supported. This mirrors the `AccessToken.token_checksum` approach introduced in 3.0.0

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -9,9 +9,11 @@ or :doc:`Celery <tutorial/tutorial_05>`.
 cleartokens
 ~~~~~~~~~~~
 
-The ``cleartokens`` management command allows the user to remove those refresh tokens whose lifetime is greater than the
-amount specified by ``REFRESH_TOKEN_EXPIRE_SECONDS`` settings. It is important that this command is run regularly
-(eg: via cron) to avoid cluttering the database with expired refresh tokens.
+The ``cleartokens`` management command allows the user to remove refresh tokens that can no longer be
+used: those whose lifetime is greater than the amount specified by the ``REFRESH_TOKEN_EXPIRE_SECONDS``
+setting, and those that have been revoked for longer than the ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS``
+setting. It is important that this command is run regularly (eg: via cron) to avoid cluttering the
+database with expired refresh tokens.
 
 If ``cleartokens`` runs daily the maximum delay before a refresh token is
 removed is ``REFRESH_TOKEN_EXPIRE_SECONDS`` + 1 day. This is normally not a

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -16,8 +16,9 @@ setting. It is important that this command is run regularly (eg: via cron) to av
 database with expired refresh tokens.
 
 If ``cleartokens`` runs daily the maximum delay before a refresh token is
-removed is ``REFRESH_TOKEN_EXPIRE_SECONDS`` + 1 day. This is normally not a
-problem since refresh tokens are long lived.
+removed is its retention period (``REFRESH_TOKEN_EXPIRE_SECONDS`` for expired
+tokens, ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS`` for revoked ones) + 1 day. This
+is normally not a problem since refresh tokens are long lived.
 
 To prevent the CPU and RAM high peaks during deletion process use ``CLEAR_EXPIRED_TOKENS_BATCH_SIZE`` and
 ``CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL`` settings to adjust the process speed.

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -22,6 +22,12 @@ To prevent the CPU and RAM high peaks during deletion process use ``CLEAR_EXPIRE
 
 The ``cleartokens`` management command will also delete expired access and ID tokens alongside expired refresh tokens.
 
+Refresh tokens that have already been revoked (for example by refresh token rotation) are removed as
+soon as their ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS`` grace period has passed, without waiting for
+``REFRESH_TOKEN_EXPIRE_SECONDS``. The exception is when ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled:
+revoked refresh tokens are then what allows reuse of a rotated token to be detected, so they are kept
+until they expire per ``REFRESH_TOKEN_EXPIRE_SECONDS``.
+
 Note: Refresh tokens need to expire before AccessTokens can be removed from the
 database. Using ``cleartokens`` without ``REFRESH_TOKEN_EXPIRE_SECONDS`` has limited effect.
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -190,13 +190,14 @@ tokens will last until revoked or the end of time. You should change this.
 
 REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The number of seconds between when a refresh token is first used when it is
-expired. The most common case of this for this is native mobile applications
-that run into issues of network connectivity during the refresh cycle and are
-unable to complete the full request/response life cycle. Without a grace
-period the application, the app then has only a consumed refresh token and the
-only recourse is to have the user re-authenticate. A suggested value, if this
-is enabled, is 2 minutes. The value must not be negative.
+The number of seconds a refresh token can still be used after it has been
+revoked, for example because it was consumed by refresh token rotation. The
+most common use case is native mobile applications that run into issues of
+network connectivity during the refresh cycle and are unable to complete the
+full request/response life cycle. Without a grace period the app has only a
+consumed refresh token and the only recourse is to have the user
+re-authenticate. A suggested value, if this is enabled, is 2 minutes. The
+value must not be negative.
 
 The ``cleartokens`` management command removes revoked refresh tokens once the
 grace period has passed, unless ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -196,7 +196,11 @@ that run into issues of network connectivity during the refresh cycle and are
 unable to complete the full request/response life cycle. Without a grace
 period the application, the app then has only a consumed refresh token and the
 only recourse is to have the user re-authenticate. A suggested value, if this
-is enabled, is 2 minutes.
+is enabled, is 2 minutes. The value must not be negative.
+
+The ``cleartokens`` management command removes revoked refresh tokens once the
+grace period has passed, unless ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled.
+Check :ref:`cleartokens` management command for further info.
 
 REFRESH_TOKEN_REUSE_PROTECTION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -828,12 +828,22 @@ def clear_expired():
         return deleted
 
     now = timezone.now()
+    refresh_revoked_at = now
     refresh_expire_at = None
     access_token_model = get_access_token_model()
     refresh_token_model = get_refresh_token_model()
     id_token_model = get_id_token_model()
     grant_model = get_grant_model()
+    REFRESH_TOKEN_GRACE_PERIOD_SECONDS = oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS
     REFRESH_TOKEN_EXPIRE_SECONDS = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+
+    if REFRESH_TOKEN_GRACE_PERIOD_SECONDS:
+        try:
+            REFRESH_TOKEN_GRACE_PERIOD_SECONDS = timedelta(seconds=REFRESH_TOKEN_GRACE_PERIOD_SECONDS)
+        except TypeError:
+            e = "REFRESH_TOKEN_GRACE_PERIOD_SECONDS must be in seconds"
+            raise ImproperlyConfigured(e)
+        refresh_revoked_at = now - REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 
     if REFRESH_TOKEN_EXPIRE_SECONDS:
         if not isinstance(REFRESH_TOKEN_EXPIRE_SECONDS, timedelta):
@@ -844,20 +854,20 @@ def clear_expired():
                 raise ImproperlyConfigured(e)
         refresh_expire_at = now - REFRESH_TOKEN_EXPIRE_SECONDS
 
+    revoked_query = models.Q(revoked__lt=refresh_revoked_at)
+    revoked = refresh_token_model.objects.filter(revoked_query)
+
+    revoked_deleted_no = batch_delete(revoked, revoked_query)
+    logger.info("%s Revoked refresh tokens deleted", revoked_deleted_no)
+
     if refresh_expire_at:
-        revoked_query = models.Q(revoked__lt=refresh_expire_at)
-        revoked = refresh_token_model.objects.filter(revoked_query)
-
-        revoked_deleted_no = batch_delete(revoked, revoked_query)
-        logger.info("%s Revoked refresh tokens deleted", revoked_deleted_no)
-
         expired_query = models.Q(access_token__expires__lt=refresh_expire_at)
         expired = refresh_token_model.objects.filter(expired_query)
 
         expired_deleted_no = batch_delete(expired, expired_query)
         logger.info("%s Expired refresh tokens deleted", expired_deleted_no)
     else:
-        logger.info("refresh_expire_at is %s. No refresh tokens deleted.", refresh_expire_at)
+        logger.info("refresh_expire_at is %s. No expired refresh tokens deleted.", refresh_expire_at)
 
     access_token_query = models.Q(refresh_token__isnull=True, expires__lt=now)
     access_tokens = access_token_model.objects.filter(access_token_query)

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -835,12 +835,22 @@ def clear_expired():
         return deleted
 
     now = timezone.now()
+    refresh_revoked_at = now
     refresh_expire_at = None
     access_token_model = get_access_token_model()
     refresh_token_model = get_refresh_token_model()
     id_token_model = get_id_token_model()
     grant_model = get_grant_model()
+    REFRESH_TOKEN_GRACE_PERIOD_SECONDS = oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS
     REFRESH_TOKEN_EXPIRE_SECONDS = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+
+    if REFRESH_TOKEN_GRACE_PERIOD_SECONDS:
+        try:
+            REFRESH_TOKEN_GRACE_PERIOD_SECONDS = timedelta(seconds=REFRESH_TOKEN_GRACE_PERIOD_SECONDS)
+        except TypeError:
+            e = "REFRESH_TOKEN_GRACE_PERIOD_SECONDS must be in seconds"
+            raise ImproperlyConfigured(e)
+        refresh_revoked_at = now - REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 
     if REFRESH_TOKEN_EXPIRE_SECONDS:
         if not isinstance(REFRESH_TOKEN_EXPIRE_SECONDS, timedelta):
@@ -851,20 +861,20 @@ def clear_expired():
                 raise ImproperlyConfigured(e)
         refresh_expire_at = now - REFRESH_TOKEN_EXPIRE_SECONDS
 
+    revoked_query = models.Q(revoked__lt=refresh_revoked_at)
+    revoked = refresh_token_model.objects.filter(revoked_query)
+
+    revoked_deleted_no = batch_delete(revoked, revoked_query)
+    logger.info("%s Revoked refresh tokens deleted", revoked_deleted_no)
+
     if refresh_expire_at:
-        revoked_query = models.Q(revoked__lt=refresh_expire_at)
-        revoked = refresh_token_model.objects.filter(revoked_query)
-
-        revoked_deleted_no = batch_delete(revoked, revoked_query)
-        logger.info("%s Revoked refresh tokens deleted", revoked_deleted_no)
-
         expired_query = models.Q(access_token__expires__lt=refresh_expire_at)
         expired = refresh_token_model.objects.filter(expired_query)
 
         expired_deleted_no = batch_delete(expired, expired_query)
         logger.info("%s Expired refresh tokens deleted", expired_deleted_no)
     else:
-        logger.info("refresh_expire_at is %s. No refresh tokens deleted.", refresh_expire_at)
+        logger.info("refresh_expire_at is %s. No expired refresh tokens deleted.", refresh_expire_at)
 
     access_token_query = models.Q(refresh_token__isnull=True, expires__lt=now)
     access_tokens = access_token_model.objects.filter(access_token_query)

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -850,6 +850,9 @@ def clear_expired():
         except TypeError:
             e = "REFRESH_TOKEN_GRACE_PERIOD_SECONDS must be in seconds"
             raise ImproperlyConfigured(e)
+        if REFRESH_TOKEN_GRACE_PERIOD_SECONDS < timedelta(0):
+            e = "REFRESH_TOKEN_GRACE_PERIOD_SECONDS must not be negative"
+            raise ImproperlyConfigured(e)
         refresh_revoked_at = now - REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 
     if REFRESH_TOKEN_EXPIRE_SECONDS:
@@ -861,11 +864,20 @@ def clear_expired():
                 raise ImproperlyConfigured(e)
         refresh_expire_at = now - REFRESH_TOKEN_EXPIRE_SECONDS
 
-    revoked_query = models.Q(revoked__lt=refresh_revoked_at)
-    revoked = refresh_token_model.objects.filter(revoked_query)
+    if oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION:
+        # Revoked refresh tokens are what allows reuse of a rotated token to
+        # be detected and the token family revoked, so they must be kept
+        # until they expire.
+        refresh_revoked_at = refresh_expire_at
 
-    revoked_deleted_no = batch_delete(revoked, revoked_query)
-    logger.info("%s Revoked refresh tokens deleted", revoked_deleted_no)
+    if refresh_revoked_at:
+        revoked_query = models.Q(revoked__lte=refresh_revoked_at)
+        revoked = refresh_token_model.objects.filter(revoked_query)
+
+        revoked_deleted_no = batch_delete(revoked, revoked_query)
+        logger.info("%s Revoked refresh tokens deleted", revoked_deleted_no)
+    else:
+        logger.info("refresh_revoked_at is %s. No revoked refresh tokens deleted.", refresh_revoked_at)
 
     if refresh_expire_at:
         expired_query = models.Q(access_token__expires__lt=refresh_expire_at)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -484,6 +484,121 @@ class TestClearExpired(BaseTestModels):
         assert remaining_gt_count == initial_gt_count // 2, "half the remaining grants should still exist."
 
 
+@pytest.mark.usefixtures("oauth2_settings")
+class TestClearRevoked(BaseTestModels):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.num_tokens = 9
+        cls.grace_secs = 1000
+        cls.now = timezone.now()
+        cls.grace_time = cls.now - timedelta(seconds=cls.grace_secs)
+        cls.within_grace = cls.now - timedelta(seconds=cls.grace_secs // 2)
+        cls.outside_grace = cls.now - timedelta(seconds=cls.grace_secs * 2)
+
+        app = Application.objects.create(
+            name="test_app",
+            redirect_uris="http://localhost http://example.com http://example.org",
+            user=cls.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        # make refresh tokens, one third current, one third revoked within
+        # grace period and one third revoked outside grace period.
+        for i in range(0, cls.num_tokens, 3):
+            RefreshToken(
+                token=f"revoked refresh token {i}",
+                application=app,
+                user=cls.user,
+                revoked=cls.outside_grace,
+            ).save()
+
+        for i in range(1, cls.num_tokens, 3):
+            RefreshToken(
+                token=f"revoked within grace period refresh token {i}",
+                application=app,
+                user=cls.user,
+                revoked=cls.within_grace,
+            ).save()
+
+        for i in range(2, cls.num_tokens, 3):
+            RefreshToken(
+                token=f"current refresh token {i}",
+                application=app,
+                user=cls.user,
+            ).save()
+
+        cls.initial_rt_count = RefreshToken.objects.count()
+        assert cls.initial_rt_count == cls.num_tokens, f"{cls.num_tokens} refresh tokens should exist."
+        initial_revoked_rt_outside_grace_count = RefreshToken.objects.filter(
+            revoked__lte=cls.grace_time
+        ).count()
+        assert initial_revoked_rt_outside_grace_count == cls.initial_rt_count // 3, (
+            "one third of the refresh tokens should be revoked and outside grace period."
+        )
+        cls.initial_revoked_rt_inside_grace_count = RefreshToken.objects.filter(
+            revoked__gt=cls.grace_time
+        ).count()
+        assert cls.initial_revoked_rt_inside_grace_count == cls.initial_rt_count // 3, (
+            "one third of the refresh tokens should be revoked and inside grace period."
+        )
+        initial_revoked_rt_count = RefreshToken.objects.filter(revoked__lte=cls.now).count()
+        assert initial_revoked_rt_count == cls.initial_rt_count // 3 * 2, (
+            "two thirds of the refresh tokens should be revoked."
+        )
+        cls.initial_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert cls.initial_current_rt_count == cls.initial_rt_count // 3, (
+            "one third of the refresh tokens should be current."
+        )
+
+    def test_clear_expired_tokens_incorrect_timetype(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = "A"
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            clear_expired()
+        result = excinfo.value.__class__.__name__
+        assert result == "ImproperlyConfigured"
+
+    def test_clear_revoked_tokens_with_grace_period(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = self.grace_secs
+
+        clear_expired()
+
+        remaining_rt_count = RefreshToken.objects.count()
+        assert remaining_rt_count == self.initial_rt_count // 3 * 2, (
+            "two thirds of the the refresh tokens should still exist."
+        )
+        remaining_rt_revoked_count = RefreshToken.objects.filter(revoked__lte=self.grace_time).count()
+        assert remaining_rt_revoked_count == 0, (
+            "no revoked refresh tokens outside grace period should still exist."
+        )
+        remaining_revoked_rt_inside_grace_count = RefreshToken.objects.filter(
+            revoked__gt=self.grace_time
+        ).count()
+        assert remaining_revoked_rt_inside_grace_count == self.initial_revoked_rt_inside_grace_count, (
+            "all revoked refresh tokens inside grace period should still exist."
+        )
+        remaining_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert remaining_current_rt_count == self.initial_current_rt_count, (
+            "all the current refresh tokens should still exist."
+        )
+
+    def test_clear_revoked_tokens_without_grace_period(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = None
+
+        clear_expired()
+
+        remaining_rt_count = RefreshToken.objects.count()
+        assert remaining_rt_count == self.initial_rt_count // 3, (
+            "one third of the the refresh tokens should still exist."
+        )
+        remaining_revoked_rt_count = RefreshToken.objects.filter(revoked__lte=self.now).count()
+        assert remaining_revoked_rt_count == 0, "no revoked refresh tokens should still exist."
+        remaining_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert remaining_current_rt_count == self.initial_current_rt_count, (
+            "all the current refresh tokens should still exist."
+        )
+
+
 @pytest.mark.django_db(databases=retrieve_current_databases())
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
 def test_id_token_methods(oidc_tokens, rf):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -696,7 +696,7 @@ class TestClearRevoked(BaseTestModels):
 
         remaining_rt_count = RefreshToken.objects.count()
         assert remaining_rt_count == self.initial_rt_count // 3 * 2, (
-            "two thirds of the the refresh tokens should still exist."
+            "two thirds of the refresh tokens should still exist."
         )
         remaining_rt_revoked_count = RefreshToken.objects.filter(revoked__lte=self.grace_time).count()
         assert remaining_rt_revoked_count == 0, (
@@ -720,7 +720,7 @@ class TestClearRevoked(BaseTestModels):
 
         remaining_rt_count = RefreshToken.objects.count()
         assert remaining_rt_count == self.initial_rt_count // 3, (
-            "one third of the the refresh tokens should still exist."
+            "one third of the refresh tokens should still exist."
         )
         remaining_revoked_rt_count = RefreshToken.objects.filter(revoked__lte=self.now).count()
         assert remaining_revoked_rt_count == 0, "no revoked refresh tokens should still exist."

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -684,6 +684,11 @@ class TestClearRevoked(BaseTestModels):
         result = excinfo.value.__class__.__name__
         assert result == "ImproperlyConfigured"
 
+    def test_clear_expired_tokens_negative_grace_period(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = -self.grace_secs
+        with pytest.raises(ImproperlyConfigured):
+            clear_expired()
+
     def test_clear_revoked_tokens_with_grace_period(self):
         self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = self.grace_secs
 
@@ -709,7 +714,7 @@ class TestClearRevoked(BaseTestModels):
         )
 
     def test_clear_revoked_tokens_without_grace_period(self):
-        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = None
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 0
 
         clear_expired()
 
@@ -719,6 +724,41 @@ class TestClearRevoked(BaseTestModels):
         )
         remaining_revoked_rt_count = RefreshToken.objects.filter(revoked__lte=self.now).count()
         assert remaining_revoked_rt_count == 0, "no revoked refresh tokens should still exist."
+        remaining_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert remaining_current_rt_count == self.initial_current_rt_count, (
+            "all the current refresh tokens should still exist."
+        )
+
+    def test_clear_revoked_tokens_with_reuse_protection(self):
+        self.oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION = True
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = self.grace_secs
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
+
+        clear_expired()
+
+        remaining_rt_count = RefreshToken.objects.count()
+        assert remaining_rt_count == self.initial_rt_count, (
+            "with reuse protection and no expiry, all revoked refresh tokens should be kept."
+        )
+
+    def test_clear_revoked_tokens_with_reuse_protection_and_expiry(self):
+        self.oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION = True
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = self.grace_secs
+        # expiry cutoff falls between the two groups of revoked tokens
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = self.grace_secs + self.grace_secs // 2
+
+        clear_expired()
+
+        remaining_rt_count = RefreshToken.objects.count()
+        assert remaining_rt_count == self.initial_rt_count // 3 * 2, (
+            "with reuse protection, only revoked refresh tokens older than the expiry should be deleted."
+        )
+        remaining_revoked_rt_inside_grace_count = RefreshToken.objects.filter(
+            revoked__gt=self.grace_time
+        ).count()
+        assert remaining_revoked_rt_inside_grace_count == self.initial_revoked_rt_inside_grace_count, (
+            "all revoked refresh tokens inside grace period should still exist."
+        )
         remaining_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
         assert remaining_current_rt_count == self.initial_current_rt_count, (
             "all the current refresh tokens should still exist."

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -610,6 +610,121 @@ class TestCustomPrimaryKeyTokens(BaseTestModels):
         )
 
 
+@pytest.mark.usefixtures("oauth2_settings")
+class TestClearRevoked(BaseTestModels):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.num_tokens = 9
+        cls.grace_secs = 1000
+        cls.now = timezone.now()
+        cls.grace_time = cls.now - timedelta(seconds=cls.grace_secs)
+        cls.within_grace = cls.now - timedelta(seconds=cls.grace_secs // 2)
+        cls.outside_grace = cls.now - timedelta(seconds=cls.grace_secs * 2)
+
+        app = Application.objects.create(
+            name="test_app",
+            redirect_uris="http://localhost http://example.com http://example.org",
+            user=cls.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        # make refresh tokens, one third current, one third revoked within
+        # grace period and one third revoked outside grace period.
+        for i in range(0, cls.num_tokens, 3):
+            RefreshToken(
+                token=f"revoked refresh token {i}",
+                application=app,
+                user=cls.user,
+                revoked=cls.outside_grace,
+            ).save()
+
+        for i in range(1, cls.num_tokens, 3):
+            RefreshToken(
+                token=f"revoked within grace period refresh token {i}",
+                application=app,
+                user=cls.user,
+                revoked=cls.within_grace,
+            ).save()
+
+        for i in range(2, cls.num_tokens, 3):
+            RefreshToken(
+                token=f"current refresh token {i}",
+                application=app,
+                user=cls.user,
+            ).save()
+
+        cls.initial_rt_count = RefreshToken.objects.count()
+        assert cls.initial_rt_count == cls.num_tokens, f"{cls.num_tokens} refresh tokens should exist."
+        initial_revoked_rt_outside_grace_count = RefreshToken.objects.filter(
+            revoked__lte=cls.grace_time
+        ).count()
+        assert initial_revoked_rt_outside_grace_count == cls.initial_rt_count // 3, (
+            "one third of the refresh tokens should be revoked and outside grace period."
+        )
+        cls.initial_revoked_rt_inside_grace_count = RefreshToken.objects.filter(
+            revoked__gt=cls.grace_time
+        ).count()
+        assert cls.initial_revoked_rt_inside_grace_count == cls.initial_rt_count // 3, (
+            "one third of the refresh tokens should be revoked and inside grace period."
+        )
+        initial_revoked_rt_count = RefreshToken.objects.filter(revoked__lte=cls.now).count()
+        assert initial_revoked_rt_count == cls.initial_rt_count // 3 * 2, (
+            "two thirds of the refresh tokens should be revoked."
+        )
+        cls.initial_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert cls.initial_current_rt_count == cls.initial_rt_count // 3, (
+            "one third of the refresh tokens should be current."
+        )
+
+    def test_clear_expired_tokens_incorrect_timetype(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = "A"
+        with pytest.raises(ImproperlyConfigured) as excinfo:
+            clear_expired()
+        result = excinfo.value.__class__.__name__
+        assert result == "ImproperlyConfigured"
+
+    def test_clear_revoked_tokens_with_grace_period(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = self.grace_secs
+
+        clear_expired()
+
+        remaining_rt_count = RefreshToken.objects.count()
+        assert remaining_rt_count == self.initial_rt_count // 3 * 2, (
+            "two thirds of the the refresh tokens should still exist."
+        )
+        remaining_rt_revoked_count = RefreshToken.objects.filter(revoked__lte=self.grace_time).count()
+        assert remaining_rt_revoked_count == 0, (
+            "no revoked refresh tokens outside grace period should still exist."
+        )
+        remaining_revoked_rt_inside_grace_count = RefreshToken.objects.filter(
+            revoked__gt=self.grace_time
+        ).count()
+        assert remaining_revoked_rt_inside_grace_count == self.initial_revoked_rt_inside_grace_count, (
+            "all revoked refresh tokens inside grace period should still exist."
+        )
+        remaining_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert remaining_current_rt_count == self.initial_current_rt_count, (
+            "all the current refresh tokens should still exist."
+        )
+
+    def test_clear_revoked_tokens_without_grace_period(self):
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = None
+
+        clear_expired()
+
+        remaining_rt_count = RefreshToken.objects.count()
+        assert remaining_rt_count == self.initial_rt_count // 3, (
+            "one third of the the refresh tokens should still exist."
+        )
+        remaining_revoked_rt_count = RefreshToken.objects.filter(revoked__lte=self.now).count()
+        assert remaining_revoked_rt_count == 0, "no revoked refresh tokens should still exist."
+        remaining_current_rt_count = RefreshToken.objects.filter(revoked__isnull=True).count()
+        assert remaining_current_rt_count == self.initial_current_rt_count, (
+            "all the current refresh tokens should still exist."
+        )
+
+
 @pytest.mark.django_db(databases="__all__")
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
 def test_id_token_methods(oidc_tokens, rf):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -679,14 +679,16 @@ class TestClearRevoked(BaseTestModels):
 
     def test_clear_expired_tokens_incorrect_timetype(self):
         self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = "A"
-        with pytest.raises(ImproperlyConfigured) as excinfo:
+        with pytest.raises(
+            ImproperlyConfigured, match="REFRESH_TOKEN_GRACE_PERIOD_SECONDS must be in seconds"
+        ):
             clear_expired()
-        result = excinfo.value.__class__.__name__
-        assert result == "ImproperlyConfigured"
 
     def test_clear_expired_tokens_negative_grace_period(self):
         self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = -self.grace_secs
-        with pytest.raises(ImproperlyConfigured):
+        with pytest.raises(
+            ImproperlyConfigured, match="REFRESH_TOKEN_GRACE_PERIOD_SECONDS must not be negative"
+        ):
             clear_expired()
 
     def test_clear_revoked_tokens_with_grace_period(self):


### PR DESCRIPTION
## Description of the Change

When refresh token grace period was introduced in 2e4d15e ("Revoke refresh tokens instead of deleting them"), the cleanup of revoked refresh tokens got moved to cleartokens.

With a short REFRESH_TOKEN_GRACE_PERIOD_SECONDS and a long REFRESH_TOKEN_EXPIRE_SECONDS, revoked refresh tokens will not be cleaned up until they expire, even if they cannot be used after the grace period.

Extend the logic in clear_expired() so that revoked refresh tokens can be removed once the grace period is over.

This does not change user visible behavior, as it only removes expired tokens after the grace period, but will reduce the number of tokens stored.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
