### PR TITLE
Fix OIDC claims when never logged 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,6 +48,7 @@ David Hill
 David Smith
 David Uzumaki
 Dawid Wolski
+Davide Bianchi
 Diego Garcia
 Diego Pasqualin
 Dominik George

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * #1594 Fix introspection token expiry handling to consistently use UTC and avoid the deprecated
   `datetime.utcfromtimestamp`.
+* #1696 Fix `auth_time` in oauth2 validator when user has never logged in.
+
 
 ## [3.3.0] - 2025-05-21
 
@@ -41,7 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow
 * #1689 Fix invalid `Cache-Control` header value on the OIDC JWKS endpoint
 * #1692 Fix consent violation and scope escalation.
-* Fix `auth_time` in oauth2 validator when user has never logged in.
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow
 * #1689 Fix invalid `Cache-Control` header value on the OIDC JWKS endpoint
 * #1692 Fix consent violation and scope escalation.
+* Fix `auth_time` in oauth2 validator when user has never logged in.
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -901,12 +901,17 @@ class OAuth2Validator(RequestValidator):
         claims = self.get_oidc_claims(token, token_handler, request)
 
         expiration_time = timezone.now() + timedelta(seconds=oauth2_settings.ID_TOKEN_EXPIRE_SECONDS)
+
+        last_login = request.user.last_login
+        if last_login is None:
+            last_login = timezone.now()
+
         # Required ID Token claims
         claims.update(
             **{
                 "iss": self.get_oidc_issuer_endpoint(request),
                 "exp": int(dateformat.format(expiration_time, "U")),
-                "auth_time": int(dateformat.format(request.user.last_login, "U")),
+                "auth_time": int(dateformat.format(last_login, "U")),
                 "jti": str(uuid.uuid4()),
             }
         )

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -902,16 +902,27 @@ class OAuth2Validator(RequestValidator):
 
         expiration_time = timezone.now() + timedelta(seconds=oauth2_settings.ID_TOKEN_EXPIRE_SECONDS)
 
-        last_login = request.user.last_login
-        if last_login is None:
-            last_login = timezone.now()
+        auth_time = request.user.last_login
+        if auth_time is None:
+            auth_time = timezone.now()
+
+        # RFC 7519 numeric dates are seconds since epoch in UTC.
+        # For USE_TZ=False, naive datetimes represent local wall-clock time.
+        # For USE_TZ=True, legacy naive values are interpreted as UTC.
+        if timezone.is_naive(auth_time):
+            if settings.USE_TZ:
+                auth_time = auth_time.replace(tzinfo=datetime_timezone.utc)
+            else:
+                auth_time = make_aware(auth_time, timezone=timezone.get_default_timezone())
+
+        auth_time = auth_time.astimezone(datetime_timezone.utc)
 
         # Required ID Token claims
         claims.update(
             **{
                 "iss": self.get_oidc_issuer_endpoint(request),
                 "exp": int(dateformat.format(expiration_time, "U")),
-                "auth_time": int(dateformat.format(last_login, "U")),
+                "auth_time": int(auth_time.timestamp()),
                 "jti": str(uuid.uuid4()),
             }
         )

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -648,6 +648,66 @@ def test_validate_id_token_bad_token_no_aud(oauth2_settings, mocker, oidc_key):
     assert status is False
 
 
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_get_id_token_dictionary_auth_time_naive_last_login_is_utc(oauth2_settings, rf):
+    validator = OAuth2Validator()
+    django_request = rf.get("/")
+    request = Request("/", headers=django_request.META)
+    request.scopes = ["openid"]
+    request.client = mock.MagicMock()
+
+    naive_last_login = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    request.user = mock.MagicMock(pk=1, last_login=naive_last_login)
+
+    with timezone.override("Europe/Rome"):
+        claims, _ = validator.get_id_token_dictionary(None, None, request)
+
+    expected_auth_time = int(naive_last_login.replace(tzinfo=datetime.timezone.utc).timestamp())
+    assert claims["auth_time"] == expected_auth_time
+
+
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_get_id_token_dictionary_auth_time_last_login_none_falls_back_to_now(oauth2_settings, rf):
+    validator = OAuth2Validator()
+    django_request = rf.get("/")
+    request = Request("/", headers=django_request.META)
+    request.scopes = ["openid"]
+    request.client = mock.MagicMock()
+    request.user = mock.MagicMock(pk=1, last_login=None)
+
+    frozen_now = datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    with mock.patch("oauth2_provider.oauth2_validators.timezone.now", return_value=frozen_now):
+        claims, _ = validator.get_id_token_dictionary(None, None, request)
+
+    assert claims["auth_time"] == int(frozen_now.timestamp())
+
+
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_get_id_token_dictionary_auth_time_naive_last_login_use_tz_false_uses_default_timezone(
+    oauth2_settings, rf, settings
+):
+    settings.USE_TZ = False
+    settings.TIME_ZONE = "Europe/Rome"
+
+    validator = OAuth2Validator()
+    django_request = rf.get("/")
+    request = Request("/", headers=django_request.META)
+    request.scopes = ["openid"]
+    request.client = mock.MagicMock()
+
+    naive_last_login = datetime.datetime(2026, 1, 1, 12, 0, 0)
+    request.user = mock.MagicMock(pk=1, last_login=naive_last_login)
+
+    claims, _ = validator.get_id_token_dictionary(None, None, request)
+
+    expected_auth_time = int(
+        timezone.make_aware(naive_last_login, timezone=timezone.get_default_timezone())
+        .astimezone(datetime.timezone.utc)
+        .timestamp()
+    )
+    assert claims["auth_time"] == expected_auth_time
+
+
 @pytest.mark.django_db(databases=retrieve_current_databases())
 def test_invalidate_authorization_token_returns_invalid_grant_error_when_grant_does_not_exist():
     client_id = "123"


### PR DESCRIPTION
<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->

## Description of the Change

This PR fixes an issue in the OpenID Connect ID token generation flow when `auth_time` is built for a user whose `last_login` value is `None`.

In the current implementation, `get_id_token_dictionary()` uses `request.user.last_login` to populate the `auth_time` claim. This works for users who have previously logged in, but it fails for users that exist in the system without a recorded login timestamp.

One example is a Django application using Django OAuth Toolkit as an OIDC provider together with an impersonation flow. An administrator may create a user from the Django admin interface and then impersonate that user, for example with `django-impersonate`, in order to verify permissions inside the client application. Since the impersonated user may never have performed a normal login, `last_login` can be `None`, causing ID token creation to fail.

This change adds a fallback for `auth_time` when `last_login` is not available. If the user has no recorded login timestamp, the current time is used instead. Existing behavior is preserved for users with a valid `last_login`.

## Why this is needed

OIDC login should not fail only because the user was created administratively or authenticated through an impersonation/debugging workflow and therefore has no `last_login` value.

The change keeps the ID token generation robust while preserving the existing claim structure.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
