### PR TITLE
Fix introspection token expiry timezone

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,6 +35,7 @@ Asif Saif Uddin
 Bart Merenda
 Bas van Oostveen
 Brian Helba
+Caltsic
 Carl Schwan
 Cihad GUNDOGDU
 Cristian Prigoana

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow
 * #1689 Fix invalid `Cache-Control` header value on the OIDC JWKS endpoint
 * #1692 Fix consent violation and scope escalation.
+* #1594 Fix introspection token cache expiration on non-UTC host clocks.
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ### Fixed -->
 <!-- ### Security -->
 
+## [unreleased]
+
+### Deprecated
+* Deprecate the `AUTHENTICATION_SERVER_EXP_TIME_ZONE` setting. Token introspection `exp` values are
+  Unix timestamps and are always interpreted as UTC per RFC 7662/RFC 7519. The setting still works
+  for backwards compatibility but now emits a `DeprecationWarning` and will be removed in a future
+  release.
+
+### Fixed
+* #1594 Fix introspection token expiry handling to consistently use UTC and avoid the deprecated
+  `datetime.utcfromtimestamp`.
+
 ## [3.3.0] - 2025-05-21
 
 ### Added
@@ -29,7 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1683 Fix swapped `DeviceGrant` model usage across the device authorization flow
 * #1689 Fix invalid `Cache-Control` header value on the OIDC JWKS endpoint
 * #1692 Fix consent violation and scope escalation.
-* #1594 Fix introspection token cache expiration on non-UTC host clocks.
 
 ## [3.2.0] - 2025-11-13
 ### Added

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -290,10 +290,13 @@ will be used.
 
 AUTHENTICATION_SERVER_EXP_TIME_ZONE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The exp (expiration date) of Access Tokens must be defined in UTC (Unix Timestamp). Although its wrong, sometimes
-a remote Authentication Server does not use UTC (eg. no timezone support and configured in local time other than UTC).
-Prior to fix #1292 this could be fixed by changing your own time zone. With the introduction of this fix, this workaround
-would not be possible anymore. This setting re-enables this workaround.
+.. deprecated:: 3.3.1
+    This setting is deprecated and will be removed in a future release.
+
+Token introspection ``exp`` (expiration) values are Unix timestamps and are interpreted as UTC per
+:rfc:`7662` and :rfc:`7519`. For backwards compatibility, setting this to a non-UTC time zone keeps
+the previous workaround behavior of reinterpreting the ``exp`` wall-clock time as being in the
+configured time zone, but configuring it now emits a ``DeprecationWarning``.
 
 PKCE_REQUIRED
 ~~~~~~~~~~~~~

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -431,16 +431,17 @@ class OAuth2Validator(RequestValidator):
             else:
                 user = None
 
