### PR TITLE
Add localhost as a valid loopback domain

### DIFF
--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -951,6 +951,7 @@ def redirect_to_uri_allowed(uri, allowed_uris):
         allowed_uri_is_loopback = parsed_allowed_uri.scheme == "http" and parsed_allowed_uri.hostname in [
             "127.0.0.1",
             "::1",
+            "localhost"
         ]
         """ check port """
         if not allowed_uri_is_loopback and parsed_allowed_uri.port != parsed_uri.port:


### PR DESCRIPTION
## Description of the Change

This adds localhost as a valid loopback domain, as
https://datatracker.ietf.org/doc/html/rfc8252#section-8.3
it should not be used but needs to be handled the same as 127.0.0.1
Some broken clients (aka Claude Code) use it :facepalm: 

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
