### PR TITLE
Fix/consent violation and scope escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1628 Fix inaccurate help_text on client_secret field of Application model
 * #1674 Add `list_select_related` to `RefreshTokenAdmin` to avoid unbounded `JOIN` queries on the changelist
 * #1621 Fix device code tokens getting the wrong scope.
+* #1692 Fix consent violation and scope escalation.
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -8,6 +8,8 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 from django.views.generic import DetailView, FormView, View
+from oauthlib.common import Request as OAuthlibRequest
+from oauthlib.common import urlencode
 from oauthlib.oauth2 import DeviceApplicationServer
 
 from oauth2_provider.compat import login_not_required
@@ -16,6 +18,7 @@ from oauth2_provider.models import (
     DeviceGrant,
     DeviceRequest,
     create_device_grant,
+    get_application_model,
     get_device_grant_model,
 )
 from oauth2_provider.views.mixins import OAuthLibMixin
@@ -32,7 +35,31 @@ class DeviceAuthorizationView(OAuthLibMixin, View):
         if status != 200:
             return http.JsonResponse(data=json.loads(response), status=status, headers=headers)
 
-        device_request = DeviceRequest(client_id=request.POST["client_id"], scope=request.POST.get("scope"))
+        client_id = request.POST["client_id"]
+        requested_scope = request.POST.get("scope", "").strip()
+        if requested_scope:
+            scope = requested_scope
+        else:
+            Application = get_application_model()
+            try:
+                application = Application.objects.get(client_id=client_id)
+            except Application.DoesNotExist:
+                return http.JsonResponse(
+                    {"error": "invalid_client", "error_description": "No application found for client_id."},
+                    status=401,
+                    headers=headers,
+                )
+            core = self.get_oauthlib_core()
+            uri = request.build_absolute_uri()
+            http_method = request.method
+            body = urlencode(core.extract_body(request))
+            req_headers = core.extract_headers(request)
+            oauthlib_request = OAuthlibRequest(uri, http_method=http_method, body=body, headers=req_headers)
+            oauthlib_request.client_id = client_id
+            oauthlib_request.client = application
+            validator = core.server.request_validator
+            scope = " ".join(validator.get_default_scopes(client_id, oauthlib_request))
+        device_request = DeviceRequest(client_id=client_id, scope=scope)
         device_response = DeviceCodeResponse(**response)
         create_device_grant(device_request, device_response)
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -812,3 +812,81 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
 
         assert token_response.status_code == 200
         assert token_response.json()["scope"] == "read"
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "def",
+    )
+    def test_device_flow_default_scopes_stored_on_grant_when_no_scope_requested(self):
+        """
+        When the device omits `scope`, DEFAULT_SCOPES must be stored on the DeviceGrant
+        at authorization time so the consent screen shows the correct scopes and the
+        issued token matches what the user approved.
+        """
+        self.oauth2_settings.OAUTH_DEVICE_VERIFICATION_URI = "example.com/device"
+        self.oauth2_settings.OAUTH_DEVICE_USER_CODE_GENERATOR = lambda: "XYZ"
+        self.oauth2_settings.OAUTH_PRE_TOKEN_VALIDATION = [set_oauthlib_user_to_device_request_user]
+
+        # Device sends authorization request with no scope
+        device_authorization_response = self.client.post(
+            reverse("oauth2_provider:device-authorization"),
+            data=urlencode({"client_id": self.application.client_id}),
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert device_authorization_response.status_code == 200
+
+        # DEFAULT_SCOPES ("read write") must be persisted on the grant immediately
+        DeviceGrantModel = get_device_grant_model()
+        grant = DeviceGrantModel.objects.get(device_code="def")
+        assert grant.scope == "read write"
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "def",
+    )
+    def test_device_flow_default_scopes_not_re_evaluated_at_token_time(self):
+        """
+        If DEFAULT_SCOPES changes between user consent and device polling, the token
+        must reflect the scopes that were shown on the consent screen (locked in at
+        authorization time), not the new DEFAULT_SCOPES.
+        """
+        self.oauth2_settings.OAUTH_DEVICE_VERIFICATION_URI = "example.com/device"
+        self.oauth2_settings.OAUTH_DEVICE_USER_CODE_GENERATOR = lambda: "XYZ"
+        self.oauth2_settings.OAUTH_PRE_TOKEN_VALIDATION = [set_oauthlib_user_to_device_request_user]
+
+        # Device sends authorization request with no scope; DEFAULT_SCOPES = ["read", "write"]
+        device_authorization_response = self.client.post(
+            reverse("oauth2_provider:device-authorization"),
+            data=urlencode({"client_id": self.application.client_id}),
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert device_authorization_response.status_code == 200
+
+        self.client.login(username="test_user", password="123456")
+        self.client.post(reverse("oauth2_provider:device"), data={"user_code": "XYZ"})
+        self.client.post(
+            reverse(
+                "oauth2_provider:device-confirm",
+                kwargs={"user_code": "XYZ", "client_id": self.application.client_id},
+            ),
+            data={"action": "accept"},
+        )
+
+        # Admin changes DEFAULT_SCOPES after consent but before the device polls
+        self.oauth2_settings.DEFAULT_SCOPES = ["read", "write", "admin"]
+
+        token_response = self.client.post(
+            "/o/token/",
+            data=urlencode(
+                {
+                    "device_code": "def",
+                    "client_id": self.application.client_id,
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                }
+            ),
+            content_type="application/x-www-form-urlencoded",
+        )
+
+        assert token_response.status_code == 200
+        # Token must reflect the scopes from consent time, not the expanded DEFAULT_SCOPES
+        assert token_response.json()["scope"] == "read write"

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -844,6 +844,30 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
         "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
         lambda: "def",
     )
