### PR TITLE
chore: eliminate dup CI jobs for push and pr

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: Test
 
-on: [push, pull_request]
+# Avoid duplicate CI runs on feature branches:
+# - run on push only for master
+# - run on pull_request for all PRs
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Description of the Change

The matrix runs were doubled up for the test workflow. This should fix that. 

