### PR TITLE
fix: validate client before prompt=none redirect to close open redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Security
+* Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
+  an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
+  *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's
+  browser to an arbitrary origin. The request is now validated against a registered client before any
+  redirect, per [OpenID Connect Core 1.0 section 3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError).
+  Reported by Brian Lee (SSLab, Georgia Tech).
+
 ### Deprecated
 * Deprecate the `AUTHENTICATION_SERVER_EXP_TIME_ZONE` setting. Token introspection `exp` values are
   Unix timestamps and are always interpreted as UTC per RFC 7662/RFC 7519. The setting still works

--- a/oauth2_provider/views/base.py
+++ b/oauth2_provider/views/base.py
@@ -258,28 +258,49 @@ class AuthorizationView(BaseAuthorizationView, FormView):
         """
         Generate response for unauthorized users.
 
-        If prompt is set to none, then we redirect with an error code
-        as defined by OIDC 3.1.2.6
+        If prompt is set to none, then we redirect with an error code as defined
+        by OpenID Connect Core 1.0 section 3.1.2.6 (Authentication Error Response)
+        <https://openid.net/specs/openid-connect-core-1_0.html#AuthError>.
 
         Some code copied from OAuthLibMixin.error_response, but that is designed
-        to operated on OAuth1Error from oauthlib wrapped in a OAuthToolkitError
+        to operate on OAuth2Error from oauthlib wrapped in a OAuthToolkitError
         """
         prompt = self.request.GET.get("prompt")
-        redirect_uri = self.request.GET.get("redirect_uri")
-        if prompt == "none" and redirect_uri:
+        if prompt == "none":
+            # Per OpenID Connect Core 1.0 section 3.1.2.6 (Authentication Error
+            # Response) an unauthenticated prompt=none request returns a
+            # login_required error to the client's redirect_uri. The request
+            # MUST be validated against a registered client *before* redirecting,
+            # otherwise this endpoint becomes an open redirector: an
+            # unauthenticated attacker could supply an arbitrary, unregistered
+            # redirect_uri (and no client_id) and have the victim's browser 302'd
+            # to an attacker-controlled origin.
+            # https://openid.net/specs/openid-connect-core-1_0.html#AuthError
+            try:
+                _scopes, credentials = self.validate_authorization_request(self.request)
+            except OAuthToolkitError as error:
+                # Invalid client_id / redirect_uri (etc). error_response only
+                # redirects for non-fatal errors, and never to an unregistered
+                # redirect_uri, so this is safe.
+                return self.error_response(error, application=None)
+
+            # oauthlib has confirmed redirect_uri is registered for the client.
+            redirect_uri = credentials["redirect_uri"]
+            application = get_application_model().objects.get(client_id=credentials["client_id"])
+
             response_parameters = {"error": "login_required"}
 
             # REQUIRED if the Authorization Request included the state parameter.
             # Set to the value received from the Client
-            state = self.request.GET.get("state")
+            state = credentials.get("state")
             if state:
                 response_parameters["state"] = state
 
             separator = "&" if "?" in redirect_uri else "?"
             redirect_to = redirect_uri + separator + urlencode(response_parameters)
-            return self.redirect(redirect_to, application=None)
-        else:
-            return super().handle_no_permission()
+            return self.redirect(redirect_to, application)
+
+        return super().handle_no_permission()
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -700,6 +700,52 @@ class TestOIDCAuthorizationCodeView(BaseTest):
         self.assertIn("login_required", parsed_query["error"])
         self.assertIn("random_state_string", parsed_query["state"])
 
+    def test_prompt_none_open_redirect_no_client(self):
+        """
+        Regression test for the prompt=none open redirect.
+
+        An unauthenticated request with prompt=none, an attacker-controlled
+        redirect_uri and *no* client_id must not redirect at all: the missing
+        client_id is a fatal error, so the error page is rendered instead of
+        any Location header being emitted.
+        """
+        query_data = {
+            "prompt": "none",
+            # http is in ALLOWED_REDIRECT_URI_SCHEMES (see BaseTest.setUp), so
+            # pre-fix this request was 302'd to the attacker origin rather than
+            # being rejected by scheme validation.
+            "redirect_uri": "http://attacker.example/cb",
+            "state": "phish-123",
+        }
+
+        response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertNotIn("Location", response)
+
+    def test_prompt_none_open_redirect_unregistered_redirect_uri(self):
+        """
+        Regression test for the prompt=none open redirect.
+
+        Even with a valid client_id, an unauthenticated prompt=none request
+        with a redirect_uri that is not registered for that client must not
+        redirect at all: the mismatching redirect_uri is a fatal error, so the
+        error page is rendered instead of any Location header being emitted.
+        """
+        query_data = {
+            "client_id": self.application.client_id,
+            "response_type": "code",
+            "scope": "openid",
+            "prompt": "none",
+            "redirect_uri": "http://attacker.example/cb",
+            "state": "phish-123",
+        }
+
+        response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertNotIn("Location", response)
+
 
 class BaseAuthorizationCodeTokenView(BaseTest):
     def get_auth(self, scope="read write"):


### PR DESCRIPTION

An unauthenticated `prompt=none` request to the authorization endpoint was redirected to the supplied `redirect_uri` with a `login_required` error before the client and `redirect_uri` were validated. Because the redirect only checked the URI scheme (not that the URI belonged to a registered client), an attacker could craft a link on the victim's authorization endpoint that 302'd the victim's browser to an arbitrary attacker-controlled origin.

`handle_no_permission` now validates the request against a registered client before performing the OIDC 3.1.2.6 `login_required` redirect, and only redirects to the oauthlib-validated `redirect_uri`. Invalid client/redirect_uri fall back to the normal error response, which never redirects to an unregistered URI.

Reported by Brian Lee (SSLab, Georgia Tech).


## Checklist

<!-- Replace '[ ]' with '[x]' to indicate that the checklist item is completed. -->
<!-- You can check the boxes now or later by just clicking on them. -->

- [X] PR only contains one change (considered splitting up PR)
- [X] unit-test added
- [X] documentation updated
- [X] `CHANGELOG.md` updated (only for user relevant changes)
- [X] author name in `AUTHORS`
- [N/A] tests/app/idp updated to demonstrate new features
- [N/A] tests/app/rp updated to demonstrate new features
