### PR TITLE
Remove redundant unique=True on DeviceGrant.device_code (duplicate unique index)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   add nullable checksum → drop the old `("token", "revoked")` unique constraint → widen `token` to
   `TextField` → backfill → make checksum non-nullable → add the `("token_checksum", "revoked")`
   unique constraint.
+* If you use a swapped device grant model (`OAUTH2_PROVIDER_DEVICE_GRANT_MODEL`), run
+  `manage.py makemigrations` after upgrading: the redundant field-level `unique=True` was removed
+  from `AbstractDeviceGrant.device_code` (#1656), so your app needs a one-operation `AlterField`
+  migration that drops the extra unique index. Uniqueness remains enforced by the
+  `<app_label>_<class>_unique_device_code` constraint. If you are doing a *fresh* install on
+  Oracle (or a MySQL backend that raises warnings as errors), you must also regenerate — or
+  hand-edit — your existing `CreateModel` migration for the swapped model, since it still declares
+  both uniqueness rules and will fail the same way migration `0013` did.
 
 ### Changed
 * #1688 `cleartokens` now removes revoked refresh tokens once `REFRESH_TOKEN_GRACE_PERIOD_SECONDS`
@@ -63,10 +71,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the migration transaction's own locks. This also makes both migrations backfill the correct
   database when migrating a non-default alias (`migrate --database=...`). Thanks to Igor Petrik for
   the diagnosis and fix.
-* #1718 Remove the redundant `unique=True` on `DeviceGrant.device_code`, which duplicated the
+* #1656 Remove the redundant `unique=True` on `DeviceGrant.device_code`, which duplicated the
   `unique_device_code` `UniqueConstraint` and created two identical unique indexes on the same
-  column. On MySQL this triggers `ER_DUP_INDEX` (1831, "duplicate index ... deprecated and will
-  be disallowed in a future release") during migration.
+  column. Fresh installs failed on Oracle (`ORA-02261`) and on MySQL backends that raise database
+  warnings as errors (`ER_DUP_INDEX`, 1831). Migration `0013` is fixed in place because the
+  duplicate was created inside `CREATE TABLE`, so a follow-up migration could never fix fresh
+  installs. Databases that already applied the old `0013` keep one harmless extra unique index;
+  it can optionally be dropped by hand. Thanks to Febin Micheal Antony (#1659) and
+  moscowmule2240 (#1718) for the fixes.
 
 ## [3.3.0] - 2025-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the migration transaction's own locks. This also makes both migrations backfill the correct
   database when migrating a non-default alias (`migrate --database=...`). Thanks to Igor Petrik for
   the diagnosis and fix.
-
+* #1718 Remove the redundant `unique=True` on `DeviceGrant.device_code`, which duplicated the
+  `unique_device_code` `UniqueConstraint` and created two identical unique indexes on the same
+  column. On MySQL this triggers `ER_DUP_INDEX` (1831, "duplicate index ... deprecated and will
+  be disallowed in a future release") during migration.
 
 ## [3.3.0] - 2025-05-21
 

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -500,6 +500,13 @@ The import string of the class (model) representing your OAuth2 device grants.
 Overwrite this value if you wrote your own implementation (subclass of
 ``oauth2_provider.models.AbstractDeviceGrant``).
 
+.. note:: ``device_code`` uniqueness is enforced by the named ``UniqueConstraint``
+    ``<app_label>_<class>_unique_device_code`` inherited from
+    ``AbstractDeviceGrant.Meta.constraints``. Do not add ``unique=True`` to the field in your
+    swapped model: declaring both creates a duplicate unique index, which breaks ``migrate`` on
+    Oracle (``ORA-02261``) and on MySQL backends that raise database warnings as errors
+    (``ER_DUP_INDEX``).
+
 OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The import string of the class (model) representing your refresh tokens.

--- a/oauth2_provider/migrations/0013_alter_application_authorization_grant_type_device.py
+++ b/oauth2_provider/migrations/0013_alter_application_authorization_grant_type_device.py
@@ -22,7 +22,7 @@ class Migration(migrations.Migration):
             name='DeviceGrant',
             fields=[
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
-                ('device_code', models.CharField(max_length=100, unique=True)),
+                ('device_code', models.CharField(max_length=100)),
                 ('user_code', models.CharField(max_length=100)),
                 ('scope', models.CharField(max_length=64, null=True)),
                 ('interval', models.IntegerField(default=5)),

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -690,7 +690,9 @@ class AbstractDeviceGrant(models.Model):
         blank=True,
         on_delete=models.CASCADE,
     )
-    device_code = models.CharField(max_length=100, unique=True)
+    # Uniqueness is enforced by the unique_device_code UniqueConstraint (Meta.constraints);
+    # adding unique=True here would create a redundant duplicate index (MySQL warns ER_DUP_INDEX 1831).
+    device_code = models.CharField(max_length=100)
     user_code = models.CharField(max_length=100)
     scope = models.CharField(max_length=64, null=True)
     interval = models.IntegerField(default=5)

--- a/tests/migrations/0008_sampledevicegrant.py
+++ b/tests/migrations/0008_sampledevicegrant.py
@@ -14,7 +14,7 @@ class Migration(migrations.Migration):
             name="SampleDeviceGrant",
             fields=[
                 ("id", models.BigAutoField(primary_key=True, serialize=False)),
-                ("device_code", models.CharField(max_length=100, unique=True)),
+                ("device_code", models.CharField(max_length=100)),
                 ("user_code", models.CharField(max_length=100)),
                 ("scope", models.CharField(max_length=64, null=True)),
                 ("interval", models.IntegerField(default=5)),


### PR DESCRIPTION
## Problem

`AbstractDeviceGrant.device_code` declares **both** `unique=True` (field level) and a
`unique_device_code` `UniqueConstraint` in `Meta.constraints`. Each creates a unique index
on the same column, so `DeviceGrant` ends up with two identical unique indexes.

On MySQL, creating the `DeviceGrant` table (migration `0013`) emits `ER_DUP_INDEX` (1831):

> Duplicate index '...' defined on the table '...'. This is deprecated and will be disallowed in a future release.

Where database warnings are raised as errors this becomes a hard error and aborts `migrate`.
This happens, for example, with `mysql.connector`'s Django backend, which sets
`raise_on_warnings = settings.DEBUG`, so test-database creation under `DEBUG=True` fails.

## Fix

Remove the redundant field-level `unique=True` from `AbstractDeviceGrant.device_code` **and
from the `0013` `CreateModel`**, so the duplicate index is never created. Uniqueness is still
enforced by the explicit `unique_device_code` `UniqueConstraint`, which also gives the
swappable subclasses a stable, per-class name via `%(app_label)s_%(class)s_...`.

I edited migration `0013` in place rather than adding a follow-up migration on purpose: a new
`AlterField`/`RemoveIndex` migration would still let `0013` create the duplicate first and hit
`ER_DUP_INDEX` before the cleanup could run, so it would not fix fresh installs. The device
flow migration is recent (3.x); installs that already applied the old `0013` keep one harmless
extra index. Happy to switch to a separate migration or a squash if you prefer.

No behaviour change -- `device_code` remains unique.

## Verification

- `django-admin makemigrations --check --settings tests.mig_settings` -> *No changes detected*
- `pytest -k device` -> **27 passed**
