### PR TITLE
fix: correct malformed Cache-Control header in JWKS info

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Andrew Chen Wang
 Andrew Zickler
 Antoine Laurent
 Anvesh Agarwal
+Aris Zhou
 Aristóbulo Meneses
 Aryan Iyappan
 Asaf Klibansky

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1628 Fix inaccurate help_text on client_secret field of Application model
 * #1674 Add `list_select_related` to `RefreshTokenAdmin` to avoid unbounded `JOIN` queries on the changelist
 * #1621 Fix device code tokens getting the wrong scope.
+* #1689 Fix invalid `Cache-Control` header value on the OIDC JWKS endpoint
 * #1692 Fix consent violation and scope escalation.
 
 ## [3.2.0] - 2025-11-13

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -128,7 +128,7 @@ class JwksInfoView(OIDCOnlyMixin, View):
         response = JsonResponse({"keys": keys})
         response["Access-Control-Allow-Origin"] = "*"
         response["Cache-Control"] = (
-            "Cache-Control: public, "
+            "public, "
             + f"max-age={oauth2_settings.OIDC_JWKS_MAX_AGE_SECONDS}, "
             + f"stale-while-revalidate={oauth2_settings.OIDC_JWKS_MAX_AGE_SECONDS}, "
             + f"stale-if-error={oauth2_settings.OIDC_JWKS_MAX_AGE_SECONDS}"

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -174,6 +174,14 @@ class TestJwksInfoView(TestCase):
         self.assertEqual(response.status_code, 200)
         assert response.json() == expected_response
 
+    def test_get_jwks_info_cache_control_header(self):
+        response = self.client.get(reverse("oauth2_provider:jwks-info"))
+
+        self.assertEqual(response.status_code, 200)
+        assert response["Cache-Control"] == (
+            "public, max-age=3600, stale-while-revalidate=3600, stale-if-error=3600"
+        )
+
     def test_get_jwks_info_no_rsa_key(self):
         self.oauth2_settings.OIDC_RSA_PRIVATE_KEY = None
         response = self.client.get(reverse("oauth2_provider:jwks-info"))

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -176,10 +176,11 @@ class TestJwksInfoView(TestCase):
 
     def test_get_jwks_info_cache_control_header(self):
         response = self.client.get(reverse("oauth2_provider:jwks-info"))
+        max_age = self.oauth2_settings.OIDC_JWKS_MAX_AGE_SECONDS
 
         self.assertEqual(response.status_code, 200)
         assert response["Cache-Control"] == (
-            "public, max-age=3600, stale-while-revalidate=3600, stale-if-error=3600"
+            f"public, max-age={max_age}, stale-while-revalidate={max_age}, stale-if-error={max_age}"
         )
 
     def test_get_jwks_info_no_rsa_key(self):


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #1689 

## Description of the Change

Fix malformed Cache-Control header in the JWKS endpoint by removing the duplicated header prefix from its value, ensuring the response is cacheable by CDN services.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