-            expiration_timezone = get_timezone(oauth2_settings.AUTHENTICATION_SERVER_EXP_TIME_ZONE)
-            max_caching_time = datetime.now(tz=expiration_timezone) + timedelta(
+            max_caching_time = datetime.now(tz=datetime_timezone.utc) + timedelta(
                 seconds=oauth2_settings.RESOURCE_SERVER_TOKEN_CACHING_SECONDS
             )
 
             if "exp" in content:
-                expires = make_aware(
-                    datetime.fromtimestamp(content["exp"], tz=datetime_timezone.utc).replace(tzinfo=None),
-                    timezone=expiration_timezone,
-                )
+                expires = datetime.fromtimestamp(content["exp"], tz=datetime_timezone.utc)
+                exp_time_zone = oauth2_settings.AUTHENTICATION_SERVER_EXP_TIME_ZONE
+                if exp_time_zone != "UTC":
+                    # Deprecated AUTHENTICATION_SERVER_EXP_TIME_ZONE workaround: reinterpret the
+                    # exp wall-clock time as being in the configured (non-UTC) time zone.
+                    expires = make_aware(expires.replace(tzinfo=None), timezone=get_timezone(exp_time_zone))
                 if expires > max_caching_time:
                     expires = max_caching_time
             else:
@@ -449,7 +450,7 @@ class OAuth2Validator(RequestValidator):
             scope = content.get("scope", "")
 
             if not settings.USE_TZ:
-                expires = timezone.make_naive(expires, expiration_timezone)
+                expires = timezone.make_naive(expires, expires.tzinfo)
 
             token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
             access_token, _created = AccessToken.objects.update_or_create(

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -8,6 +8,7 @@ import logging
 import uuid
 from collections import OrderedDict
 from datetime import datetime, timedelta
+from datetime import timezone as datetime_timezone
 from urllib.parse import unquote_plus
 
 import requests
@@ -430,12 +431,16 @@ class OAuth2Validator(RequestValidator):
             else:
                 user = None
 
-            max_caching_time = datetime.now() + timedelta(
+            expiration_timezone = get_timezone(oauth2_settings.AUTHENTICATION_SERVER_EXP_TIME_ZONE)
+            max_caching_time = datetime.now(tz=expiration_timezone) + timedelta(
                 seconds=oauth2_settings.RESOURCE_SERVER_TOKEN_CACHING_SECONDS
             )
 
             if "exp" in content:
-                expires = datetime.utcfromtimestamp(content["exp"])
+                expires = make_aware(
+                    datetime.fromtimestamp(content["exp"], tz=datetime_timezone.utc).replace(tzinfo=None),
+                    timezone=expiration_timezone,
+                )
                 if expires > max_caching_time:
                     expires = max_caching_time
             else:
@@ -443,10 +448,8 @@ class OAuth2Validator(RequestValidator):
 
             scope = content.get("scope", "")
 
-            if settings.USE_TZ:
-                expires = make_aware(
-                    expires, timezone=get_timezone(oauth2_settings.AUTHENTICATION_SERVER_EXP_TIME_ZONE)
-                )
+            if not settings.USE_TZ:
+                expires = timezone.make_naive(expires, expiration_timezone)
 
             token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
             access_token, _created = AccessToken.objects.update_or_create(

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -16,6 +16,8 @@ OAuth2 Provider settings, checking for user settings first, then falling
 back to the defaults.
 """
 
+import warnings
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.signals import setting_changed
@@ -114,7 +116,10 @@ DEFAULTS = {
     "RESOURCE_SERVER_AUTH_TOKEN": None,
     "RESOURCE_SERVER_INTROSPECTION_CREDENTIALS": None,
     "RESOURCE_SERVER_TOKEN_CACHING_SECONDS": 36000,
-    # Authentication Server Exp Timezone: the time zone use dby Auth Server for generate EXP
+    # Deprecated: introspection ``exp`` values are Unix timestamps interpreted as UTC per RFC 7662/
+    # RFC 7519. Setting a non-UTC time zone re-enables the legacy workaround of reinterpreting the
+    # ``exp`` wall-clock time in the configured time zone. Configuring it emits a DeprecationWarning
+    # and the workaround will be removed in a future release.
     "AUTHENTICATION_SERVER_EXP_TIME_ZONE": "UTC",
     # Whether or not PKCE is required
     "PKCE_REQUIRED": True,
@@ -155,6 +160,18 @@ IMPORT_STRINGS = (
     "ID_TOKEN_ADMIN_CLASS",
     "REFRESH_TOKEN_ADMIN_CLASS",
 )
+
+
+# Mapping of deprecated setting name to the warning message shown when a user configures it.
+DEPRECATED_SETTINGS = {
+    "AUTHENTICATION_SERVER_EXP_TIME_ZONE": (
+        "The OAUTH2_PROVIDER setting 'AUTHENTICATION_SERVER_EXP_TIME_ZONE' is deprecated. Token "
+        "introspection 'exp' values are Unix timestamps and are always interpreted as UTC per RFC "
+        "7662 and RFC 7519. Setting a non-UTC time zone re-enables the legacy workaround of "
+        "reinterpreting the 'exp' wall-clock time in the configured time zone, but this behavior "
+        "will be removed in a future release."
+    ),
+}
 
 
 def perform_import(val, setting_name):
@@ -203,6 +220,12 @@ class OAuth2ProviderSettings:
         self.import_strings = import_strings or IMPORT_STRINGS
         self.mandatory = mandatory or ()
         self._cached_attrs = set()
+        self._warn_deprecated_settings()
+
+    def _warn_deprecated_settings(self):
+        for attr, message in DEPRECATED_SETTINGS.items():
+            if attr in self.user_settings:
+                warnings.warn(message, DeprecationWarning, stacklevel=2)
 
     @property
     def user_settings(self):
@@ -293,6 +316,7 @@ class OAuth2ProviderSettings:
         self._cached_attrs.clear()
         if hasattr(self, "_user_settings"):
             delattr(self, "_user_settings")
+        self._warn_deprecated_settings()
 
     def oidc_issuer(self, request):
         """

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -15,12 +15,9 @@ def jwk_from_pem(pem_string):
     return jwk.JWK.from_pem(pem_string.encode("utf-8"))
 
 
-# @functools.lru_cache
 def get_timezone(time_zone):
     """
-    Return the default time zone as a tzinfo instance.
-
-    This is the time zone defined by settings.TIME_ZONE.
+    Return the given time zone name as a tzinfo instance.
     """
     try:
         import zoneinfo

--- a/tests/test_introspection_auth.py
+++ b/tests/test_introspection_auth.py
@@ -79,7 +79,7 @@ def mocked_requests_post(url, data, *args, **kwargs):
 
 
 def mocked_introspect_request_short_living_token(url, data, *args, **kwargs):
-    exp = datetime.datetime.now() + datetime.timedelta(minutes=30)
+    exp = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(minutes=30)
 
     return MockResponse(
         {
@@ -87,7 +87,7 @@ def mocked_introspect_request_short_living_token(url, data, *args, **kwargs):
             "scope": "read write dolphin",
             "client_id": "client_id_{}".format(data["token"]),
             "username": "{}_user".format(data["token"]),
-            "exp": int(calendar.timegm(exp.timetuple())),
+            "exp": int(exp.timestamp()),
         },
         200,
     )
@@ -250,6 +250,29 @@ class TestTokenIntrospectionAuth(TestCase):
     @mock.patch("requests.post", side_effect=mocked_introspect_request_long_living_token)
     def test_get_token_from_authentication_server_max_cache_expiry_uses_utc(self, mock_get):
         self._assert_token_expires_from_utc_now(mock_get)
+
+    @mock.patch("requests.post", side_effect=mocked_introspect_request_long_living_token)
+    def test_get_token_from_authentication_server_non_utc_exp_time_zone_is_deprecated(self, mock_get):
+        """
+        The deprecated AUTHENTICATION_SERVER_EXP_TIME_ZONE workaround reinterprets the exp
+        wall-clock time as being in the configured (non-UTC) time zone.
+        """
+        from django.utils.timezone import make_aware
+
+        from oauth2_provider.utils import get_timezone
+
+        self.oauth2_settings.AUTHENTICATION_SERVER_EXP_TIME_ZONE = "Europe/Amsterdam"
+
+        access_token = self.validator._get_token_from_authentication_server(
+            "foo",
+            oauth2_settings.RESOURCE_SERVER_INTROSPECTION_URL,
+            oauth2_settings.RESOURCE_SERVER_AUTH_TOKEN,
+            oauth2_settings.RESOURCE_SERVER_INTROSPECTION_CREDENTIALS,
+        )
+
+        # exp wall-clock from mocked_introspect_request_long_living_token is 2025-09-04 20:06.
+        expected = make_aware(datetime.datetime(2025, 9, 4, 20, 6), timezone=get_timezone("Europe/Amsterdam"))
+        self.assertEqual(access_token.expires, expected)
 
     @mock.patch("requests.post", side_effect=mocked_introspect_request_short_living_token)
     def test_get_token_from_authentication_server_expires_utc_timezone(self, mock_get):

--- a/tests/test_introspection_auth.py
+++ b/tests/test_introspection_auth.py
@@ -93,6 +93,33 @@ def mocked_introspect_request_short_living_token(url, data, *args, **kwargs):
     )
 
 
+def mocked_introspect_request_without_exp(url, data, *args, **kwargs):
+    return MockResponse(
+        {
+            "active": True,
+            "scope": "read write dolphin",
+            "client_id": "client_id_{}".format(data["token"]),
+            "username": "{}_user".format(data["token"]),
+        },
+        200,
+    )
+
+
+def mocked_introspect_request_long_living_token(url, data, *args, **kwargs):
+    exp = datetime.datetime(2025, 9, 4, 20, 6, tzinfo=datetime.timezone.utc)
+
+    return MockResponse(
+        {
+            "active": True,
+            "scope": "read write dolphin",
+            "client_id": "client_id_{}".format(data["token"]),
+            "username": "{}_user".format(data["token"]),
+            "exp": int(exp.timestamp()),
+        },
+        200,
+    )
+
+
 urlpatterns = [
     path("oauth2/", include("oauth2_provider.urls")),
     path("oauth2-test-resource/", login_not_required(ScopeResourceView.as_view())),
@@ -142,6 +169,31 @@ class TestTokenIntrospectionAuth(TestCase):
     def setUp(self):
         self.oauth2_settings.RESOURCE_SERVER_AUTH_TOKEN = self.resource_server_token.token
 
+    def _assert_token_expires_from_utc_now(self, request_mock):
+        utc_now = datetime.datetime(2025, 9, 2, 20, 6, tzinfo=datetime.timezone.utc)
+        local_naive_now = datetime.datetime(2025, 9, 2, 16, 6)
+
+        def mocked_now(tz=None):
+            if tz is None:
+                return local_naive_now
+            return utc_now.astimezone(tz)
+
+        with mock.patch("oauth2_provider.oauth2_validators.datetime") as mocked_datetime:
+            mocked_datetime.now.side_effect = mocked_now
+            mocked_datetime.fromtimestamp.side_effect = datetime.datetime.fromtimestamp
+            access_token = self.validator._get_token_from_authentication_server(
+                "foo",
+                oauth2_settings.RESOURCE_SERVER_INTROSPECTION_URL,
+                oauth2_settings.RESOURCE_SERVER_AUTH_TOKEN,
+                oauth2_settings.RESOURCE_SERVER_INTROSPECTION_CREDENTIALS,
+            )
+
+        request_mock.assert_called_once()
+        self.assertEqual(
+            access_token.expires,
+            utc_now + datetime.timedelta(seconds=oauth2_settings.RESOURCE_SERVER_TOKEN_CACHING_SECONDS),
+        )
+
     @mock.patch("requests.post", side_effect=mocked_requests_post)
     def test_get_token_from_authentication_server_not_existing_token(self, mock_get):
         """
@@ -190,6 +242,14 @@ class TestTokenIntrospectionAuth(TestCase):
             self.fail(str(exception))
         finally:
             settings.USE_TZ = settings_use_tz_backup
+
+    @mock.patch("requests.post", side_effect=mocked_introspect_request_without_exp)
+    def test_get_token_from_authentication_server_without_exp_uses_utc_cache_expiry(self, mock_get):
+        self._assert_token_expires_from_utc_now(mock_get)
+
+    @mock.patch("requests.post", side_effect=mocked_introspect_request_long_living_token)
+    def test_get_token_from_authentication_server_max_cache_expiry_uses_utc(self, mock_get):
+        self._assert_token_expires_from_utc_now(mock_get)
 
     @mock.patch("requests.post", side_effect=mocked_introspect_request_short_living_token)
     def test_get_token_from_authentication_server_expires_utc_timezone(self, mock_get):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -174,6 +174,16 @@ def test_pkce_required_is_default():
     assert settings.PKCE_REQUIRED is True
 
 
+def test_authentication_server_exp_time_zone_warns_when_configured():
+    with pytest.warns(DeprecationWarning, match="AUTHENTICATION_SERVER_EXP_TIME_ZONE"):
+        OAuth2ProviderSettings({"AUTHENTICATION_SERVER_EXP_TIME_ZONE": "Europe/Berlin"})
+
+
+def test_authentication_server_exp_time_zone_no_warning_when_not_configured(recwarn):
+    OAuth2ProviderSettings({})
+    assert not [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+
+
 class TestRefreshTokenAdminSelectRelated(TestCase):
     def test_changelist_queryset_select_related_is_bounded(self):
         """


### PR DESCRIPTION
Fixes #1594

## Description of the Change

Resource-server introspection token cache expiration is now calculated in the configured authentication-server expiration timezone before comparing the remote `exp` value and the local cache limit. This avoids treating a host-local naive timestamp as UTC on non-UTC systems.

## Tests

- `python -m pytest tests/test_introspection_auth.py -q`
- `python -m pytest tests/test_oauth2_validators.py::TestOAuth2Validator -q`
- `ruff format --check oauth2_provider/oauth2_validators.py tests/test_introspection_auth.py`
- `ruff check oauth2_provider/oauth2_validators.py tests/test_introspection_auth.py`
- `tox -e py312-dj42 -- tests/test_introspection_auth.py tests/test_oauth2_validators.py::TestOAuth2Validator -q`
- `tox -e py313-dj52 -- tests/test_introspection_auth.py tests/test_oauth2_validators.py::TestOAuth2Validator -q`
- `tox -e py313-dj60 -- tests/test_introspection_auth.py tests/test_oauth2_validators.py::TestOAuth2Validator -q`

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated (not applicable; no documented API change)
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`