### PR TITLE
Add dynamic help text for client_secret field on application form

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -141,3 +141,4 @@ Miriam Forner
 Alex Kerkum
 Tuhin Mitra
 q0w
+Emmanuel Angelo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * #1373 Integration and docs for Django Ninja authentication
 * #1546 Support for RP-Initiated Registration
+* #1635 Dynamic help text on the application form's `client_secret` field, warning users to copy the
+  secret on creation and explaining it is hashed and unrecoverable when editing.
 
 ### Security
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -1,4 +1,6 @@
 from django import forms
+from django.forms.models import modelform_factory
+from .models import get_application_model
 
 
 class AllowForm(forms.Form):
@@ -26,3 +28,18 @@ class ConfirmLogoutForm(forms.Form):
     def __init__(self, *args, **kwargs):
         self.request = kwargs.pop("request", None)
         super(ConfirmLogoutForm, self).__init__(*args, **kwargs)
+
+
+class ApplicationForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance and self.instance.pk:
+            self.fields["client_secret"].help_text = (
+                "⚠️ The client secret has been hashed and can no longer be viewed. "
+                "If you need the original value, you must regenerate it and save it immediately."
+            )
+        else:
+            self.fields["client_secret"].help_text = (
+                "⚠️ Copy and store this secret now. "
+                "Once saved, it will be hashed and cannot be recovered."
+            )

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -54,28 +54,35 @@ class ApplicationForm(forms.ModelForm):
         # be) hashed.
         existing = bool(self.instance and self.instance.pk)
         if existing and _is_hashed(self.instance.client_secret):
-            # Already hashed. This cannot be undone, so the flag is irrelevant here.
+            # Already hashed. This cannot be undone, so the flag is irrelevant here
+            # and there is nothing for the live toggle to swap.
             self.fields["client_secret"].help_text = _(
                 "The client secret is hashed and can no longer be viewed. "
                 "To rotate it, enter a new value and copy it before saving; "
                 "the original secret cannot be recovered."
             )