+    def test_device_flow_whitespace_only_scope_falls_back_to_default_scopes(self):
+        """
+        When the device sends scope consisting only of whitespace (e.g. scope="   "),
+        it must be treated as if scope was omitted and DEFAULT_SCOPES must be stored
+        on the DeviceGrant, not the raw whitespace string.
+        """
+        self.oauth2_settings.OAUTH_DEVICE_VERIFICATION_URI = "example.com/device"
+        self.oauth2_settings.OAUTH_DEVICE_USER_CODE_GENERATOR = lambda: "XYZ"
+
+        device_authorization_response = self.client.post(
+            reverse("oauth2_provider:device-authorization"),
+            data=urlencode({"client_id": self.application.client_id, "scope": "   "}),
+            content_type="application/x-www-form-urlencoded",
+        )
+        assert device_authorization_response.status_code == 200
+
+        DeviceGrantModel = get_device_grant_model()
+        grant = DeviceGrantModel.objects.get(device_code="def")
+        assert grant.scope == "read write"
+
+    @mock.patch(
+        "oauthlib.oauth2.rfc8628.endpoints.device_authorization.generate_token",
+        lambda: "def",
+    )
     def test_device_flow_default_scopes_not_re_evaluated_at_token_time(self):
         """
         If DEFAULT_SCOPES changes between user consent and device polling, the token
@@ -872,8 +896,24 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
             data={"action": "accept"},
         )
 
-        # Admin changes DEFAULT_SCOPES after consent but before the device polls
+        # Admin changes DEFAULT_SCOPES after consent but before the device polls.
+        # "admin" must also be in SCOPES or oauth2_settings raises ImproperlyConfigured
+        # when _DEFAULT_SCOPES is re-evaluated after reload().
+        self.oauth2_settings.SCOPES = {
+            "read": "Reading scope",
+            "write": "Writing scope",
+            "admin": "Admin scope",
+        }
         self.oauth2_settings.DEFAULT_SCOPES = ["read", "write", "admin"]
+        # Clear only the computed scope caches so the new SCOPES/DEFAULT_SCOPES
+        # values take effect without wiping the overrides we just set above.
+        # Calling reload() would delete those overrides and fall back to Django settings.
+        for _attr in ("_SCOPES", "_DEFAULT_SCOPES"):
+            try:
+                delattr(self.oauth2_settings, _attr)
+            except AttributeError:
+                pass
+            self.oauth2_settings._cached_attrs.discard(_attr)
 
         token_response = self.client.post(
             "/o/token/",
@@ -890,3 +930,36 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
         assert token_response.status_code == 200
         # Token must reflect the scopes from consent time, not the expanded DEFAULT_SCOPES
         assert token_response.json()["scope"] == "read write"
+
+    def test_device_authorization_returns_invalid_client_when_application_deleted_before_scope_resolution(
+        self,
+    ):
+        """
+        If the Application is deleted between oauthlib validating the client and DOT
+        resolving default scopes, the view must return an invalid_client error rather
+        than silently proceeding with application=None.
+
+        This covers the DoesNotExist branch in DeviceAuthorizationView.post() that is
+        only reached when scope is omitted (so default-scope resolution is attempted).
+        """
+        self.oauth2_settings.OAUTH_DEVICE_VERIFICATION_URI = "example.com/device"
+        self.oauth2_settings.OAUTH_DEVICE_USER_CODE_GENERATOR = lambda: "XYZ"
+
+        Application = get_application_model()
+
+        # Patch get_application_model as imported in the view to simulate a race where
+        # the Application row is deleted between oauthlib validation and scope resolution.
+        # We use a spec'd mock so that DoesNotExist is accessible as an attribute.
+        mock_model = mock.MagicMock(spec=Application)
+        mock_model.DoesNotExist = Application.DoesNotExist
+        mock_model.objects.get.side_effect = Application.DoesNotExist
+
+        with mock.patch("oauth2_provider.views.device.get_application_model", return_value=mock_model):
+            response = self.client.post(
+                reverse("oauth2_provider:device-authorization"),
+                data=urlencode({"client_id": self.application.client_id}),
+                content_type="application/x-www-form-urlencoded",
+            )
+
+        assert response.status_code == 401
+        assert response.json()["error"] == "invalid_client"


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
## Description of the Change

When a device authorization request omits `scope`, the DeviceGrant was
created with `scope=None`. At token exchange time, OAuthLib's
`validate_scopes` falls back to `get_default_scopes()`, which evaluates
`DEFAULT_SCOPES` at that moment — not at the time the user consented.

This means:
- The consent screen showed an empty scope list while the issued token
  carried whatever DEFAULT_SCOPES happened to be at redemption time
- If an admin changed DEFAULT_SCOPES between user consent and device
  polling, the token could contain scopes the user never authorized

Fix by resolving DEFAULT_SCOPES in DeviceAuthorizationView at grant
creation time, so the scope is locked in before the consent screen is
shown and before the user approves. The existing
set_oauthlib_user_to_device_request_user pre-token validator then
propagates the stored scope into the OAuthLib request, preventing the
fallback to get_default_scopes() entirely.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [N/A] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [N/A] tests/app/idp updated to demonstrate new features
- [N/A] tests/app/rp updated to demonstrate new features
