### PR TITLE
chore: infer actions test matrix from tox.ini

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,39 +14,150 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  discover-matrices:
+    name: Discover tox matrices
+    runs-on: ubuntu-latest
+    outputs:
+      core-matrix: ${{ steps.discover.outputs.core-matrix }}
+      postgres-matrix: ${{ steps.discover.outputs.postgres-matrix }}
+      mysql-matrix: ${{ steps.discover.outputs.mysql-matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install tox
+        run: python -m pip install --upgrade tox
+
+      - name: Discover tox environments
+        id: discover
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+
+          def py_factor_to_version(py_factor: str) -> str:
+            return f"{int(py_factor[0])}.{int(py_factor[1:])}"
+
+          def dj_factor_to_version(dj_factor: str) -> str:
+            if dj_factor == "main":
+              return "main"
+            return f"{int(dj_factor[0])}.{int(dj_factor[1:])}"
+
+          def list_envs(*args: str) -> list[str]:
+            result = subprocess.run(
+              ["tox", "list", "--no-desc", *args],
+              check=False,
+              capture_output=True,
+              text=True,
+            )
+            if result.returncode != 0:
+              raise RuntimeError(result.stderr.strip() or f"tox list failed: {' '.join(args)}")
+            return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+          core_envs = list_envs("-f", "lite3")
+          postgres_envs = list_envs("-f", "pg16")
+          mysql_envs = list_envs("-f", "my84")
+
+          core = []
+          postgres_tests = {}
+          mysql_tests = {}
+          postgres_migrations = {}
+          mysql_migrations = {}
+
+          core_pat = re.compile(r"^py(\d+)-dj(\d+|main)-lite\d+(?:-ha)?$")
+          pg_test_pat = re.compile(r"^py(\d+)-dj(\d+|main)-pg(\d+)(?:-(ha))?$")
+          my_test_pat = re.compile(r"^py(\d+)-dj(\d+|main)-my(\d+)(?:-(ha))?$")
+          pg_mig_pat = re.compile(r"^migrations-dj(\d+|main)-pg(\d+)(?:-(ha))?$")
+          my_mig_pat = re.compile(r"^migrations-dj(\d+|main)-my(\d+)(?:-(ha))?$")
+
+          for env in core_envs:
+            m = core_pat.match(env)
+            if m:
+              py_factor, dj_factor = m.groups()
+              core.append(
+                {
+                  "toxenv": env,
+                  "python-version": py_factor_to_version(py_factor),
+                  "django-version": dj_factor_to_version(dj_factor),
+                }
+              )
+          for env in postgres_envs:
+            m = pg_test_pat.match(env)
+            if m:
+              py_factor, dj_factor, db_version, topology = m.groups()
+              postgres_tests[(dj_factor, db_version, topology or "standalone")] = {
+                "toxenv": env,
+                "python-version": py_factor_to_version(py_factor),
+                "django-version": dj_factor_to_version(dj_factor),
+              }
+              continue
+
+            m = pg_mig_pat.match(env)
+            if m:
+              dj_factor, db_version, topology = m.groups()
+              postgres_migrations[(dj_factor, db_version, topology or "standalone")] = env
+              continue
+
+          for env in mysql_envs:
+            m = my_test_pat.match(env)
+            if m:
+              py_factor, dj_factor, db_version, topology = m.groups()
+              mysql_tests[(dj_factor, db_version, topology or "standalone")] = {
+                "toxenv": env,
+                "python-version": py_factor_to_version(py_factor),
+                "django-version": dj_factor_to_version(dj_factor),
+              }
+              continue
+
+            m = my_mig_pat.match(env)
+            if m:
+              dj_factor, db_version, topology = m.groups()
+              mysql_migrations[(dj_factor, db_version, topology or "standalone")] = env
+
+          def build_backend_matrix(tests: dict[tuple[str, str, str], dict[str, str]], migrations: dict[tuple[str, str, str], str], engine: str) -> list[dict[str, str]]:
+            rows = []
+            for key, test_entry in tests.items():
+              migration_toxenv = migrations.get(key)
+              if not migration_toxenv:
+                dj_factor, db_version, topology = key
+                raise RuntimeError(
+                  f"missing migrations-dj{dj_factor}-{engine}{db_version}{'-' + topology if topology != 'standalone' else ''} for {test_entry['toxenv']}"
+                )
+              rows.append({**test_entry, "migration_toxenv": migration_toxenv})
+            rows.sort(key=lambda x: x["toxenv"])
+            return rows
+
+          core.sort(key=lambda x: x["toxenv"])
+          postgres = build_backend_matrix(postgres_tests, postgres_migrations, "pg")
+          mysql = build_backend_matrix(mysql_tests, mysql_migrations, "my")
+
+          outputs = {
+            "core-matrix": {"include": core},
+            "postgres-matrix": {"include": postgres},
+            "mysql-matrix": {"include": mysql},
+          }
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as out:
+            for name, value in outputs.items():
+              out.write(f"{name}={json.dumps(value, separators=(',', ':'))}\n")
+          PY
+
   test-package:
+    needs: discover-matrices
     name: DOT SQLite (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     permissions:
       id-token: write # Required for Codecov OIDC token
     strategy:
       fail-fast: false
-      matrix:
-        python-version:
-        - '3.10'
-        - '3.11'
-        - '3.12'
-        - '3.13'
-        django-version:
-        - '4.2'
-        - '5.0'
-        - '5.1'
-        - '5.2'
-        - 'main'
-        ## include/exclude version combinations, typically for the newest and oldest django/python versions.
-        ## python-version and django-version should be selected such that they minimize the number of include
-        ## and exclude entries.
-        include:
-          - { django-version: '5.2', python-version: '3.14' }
-          - { django-version: '6.0', python-version: '3.12' }
-          - { django-version: '6.0', python-version: '3.13' }
-          - { django-version: '6.0', python-version: '3.14' }
-          - { django-version: 'main', python-version: '3.14' }
-        exclude:
-          - { django-version: '4.2', python-version: '3.13' }
-          - { django-version: '5.0', python-version: '3.13' }
-          - { django-version: 'main', python-version: '3.10' }
-          - { django-version: 'main', python-version: '3.11' }
+      matrix: ${{ fromJSON(needs.discover-matrices.outputs.core-matrix) }}
 
     steps:
     - uses: actions/checkout@v4
@@ -73,13 +184,10 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install --upgrade tox tox-gh-actions
+        python -m pip install --upgrade tox
 
     - name: Tox tests
-      run: |
-        tox -v
-      env:
-        DJANGO: ${{ matrix.django-version }}
+      run: tox -v -e ${{ matrix.toxenv }}
 
     - name: Upload coverage
       uses: codecov/codecov-action@v5
@@ -136,11 +244,9 @@ jobs:
         run: python -m pip install --upgrade tox
 
       - name: Check no missing migrations
-        run: tox -e migrations-sqlite
-        env:
-          DJANGO: '5.2'
+        run: tox -e migrations-dj52-lite3
 
-  migrate_swapped:
+  scenario-migrate-swapped:
     name: DOT Migrate Swapped Models
     runs-on: ubuntu-latest
     steps:
@@ -155,9 +261,7 @@ jobs:
         run: python -m pip install --upgrade tox
 
       - name: Run swapped model migrations
-        run: tox -e migrate_swapped
-        env:
-          DJANGO: '5.2'
+        run: tox -e scenario-migrate-swapped-dj52-lite3
 
   multi-db:
     name: DOT Multi-DB Tests (Python 3.12, Django 4.2)
@@ -177,24 +281,12 @@ jobs:
         run: tox -e py312-dj42-multi-db
 
   postgres-standalone:
+    needs: discover-matrices
     name: DOT PostgreSQL (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - python-version: '3.10'
-            py-factor: '310'
-            django-version: '4.2'
-            dj-factor: '42'
-          - python-version: '3.12'
-            py-factor: '312'
-            django-version: '5.2'
-            dj-factor: '52'
-          - python-version: '3.14'
-            py-factor: '314'
-            django-version: '6.0'
-            dj-factor: '60'
+      matrix: ${{ fromJSON(needs.discover-matrices.outputs.postgres-matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -212,12 +304,12 @@ jobs:
           POSTGRES_BIND_PORT: '5432'
 
       - name: Run postgres standalone tests
-        run: tox -e py${{ matrix.py-factor }}-dj${{ matrix.dj-factor }}-postgres
+        run: tox -e ${{ matrix.toxenv }}
         env:
           POSTGRES_PORT: '5432'
 
       - name: Run postgres migration checks
-        run: tox -e migrations-postgres-dj${{ matrix.dj-factor }}
+        run: tox -e ${{ matrix.migration_toxenv }}
         env:
           POSTGRES_PORT: '5432'
 
@@ -228,24 +320,12 @@ jobs:
           POSTGRES_BIND_PORT: '5432'
 
   mysql-standalone:
+    needs: discover-matrices
     name: DOT MySQL (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - python-version: '3.10'
-            py-factor: '310'
-            django-version: '4.2'
-            dj-factor: '42'
-          - python-version: '3.12'
-            py-factor: '312'
-            django-version: '5.2'
-            dj-factor: '52'
-          - python-version: '3.14'
-            py-factor: '314'
-            django-version: '6.0'
-            dj-factor: '60'
+      matrix: ${{ fromJSON(needs.discover-matrices.outputs.mysql-matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -263,12 +343,12 @@ jobs:
           MYSQL_BIND_PORT: '3306'
 
       - name: Run mysql standalone tests
-        run: tox -e py${{ matrix.py-factor }}-dj${{ matrix.dj-factor }}-mysql
+        run: tox -e ${{ matrix.toxenv }}
         env:
           MYSQL_PORT: '3306'
 
       - name: Run mysql migration checks
-        run: tox -e migrations-mysql-dj${{ matrix.dj-factor }}
+        run: tox -e ${{ matrix.migration_toxenv }}
         env:
           MYSQL_PORT: '3306'
 
@@ -337,7 +417,7 @@ jobs:
       - lint
       - sphinxlint
       - migrations
-      - migrate_swapped
+      - scenario-migrate-swapped
       - multi-db
       - postgres-standalone
       - mysql-standalone

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -95,7 +95,7 @@ Migrations
 If you alter any models, a new migration will need to be generated. This step is frequently missed
 by new contributors. You can check if a new migration is needed with::
 
-  tox -e migrations-sqlite
+  tox -e migrations-dj52-lite3
 
 And, if a new migration is needed, use::
 
@@ -252,30 +252,31 @@ In addition to the default SQLite test flow, we run backend-specific standalone 
 To keep CI runtime and resource usage bounded, backend DB checks cover the latest Django release in each supported
 major line: 4.2, 5.2, and 6.0.
 
-The ``-djXX`` suffix in migration and backend env names (for example ``migrations-postgres-dj52``) is intentional:
-it pins the Django major/minor line being exercised. The brace-expanded section syntax used in ``tox.ini`` is an
-implementation detail; user-facing docs list only concrete env names.
+Backend env names follow ``py{python}-dj{django}-{db}``, and migration env names mirror that
+with ``migrations-dj{django}-{db}``. For example, ``py312-dj52-pg16`` and
+``migrations-dj52-pg16``. This naming is intentional: it keeps DB engine/version explicit and
+ready for future topology variants like ``-ha``.
 
 Run PostgreSQL standalone checks locally::
 
   docker compose -f docker-compose.postgres.yml up -d --wait
-  tox -e py310-dj42-postgres
-  tox -e migrations-postgres-dj42
-  tox -e py312-dj52-postgres
-  tox -e migrations-postgres-dj52
-  tox -e py314-dj60-postgres
-  tox -e migrations-postgres-dj60
+  tox -e py310-dj42-pg16
+  tox -e migrations-dj42-pg16
+  tox -e py312-dj52-pg16
+  tox -e migrations-dj52-pg16
+  tox -e py314-dj60-pg16
+  tox -e migrations-dj60-pg16
   docker compose -f docker-compose.postgres.yml down -v
 
 Run MySQL standalone checks locally::
 
   docker compose -f docker-compose.mysql.yml up -d --wait
-  tox -e py310-dj42-mysql
-  tox -e migrations-mysql-dj42
-  tox -e py312-dj52-mysql
-  tox -e migrations-mysql-dj52
-  tox -e py314-dj60-mysql
-  tox -e migrations-mysql-dj60
+  tox -e py310-dj42-my84
+  tox -e migrations-dj42-my84
+  tox -e py312-dj52-my84
+  tox -e migrations-dj52-my84
+  tox -e py314-dj60-my84
+  tox -e migrations-dj60-my84
   docker compose -f docker-compose.mysql.yml down -v
 
 Add the tests!

--- a/tox.ini
+++ b/tox.ini
@@ -1,34 +1,30 @@
 [tox]
+# Environment naming conventions:
+# - Test envs: py{python}-dj{django}-{db}[{-topology}]
+# - Migration envs: migrations-dj{django}-{db}[{-topology}]
+# - Scenario envs: scenario-{name}-dj{django}-{db}[{-topology}]
+# - DB tokens are terse engine/version identifiers:
+#   - lite3 for SQLite 3
+#   - pg16 for PostgreSQL 16
+#   - my84 for MySQL 8.4
+# - Optional topology suffixes (for future expansion): ha, etc.
+# Examples:
+#   - py312-dj52-lite3
+#   - py314-dj60-pg16
+#   - migrations-dj52-my84
 envlist =
-    migrations-sqlite,
-    migrate_swapped,
+    migrations-dj52-lite3,
+    scenario-migrate-swapped-dj52-lite3,
     docs,
     lint,
     sphinxlint,
-    py{310,311,312}-dj42,
-    py{310,311,312,313}-dj50,
-    py{310,311,312,313}-dj51,
-    py{310,311,312,313,314}-dj52,
-    py{312,313,314}-dj60,
-    py{312,313,314}-djmain,
+    py{310,311,312}-dj42-lite3,
+    py{310,311,312,313}-dj50-lite3,
+    py{310,311,312,313}-dj51-lite3,
+    py{310,311,312,313,314}-dj52-lite3,
+    py{312,313,314}-dj60-lite3,
+    py{312,313,314}-djmain-lite3,
     py312-dj42-multi-db,
-
-[gh-actions]
-python =
-    3.10: py310
-    3.11: py311
-    3.12: py312
-    3.13: py313
-    3.14: py314
-
-[gh-actions:env]
-DJANGO =
-    4.2: dj42
-    5.0: dj50
-    5.1: dj51
-    5.2: dj52
-    6.0: dj60
-    main: djmain
 
 [testenv]
 commands =
@@ -61,7 +57,7 @@ passenv =
     POSTGRES_*
     MYSQL_*
 
-[testenv:py{310,311,312,313,314}-djmain]
+[testenv:py{310,311,312,313,314}-djmain-lite3]
 ignore_errors = true
 ignore_outcome = true
 
@@ -105,13 +101,13 @@ commands =
     python -c "import django; django.setup(); from django.db import connections; c=connections['default']; c.ensure_connection(); c.close()"
     django-admin makemigrations --dry-run --check
 
-[testenv:migrations-sqlite]
+[testenv:migrations-dj52-lite3]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.mig_settings
     {[testenv:.migrations-base]setenv}
 commands = {[testenv:.migrations-base]commands}
 
-[testenv:migrations-postgres-dj{42,52,60}]
+[testenv:migrations-dj{42,52,60}-pg16]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.postgres_mig_settings
     {[testenv:.migrations-base]setenv}
@@ -120,7 +116,7 @@ deps =
     {[testenv]deps}
     psycopg[binary]>=3.2
 
-[testenv:migrations-mysql-dj{42,52,60}]
+[testenv:migrations-dj{42,52,60}-my84]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.mysql_mig_settings
     {[testenv:.migrations-base]setenv}
@@ -135,7 +131,7 @@ setenv =
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
 
-[testenv:{py310-dj42,py312-dj52,py314-dj60}-postgres]
+[testenv:{py310-dj42,py312-dj52,py314-dj60}-pg16]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.postgres_settings
     PYTHONPATH = {toxinidir}
@@ -144,7 +140,7 @@ deps =
     {[testenv]deps}
     psycopg[binary]>=3.2
 
-[testenv:{py310-dj42,py312-dj52,py314-dj60}-mysql]
+[testenv:{py310-dj42,py312-dj52,py314-dj60}-my84]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.mysql_settings
     PYTHONPATH = {toxinidir}
@@ -153,7 +149,7 @@ deps =
     {[testenv]deps}
     PyMySQL>=1.1
 
-[testenv:migrate_swapped]
+[testenv:scenario-migrate-swapped-dj52-lite3]
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings_swapped
     PYTHONPATH = {toxinidir}


### PR DESCRIPTION
We currently need to update both test.yml and tox.ini to change the coverage of our test suite. This PR updates the test.yml to infer the matrix from tox.ini so we only need to update the matrix in it. The environment naming has also been updated to support multiple db platforms and versions with guidelines for adding topology suffixes to capture various multiple database scenarios like primary/replica, multimaster, etc.


## Description of the Change
- update environment naming conventions to support multiple dbs and version.

## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [N/A] unit-test added
- [X] documentation updated
- [N/A] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [N/A] tests/app/idp updated to demonstrate new features
- [N/A] tests/app/rp updated to demonstrate new features