-        elif self._will_hash_client_secret():
-            # Secret is currently readable but will be hashed on save. Covers a new
-            # application and an existing cleartext secret with hashing being enabled
-            # (e.g. re-rendered after a failed POST).
-            self.fields["client_secret"].help_text = _(
-                "Copy and store this secret now. Once saved, it will be hashed and cannot be recovered."
-            )
-        elif existing:
-            self.fields["client_secret"].help_text = _(
+            return
+        # The secret is currently readable. Which warning applies depends on whether
+        # it will be hashed on save, which the user toggles via hash_client_secret.
+        # Expose both messages so the template can swap them live as the checkbox
+        # changes; the server picks the correct one for the initial / no-JS render.
+        self.client_secret_help_when_hashed = _(
+            "Copy and store this secret now. Once saved, it will be hashed and cannot be recovered."
+        )
+        if existing:
+            self.client_secret_help_when_unhashed = _(
                 "This application stores its client secret unhashed, so the value above "
                 "remains usable. Entering a new value replaces it."
             )
         else:
-            self.fields["client_secret"].help_text = _(
+            self.client_secret_help_when_unhashed = _(
                 "Copy and store this secret now. This application stores the secret unhashed."
             )
+        self.fields["client_secret"].help_text = (
+            self.client_secret_help_when_hashed
+            if self._will_hash_client_secret()
+            else self.client_secret_help_when_unhashed
+        )
 
     def _will_hash_client_secret(self):
         """Whether the client secret will be hashed on save.

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -1,6 +1,17 @@
 from django import forms
-from django.forms.models import modelform_factory
-from .models import get_application_model
+from django.contrib.auth.hashers import identify_hasher
+from django.utils.translation import gettext_lazy as _
+
+
+def _is_hashed(secret):
+    """Return True if ``secret`` is a recognized password hash (not cleartext)."""
+    if not secret:
+        return False
+    try:
+        identify_hasher(secret)
+    except ValueError:
+        return False
+    return True
 
 
 class AllowForm(forms.Form):
@@ -33,13 +44,48 @@ class ConfirmLogoutForm(forms.Form):
 class ApplicationForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if self.instance and self.instance.pk:
-            self.fields["client_secret"].help_text = (
-                "⚠️ The client secret has been hashed and can no longer be viewed. "
-                "If you need the original value, you must regenerate it and save it immediately."
+        # This form is normally bound to the (swappable) application model via
+        # ``modelform_factory``; guard against field sets that omit client_secret.
+        if "client_secret" not in self.fields:
+            return
+        # Hashing is optional per-application (``hash_client_secret``); when it is
+        # disabled the secret is stored as-is and stays readable, so the warnings
+        # about hashing / unrecoverability only apply when the secret is (or will
+        # be) hashed.
+        existing = bool(self.instance and self.instance.pk)
+        if existing and _is_hashed(self.instance.client_secret):
+            # Already hashed. This cannot be undone, so the flag is irrelevant here.
+            self.fields["client_secret"].help_text = _(
+                "The client secret is hashed and can no longer be viewed. "
+                "To rotate it, enter a new value and copy it before saving; "
+                "the original secret cannot be recovered."
+            )
+        elif self._will_hash_client_secret():
+            # Secret is currently readable but will be hashed on save. Covers a new
+            # application and an existing cleartext secret with hashing being enabled
+            # (e.g. re-rendered after a failed POST).
+            self.fields["client_secret"].help_text = _(
+                "Copy and store this secret now. Once saved, it will be hashed and cannot be recovered."
+            )
+        elif existing:
+            self.fields["client_secret"].help_text = _(
+                "This application stores its client secret unhashed, so the value above "
+                "remains usable. Entering a new value replaces it."
             )
         else:
-            self.fields["client_secret"].help_text = (
-                "⚠️ Copy and store this secret now. "
-                "Once saved, it will be hashed and cannot be recovered."
+            self.fields["client_secret"].help_text = _(
+                "Copy and store this secret now. This application stores the secret unhashed."
             )
+
+    def _will_hash_client_secret(self):
+        """Whether the client secret will be hashed on save.
+
+        Honors the submitted value so the help text stays correct when the form
+        is re-rendered after a failed POST; otherwise falls back to the
+        instance/model default.
+        """
+        if self.is_bound and "hash_client_secret" in self.fields:
+            return self.fields["hash_client_secret"].widget.value_from_datadict(
+                self.data, self.files, self.add_prefix("hash_client_secret")
+            )
+        return getattr(self.instance, "hash_client_secret", True)

--- a/oauth2_provider/templates/oauth2_provider/application_form.html
+++ b/oauth2_provider/templates/oauth2_provider/application_form.html
@@ -42,4 +42,34 @@
             </div>
         </form>
     </div>
+
+    {% if form.client_secret_help_when_hashed and form.client_secret_help_when_unhashed %}
+        {{ form.client_secret_help_when_hashed|json_script:"client-secret-help-when-hashed" }}
+        {{ form.client_secret_help_when_unhashed|json_script:"client-secret-help-when-unhashed" }}
+        <script>
+            (function () {
+                var hashField = document.getElementById("id_hash_client_secret");
+                var secretField = document.getElementById("id_client_secret");
+                if (!hashField || !secretField) {
+                    return;
+                }
+                var controls = secretField.closest(".controls");
+                var help = controls ? controls.querySelector(".help-block") : null;
+                if (!help) {
+                    return;
+                }
+                var whenHashed = JSON.parse(
+                    document.getElementById("client-secret-help-when-hashed").textContent
+                );
+                var whenUnhashed = JSON.parse(
+                    document.getElementById("client-secret-help-when-unhashed").textContent
+                );
+                function sync() {
+                    help.textContent = hashField.checked ? whenHashed : whenUnhashed;
+                }
+                hashField.addEventListener("change", sync);
+                sync();
+            })();
+        </script>
+    {% endif %}
 {% endblock %}

--- a/oauth2_provider/templates/oauth2_provider/application_form.html
+++ b/oauth2_provider/templates/oauth2_provider/application_form.html
@@ -16,6 +16,9 @@
                     <label class="control-label" for="{{ field.id_for_label }}">{{ field.label }}</label>
                     <div class="controls">
                         {{ field }}
+                        {% if field.help_text %}
+                            <span class="help-block">{{ field.help_text }}</span>
+                        {% endif %}
                         {% for error in field.errors %}
                             <span class="help-inline">{{ error }}</span>
                         {% endfor %}

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -6,6 +6,7 @@ from django.views.generic import CreateView, DeleteView, DetailView, ListView, U
 from ..forms import ApplicationForm
 from ..models import get_application_model
 
+
 APPLICATION_FIELDS = (
     "name",
     "client_id",

--- a/oauth2_provider/views/application.py
+++ b/oauth2_provider/views/application.py
@@ -3,7 +3,21 @@ from django.forms.models import modelform_factory
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, DeleteView, DetailView, ListView, UpdateView
 
+from ..forms import ApplicationForm
 from ..models import get_application_model
+
+APPLICATION_FIELDS = (
+    "name",
+    "client_id",
+    "client_secret",
+    "hash_client_secret",
+    "client_type",
+    "authorization_grant_type",
+    "redirect_uris",
+    "post_logout_redirect_uris",
+    "allowed_origins",
+    "algorithm",
+)
 
 
 class ApplicationOwnerIsUserMixin(LoginRequiredMixin):
@@ -25,24 +39,7 @@ class ApplicationRegistration(LoginRequiredMixin, CreateView):
     template_name = "oauth2_provider/application_registration_form.html"
 
     def get_form_class(self):
-        """
-        Returns the form class for the application model
-        """
-        return modelform_factory(
-            get_application_model(),
-            fields=(
-                "name",
-                "client_id",
-                "client_secret",
-                "hash_client_secret",
-                "client_type",
-                "authorization_grant_type",
-                "redirect_uris",
-                "post_logout_redirect_uris",
-                "allowed_origins",
-                "algorithm",
-            ),
-        )
+        return modelform_factory(get_application_model(), form=ApplicationForm, fields=APPLICATION_FIELDS)
 
     def form_valid(self, form):
         form.instance.user = self.request.user
@@ -86,21 +83,4 @@ class ApplicationUpdate(ApplicationOwnerIsUserMixin, UpdateView):
     template_name = "oauth2_provider/application_form.html"
 
     def get_form_class(self):
-        """
-        Returns the form class for the application model
-        """
-        return modelform_factory(
-            get_application_model(),
-            fields=(
-                "name",
-                "client_id",
-                "client_secret",
-                "hash_client_secret",
-                "client_type",
-                "authorization_grant_type",
-                "redirect_uris",
-                "post_logout_redirect_uris",
-                "allowed_origins",
-                "algorithm",
-            ),
-        )
+        return modelform_factory(get_application_model(), form=ApplicationForm, fields=APPLICATION_FIELDS)

--- a/tests/app/idp/pyproject.toml
+++ b/tests/app/idp/pyproject.toml
@@ -6,8 +6,9 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "Django>=4.2,<=5.2",
-    "django-cors-headers==3.14.0",
-    "django-environ==0.11.2",
+    "django-cors-headers==4.6.0",
+    "django-environ==0.12.0",
+    "whitenoise==6.8.2",
     "django-oauth-toolkit",
 ]
 

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -1,7 +1,10 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.contrib.auth.hashers import make_password
+from django.forms.models import modelform_factory
 from django.urls import reverse
 
+from oauth2_provider.forms import ApplicationForm, _is_hashed
 from oauth2_provider.models import get_application_model
 from oauth2_provider.views.application import ApplicationRegistration
 
@@ -287,9 +290,82 @@ class TestApplicationViews(BaseTest):
         response = self.client.get(reverse("oauth2_provider:register"))
         form = response.context["form"]
         self.assertIn("Copy and store this secret now", form.fields["client_secret"].help_text)
+        self.assertContains(response, "Copy and store this secret now")
 
     def test_client_secret_help_text_existing_application(self):
         self.client.login(username="foo_user", password="123456")
         response = self.client.get(reverse("oauth2_provider:update", args=(self.app_foo_1.pk,)))
         form = response.context["form"]
-        self.assertIn("has been hashed", form.fields["client_secret"].help_text)
+        self.assertIn("can no longer be viewed", form.fields["client_secret"].help_text)
+        self.assertContains(response, "can no longer be viewed")
+
+    def test_client_secret_help_text_existing_application_unhashed(self):
+        # Create with hashing disabled from the start so the stored secret stays cleartext.
+        app = Application.objects.create(
+            name="app foo_user unhashed",
+            redirect_uris="http://example.com",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.foo_user,
+            hash_client_secret=False,
+            client_secret="cleartext-secret",
+        )
+        self.assertEqual(app.client_secret, "cleartext-secret")  # sanity: not hashed on save
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:update", args=(app.pk,)))
+        form = response.context["form"]
+        self.assertIn("stores its client secret unhashed", form.fields["client_secret"].help_text)
+        self.assertContains(response, "stores its client secret unhashed")
+
+    def test_client_secret_help_text_existing_application_hashed_after_disable(self):
+        # Disabling hash_client_secret does not unhash an already-hashed stored secret,
+        # so the edit form must still show the "hashed / cannot be viewed" message.
+        app = self._create_application("app foo_user was hashed", self.foo_user)
+        self.assertTrue(app.hash_client_secret)  # hashed on create by default
+        app.hash_client_secret = False
+        app.save()
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:update", args=(app.pk,)))
+        form = response.context["form"]
+        self.assertIn("can no longer be viewed", form.fields["client_secret"].help_text)
+
+    def test_client_secret_help_text_existing_unhashed_enabling_hashing(self):
+        # Existing cleartext secret + hashing being enabled (e.g. failed-POST
+        # re-render): the secret will be hashed on save, so the form must warn
+        # rather than say the value "remains usable".
+        app = Application.objects.create(
+            name="app foo_user enabling hashing",
+            redirect_uris="http://example.com",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=self.foo_user,
+            hash_client_secret=False,
+            client_secret="cleartext-secret",
+        )
+        form_class = ApplicationRegistration().get_form_class()
+        form = form_class(data={"hash_client_secret": "on"}, instance=app)
+        self.assertIn("it will be hashed and cannot be recovered", form.fields["client_secret"].help_text)
+
+    def test_client_secret_help_text_new_application_unhashed(self):
+        form_class = ApplicationRegistration().get_form_class()
+        form = form_class(instance=Application(hash_client_secret=False))
+        self.assertIn("stores the secret unhashed", form.fields["client_secret"].help_text)
+
+    def test_client_secret_help_text_new_application_honors_submitted_value(self):
+        # After a failed POST the help text should reflect the submitted
+        # hash_client_secret value, not just the model default.
+        form_class = ApplicationRegistration().get_form_class()
+        form = form_class(data={"name": "incomplete"})  # bound, hash checkbox unchecked -> False
+        self.assertIn("stores the secret unhashed", form.fields["client_secret"].help_text)
+
+    def test_application_form_without_client_secret_field(self):
+        # ApplicationForm must not assume client_secret / hash_client_secret are
+        # present in the field set when used as a modelform_factory base.
+        form_class = modelform_factory(Application, form=ApplicationForm, fields=("name",))
+        form_class()  # should not raise KeyError
+
+    def test_is_hashed_helper(self):
+        self.assertFalse(_is_hashed(""))  # empty/falsy
+        self.assertFalse(_is_hashed(None))  # None (guards against identify_hasher TypeError)
+        self.assertFalse(_is_hashed("cleartext-secret"))  # unrecognized -> ValueError
+        self.assertTrue(_is_hashed(make_password("cleartext-secret")))  # real hash

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -281,3 +281,15 @@ class TestApplicationViews(BaseTest):
         self.assertEqual(self.app_foo_1.post_logout_redirect_uris, form_data["post_logout_redirect_uris"])
         self.assertEqual(self.app_foo_1.client_type, form_data["client_type"])
         self.assertEqual(self.app_foo_1.authorization_grant_type, form_data["authorization_grant_type"])
+    
+    def test_client_secret_help_text_new_application(self):
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:register"))
+        form = response.context["form"]
+        self.assertIn("Copy and store this secret now", form.fields["client_secret"].help_text)
+
+    def test_client_secret_help_text_existing_application(self):
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:update", args=(self.app_foo_1.pk,)))
+        form = response.context["form"]
+        self.assertIn("has been hashed", form.fields["client_secret"].help_text)

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -281,7 +281,7 @@ class TestApplicationViews(BaseTest):
         self.assertEqual(self.app_foo_1.post_logout_redirect_uris, form_data["post_logout_redirect_uris"])
         self.assertEqual(self.app_foo_1.client_type, form_data["client_type"])
         self.assertEqual(self.app_foo_1.authorization_grant_type, form_data["authorization_grant_type"])
-    
+
     def test_client_secret_help_text_new_application(self):
         self.client.login(username="foo_user", password="123456")
         response = self.client.get(reverse("oauth2_provider:register"))

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -358,6 +358,27 @@ class TestApplicationViews(BaseTest):
         form = form_class(data={"name": "incomplete"})  # bound, hash checkbox unchecked -> False
         self.assertIn("stores the secret unhashed", form.fields["client_secret"].help_text)
 
+    def test_client_secret_help_text_live_toggle_rendered_on_register(self):
+        # The register page must ship both help variants plus the checkbox-driven
+        # script so the message updates live as hash_client_secret is toggled,
+        # rather than being frozen at the server-rendered value.
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:register"))
+        self.assertContains(response, 'id="client-secret-help-when-hashed"')
+        self.assertContains(response, 'id="client-secret-help-when-unhashed"')
+        self.assertContains(response, "it will be hashed and cannot be recovered")
+        self.assertContains(response, "stores the secret unhashed")
+        self.assertContains(response, "id_hash_client_secret")
+        self.assertContains(response, "addEventListener")
+
+    def test_client_secret_help_text_no_live_toggle_when_already_hashed(self):
+        # An already-hashed secret cannot be reverted by unchecking the box, so the
+        # toggle script must not be rendered on that edit page.
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:update", args=(self.app_foo_1.pk,)))
+        self.assertContains(response, "can no longer be viewed")
+        self.assertNotContains(response, 'id="client-secret-help-when-hashed"')
+
     def test_application_form_without_client_secret_field(self):
         # ApplicationForm must not assume client_secret / hash_client_secret are
         # present in the field set when used as a modelform_factory base.

--- a/uv.lock
+++ b/uv.lock
@@ -446,23 +446,24 @@ wheels = [
 
 [[package]]
 name = "django-cors-headers"
-version = "3.14.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "asgiref" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bc/f4/8b8c3d5e9a0aeea43576fbe623599052a7699abb54378ddb44adb1ef1ed3/django_cors_headers-3.14.0.tar.gz", hash = "sha256:5fbd58a6fb4119d975754b2bc090f35ec160a8373f276612c675b00e8a138739", size = 24892, upload-time = "2023-02-25T07:20:18.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/e5/3b67fc05b9c02b926411436dfc553829bc00843706ce7f99752433017f47/django_cors_headers-4.6.0.tar.gz", hash = "sha256:14d76b4b4c8d39375baeddd89e4f08899051eeaf177cb02a29bd6eae8cf63aa8", size = 20961, upload-time = "2024-10-29T10:38:15.281Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/f1/972b3a183192841b811e4b7496de0a31c09ae1d83a5391743c8ae0cbd86e/django_cors_headers-3.14.0-py3-none-any.whl", hash = "sha256:684180013cc7277bdd8702b80a3c5a4b3fcae4abb2bf134dceb9f5dfe300228e", size = 13187, upload-time = "2023-02-25T07:20:16.376Z" },
+    { url = "https://files.pythonhosted.org/packages/52/73/689532cf164ab10ed1521d825ea156656520cec98886c8d2ac1ce8829220/django_cors_headers-4.6.0-py3-none-any.whl", hash = "sha256:8edbc0497e611c24d5150e0055d3b178c6534b8ed826fb6f53b21c63f5d48ba3", size = 12791, upload-time = "2024-10-29T10:38:13.784Z" },
 ]
 
 [[package]]
 name = "django-environ"
-version = "0.11.2"
+version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d6/0b/f2c024529ee4bbf8b95176eebeb86c6e695192a9ce0e91059cb83a33c1d3/django-environ-0.11.2.tar.gz", hash = "sha256:f32a87aa0899894c27d4e1776fa6b477e8164ed7f6b3e410a62a6d72caaf64be", size = 54326, upload-time = "2023-09-01T21:03:02.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/04/65d2521842c42f4716225f20d8443a50804920606aec018188bbee30a6b0/django_environ-0.12.0.tar.gz", hash = "sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a", size = 56804, upload-time = "2025-01-13T17:03:37.74Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/f1/468b49cccba3b42dda571063a14c668bb0b53a1d5712426d18e36663bd53/django_environ-0.11.2-py2.py3-none-any.whl", hash = "sha256:0ff95ab4344bfeff693836aa978e6840abef2e2f1145adff7735892711590c05", size = 19141, upload-time = "2023-09-01T21:02:59.88Z" },
+    { url = "https://files.pythonhosted.org/packages/83/b3/0a3bec4ecbfee960f39b1842c2f91e4754251e0a6ed443db9fe3f666ba8f/django_environ-0.12.0-py2.py3-none-any.whl", hash = "sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca", size = 19957, upload-time = "2025-01-13T17:03:32.918Z" },
 ]
 
 [[package]]
@@ -615,14 +616,16 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "django-environ" },
     { name = "django-oauth-toolkit" },
+    { name = "whitenoise" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=4.2,<=5.2" },
-    { name = "django-cors-headers", specifier = "==3.14.0" },
-    { name = "django-environ", specifier = "==0.11.2" },
+    { name = "django-cors-headers", specifier = "==4.6.0" },
+    { name = "django-environ", specifier = "==0.12.0" },
     { name = "django-oauth-toolkit", editable = "." },
+    { name = "whitenoise", specifier = "==6.8.2" },
 ]
 
 [[package]]
@@ -1273,4 +1276,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "whitenoise"
+version = "6.8.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/49/c21ebb5b911888c349a849ec7d1ead2dffbbcc4e2be0f6af2a7dbac03393/whitenoise-6.8.2.tar.gz", hash = "sha256:486bd7267a375fa9650b136daaec156ac572971acc8bf99add90817a530dd1d4", size = 25892, upload-time = "2024-10-29T23:04:39.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/3a/8d22513e1942899270dcdbd47f9886309836442cd7ede4b0d00be79715f5/whitenoise-6.8.2-py3-none-any.whl", hash = "sha256:df12dce147a043d1956d81d288c6f0044147c6d2ab9726e5772ac50fb45d2280", size = 20158, upload-time = "2024-10-29T23:04:38.415Z" },
 ]


### PR DESCRIPTION
Fixes #1635 - warns users to save their secret on creation, and informs them it is hashed and unrecoverable when editing.

<!-- See  https://django-oauth-toolkit.readthedocs.io/en/latest/contributing.html#pull-requests -->
<!-- If there's already an issue that this PR fixes, add that issue number below after 'Fixes #' -->
Fixes #

## Description of the Change

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [x] tests/app/idp updated to demonstrate new features
- [x] tests/app/rp updated to demonstrate new features
