### PR TITLE
fix: support refresh tokens longer than 255 chars via token_checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   redirect, per [OpenID Connect Core 1.0 section 3.1.2.6](https://openid.net/specs/openid-connect-core-1_0.html#AuthError).
   Reported by Brian Lee (SSLab, Georgia Tech).
 
+### WARNING - POTENTIAL BREAKING CHANGES
+* Changes to the `AbstractRefreshToken` model require doing a `manage.py migrate` after upgrading.
+* If you use a swapped refresh token model (`OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL`) you will need to
+  update your custom model with `manage.py makemigrations`. If your table already contains refresh
+  tokens you must also backfill `token_checksum` with a data migration — copy `forwards_func` from
+  `oauth2_provider/migrations/0015_refreshtoken_token_checksum.py` and keep the same operation order:
+  add nullable checksum → drop the old `("token", "revoked")` unique constraint → widen `token` to
+  `TextField` → backfill → make checksum non-nullable → add the `("token_checksum", "revoked")`
+  unique constraint.
+
+### Changed
+* #1601 `RefreshToken.token` is now a `TextField` and lookups use a new SHA-256 `token_checksum`
+  field, removing the 255 character limit so long refresh tokens (e.g. Microsoft's JWT refresh
+  tokens) are supported. This mirrors the `AccessToken.token_checksum` approach introduced in 3.0.0
+  (#1447). The revocation endpoint also looks up access tokens by checksum now, restoring an indexed
+  lookup there.
+
 ### Deprecated
 * Deprecate the `AUTHENTICATION_SERVER_EXP_TIME_ZONE` setting. Token introspection `exp` values are
   Unix timestamps and are always interpreted as UTC per RFC 7662/RFC 7519. The setting still works

--- a/oauth2_provider/migrations/0015_refreshtoken_token_checksum.py
+++ b/oauth2_provider/migrations/0015_refreshtoken_token_checksum.py
@@ -1,0 +1,68 @@
+import hashlib
+
+from django.db import migrations, models
+
+import oauth2_provider.models
+from oauth2_provider.settings import oauth2_settings
+
+
+def forwards_func(apps, schema_editor):
+    """
+    Backfill token_checksum for existing refresh tokens.
+
+    The checksum is computed explicitly instead of relying on
+    TokenChecksumField.pre_save because bulk_update does not call pre_save.
+    """
+    RefreshToken = apps.get_model(oauth2_settings.REFRESH_TOKEN_MODEL)
+    if RefreshToken._meta.label_lower != "oauth2_provider.refreshtoken":
+        # The refresh token model is swapped out. The schema operations in this
+        # migration are skipped for swapped models, so the swapped app has to add
+        # the field and backfill it in its own migration (see CHANGELOG).
+        return
+    db_alias = schema_editor.connection.alias
+    batch = []
+    for refresh_token in RefreshToken._default_manager.using(db_alias).only("pk", "token").iterator():
+        refresh_token.token_checksum = hashlib.sha256(refresh_token.token.encode("utf-8")).hexdigest()
+        batch.append(refresh_token)
+        if len(batch) >= 1000:
+            RefreshToken._default_manager.using(db_alias).bulk_update(batch, ["token_checksum"])
+            batch = []
+    if batch:
+        RefreshToken._default_manager.using(db_alias).bulk_update(batch, ["token_checksum"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oauth2_provider", "0014_alter_help_text"),
+        migrations.swappable_dependency(oauth2_settings.REFRESH_TOKEN_MODEL),
+    ]
+
+    operations = [
+        # Add the checksum column as nullable first so existing rows migrate cleanly.
+        migrations.AddField(
+            model_name="refreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(blank=True, null=True, max_length=64),
+        ),
+        # Drop the old unique_together before widening token: MySQL cannot keep
+        # a TEXT column in an index without an explicit prefix length.
+        migrations.AlterUniqueTogether(
+            name="refreshtoken",
+            unique_together=set(),
+        ),
+        migrations.AlterField(
+            model_name="refreshtoken",
+            name="token",
+            field=models.TextField(),
+        ),
+        migrations.RunPython(forwards_func, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="refreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(blank=False, max_length=64),
+        ),
+        migrations.AlterUniqueTogether(
+            name="refreshtoken",
+            unique_together={("token_checksum", "revoked")},
+        ),
+    ]

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -506,7 +506,11 @@ class AbstractRefreshToken(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE, related_name="%(app_label)s_%(class)s"
     )
-    token = models.CharField(max_length=255)
+    token = models.TextField()
+    token_checksum = TokenChecksumField(
+        max_length=64,
+        blank=False,
+    )
     application = models.ForeignKey(oauth2_settings.APPLICATION_MODEL, on_delete=models.CASCADE)
     access_token = models.OneToOneField(
         oauth2_settings.ACCESS_TOKEN_MODEL,
@@ -549,7 +553,7 @@ class AbstractRefreshToken(models.Model):
     class Meta:
         abstract = True
         unique_together = (
-            "token",
+            "token_checksum",
             "revoked",
         )
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -773,13 +773,14 @@ class OAuth2Validator(RequestValidator):
             "refresh_token": RefreshToken,
         }
 
+        token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
         token_type = token_types.get(token_type_hint, AccessToken)
         try:
-            token_type.objects.get(token=token).revoke()
+            token_type.objects.get(token_checksum=token_checksum).revoke()
         except ObjectDoesNotExist:
             for other_type in [_t for _t in token_types.values() if _t != token_type]:
                 # slightly inefficient on Python2, but the queryset contains only one instance
-                list(map(lambda t: t.revoke(), other_type.objects.filter(token=token)))
+                list(map(lambda t: t.revoke(), other_type.objects.filter(token_checksum=token_checksum)))
 
     def validate_user(self, username, password, client, request, *args, **kwargs):
         """
@@ -816,7 +817,8 @@ class OAuth2Validator(RequestValidator):
         Also attach User instance to the request object
         """
 
-        rt = RefreshToken.objects.filter(token=refresh_token).select_related("access_token").first()
+        token_checksum = hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
+        rt = RefreshToken.objects.filter(token_checksum=token_checksum).select_related("access_token").first()
 
         if not rt:
             return False

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -15,8 +15,8 @@ import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.hashers import check_password, identify_hasher
-from django.core.exceptions import ObjectDoesNotExist
 from django.db import router, transaction
+from django.db.models import F
 from django.http import HttpRequest
 from django.utils import dateformat, timezone
 from django.utils.crypto import constant_time_compare
@@ -775,12 +775,14 @@ class OAuth2Validator(RequestValidator):
 
         token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
         token_type = token_types.get(token_type_hint, AccessToken)
-        try:
-            token_type.objects.get(token_checksum=token_checksum).revoke()
-        except ObjectDoesNotExist:
+        # RefreshToken uniqueness is (token_checksum, revoked), so several rows may share a
+        # checksum; revoke every match instead of get() to avoid MultipleObjectsReturned.
+        tokens = list(token_type.objects.filter(token_checksum=token_checksum))
+        if not tokens:
             for other_type in [_t for _t in token_types.values() if _t != token_type]:
-                # slightly inefficient on Python2, but the queryset contains only one instance
-                list(map(lambda t: t.revoke(), other_type.objects.filter(token_checksum=token_checksum)))
+                tokens.extend(other_type.objects.filter(token_checksum=token_checksum))
+        for t in tokens:
+            t.revoke()
 
     def validate_user(self, username, password, client, request, *args, **kwargs):
         """
@@ -818,7 +820,14 @@ class OAuth2Validator(RequestValidator):
         """
 
         token_checksum = hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
-        rt = RefreshToken.objects.filter(token_checksum=token_checksum).select_related("access_token").first()
+        # Several rows may share a checksum (uniqueness is (token_checksum, revoked)):
+        # prefer the unrevoked row, otherwise the most recently revoked one.
+        rt = (
+            RefreshToken.objects.filter(token_checksum=token_checksum)
+            .select_related("access_token")
+            .order_by(F("revoked").desc(nulls_first=True))
+            .first()
+        )
 
         if not rt:
             return False

--- a/tests/migrations/0010_refreshtoken_token_checksum.py
+++ b/tests/migrations/0010_refreshtoken_token_checksum.py
@@ -1,0 +1,50 @@
+from django.db import migrations, models
+
+import oauth2_provider.models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tests", "0009_custompkaccesstoken_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="samplerefreshtoken",
+            unique_together=set(),
+        ),
+        migrations.AlterField(
+            model_name="samplerefreshtoken",
+            name="token",
+            field=models.TextField(),
+        ),
+        migrations.AddField(
+            model_name="samplerefreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(default="", max_length=64),
+            preserve_default=False,
+        ),
+        migrations.AlterUniqueTogether(
+            name="samplerefreshtoken",
+            unique_together={("token_checksum", "revoked")},
+        ),
+        migrations.AlterUniqueTogether(
+            name="custompkrefreshtoken",
+            unique_together=set(),
+        ),
+        migrations.AlterField(
+            model_name="custompkrefreshtoken",
+            name="token",
+            field=models.TextField(),
+        ),
+        migrations.AddField(
+            model_name="custompkrefreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(default="", max_length=64),
+            preserve_default=False,
+        ),
+        migrations.AlterUniqueTogether(
+            name="custompkrefreshtoken",
+            unique_together={("token_checksum", "revoked")},
+        ),
+    ]

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -866,6 +866,88 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         content = json.loads(response.content.decode("utf-8"))
         self.assertTrue("invalid_grant" in content.values())
 
+    def test_refresh_with_long_token(self):
+        """
+        Request an access token using a refresh token longer than 255 characters,
+        as issued by e.g. Microsoft. Long tokens are looked up via their SHA-256
+        checksum, see issue #1601.
+        """
+        self.oauth2_settings.REFRESH_TOKEN_GENERATOR = lambda request: "x" * 300 + get_random_string(32)
+        self.client.login(username="test_user", password="123456")
+        authorization_code = self.get_auth()
+
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
+        }
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        content = json.loads(response.content.decode("utf-8"))
+        self.assertTrue("refresh_token" in content)
+        self.assertGreater(len(content["refresh_token"]), 255)
+
+        token_request_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": content["refresh_token"],
+            "scope": content["scope"],
+        }
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 200)
+
+        content = json.loads(response.content.decode("utf-8"))
+        self.assertTrue("access_token" in content)
+        self.assertGreater(len(content["refresh_token"]), 255)
+
+        # check refresh token cannot be used twice
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 400)
+        content = json.loads(response.content.decode("utf-8"))
+        self.assertTrue("invalid_grant" in content.values())
+
+    def test_refresh_with_grace_period_long_token(self):
+        """
+        The grace period returns the previously issued (plaintext) refresh token,
+        which must survive the round trip for tokens longer than 255 characters.
+        """
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 120
+        self.oauth2_settings.REFRESH_TOKEN_GENERATOR = lambda request: "x" * 300 + get_random_string(32)
+        self.client.login(username="test_user", password="123456")
+        authorization_code = self.get_auth()
+
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
+        }
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        content = json.loads(response.content.decode("utf-8"))
+        self.assertTrue("refresh_token" in content)
+        self.assertGreater(len(content["refresh_token"]), 255)
+
+        token_request_data = {
+            "grant_type": "refresh_token",
+            "refresh_token": content["refresh_token"],
+            "scope": content["scope"],
+        }
+
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 200)
+
+        content = json.loads(response.content.decode("utf-8"))
+        first_access_token = content["access_token"]
+        first_refresh_token = content["refresh_token"]
+
+        # within the grace period the same tokens are returned
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content.decode("utf-8"))
+        self.assertEqual(content["access_token"], first_access_token)
+        self.assertEqual(content["refresh_token"], first_refresh_token)
+
     def test_refresh_with_grace_period(self):
         """
         Request an access token using a refresh token

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -345,9 +345,65 @@ class TestAccessTokenModel(BaseTestModels):
 
 
 class TestRefreshTokenModel(BaseTestModels):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.app = Application.objects.create(
+            name="test_app",
+            redirect_uris="http://localhost http://example.com http://example.org",
+            user=cls.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+
     def test_str(self):
         refresh_token = RefreshToken(token="test_token")
         self.assertEqual("%s" % refresh_token, refresh_token.token)
+
+    def test_token_checksum_field(self):
+        token = secrets.token_urlsafe(32)
+        refresh_token = RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.app,
+        )
+        expected_checksum = hashlib.sha256(token.encode()).hexdigest()
+
+        self.assertEqual(refresh_token.token_checksum, expected_checksum)
+
+    def test_token_longer_than_255_characters(self):
+        # e.g. Microsoft issues JWT refresh tokens well over 255 characters
+        token = secrets.token_urlsafe(600)
+        self.assertGreater(len(token), 255)
+        refresh_token = RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.app,
+        )
+        refresh_token.refresh_from_db()
+
+        self.assertEqual(refresh_token.token, token)
+        self.assertEqual(
+            refresh_token.token_checksum,
+            hashlib.sha256(token.encode()).hexdigest(),
+        )
+
+    def test_same_token_allowed_with_different_revoked_timestamps(self):
+        token = secrets.token_urlsafe(32)
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.app,
+            revoked=timezone.now(),
+        )
+        active = RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.app,
+        )
+
+        self.assertIsNone(active.revoked)
+        self.assertEqual(RefreshToken.objects.filter(token_checksum=active.token_checksum).count(), 2)
 
 
 @pytest.mark.usefixtures("oauth2_settings")

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -302,6 +302,45 @@ class TestOAuth2Validator(TransactionTestCase):
         refresh_token.refresh_from_db()
         self.assertIsNotNone(refresh_token.revoked)
 
+    def test_validate_refresh_token_prefers_unrevoked_row_over_revoked_duplicate(self):
+        # (token_checksum, revoked) uniqueness allows the same token value to exist
+        # as both a revoked row and an active row; validation must pick the active one.
+        token = "duplicate-refresh-token"
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            revoked=timezone.now() - datetime.timedelta(days=1),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+        )
+        request = mock.MagicMock(wraps=Request)
+
+        self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
+        self.assertIsNone(request.refresh_token_instance.revoked)
+
+    def test_revoke_token_with_duplicate_refresh_token_checksums(self):
+        token = "duplicate-refresh-token"
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            revoked=timezone.now() - datetime.timedelta(days=1),
+        )
+        active_token = RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+        )
+
+        self.validator.revoke_token(token, "refresh_token", mock.MagicMock(wraps=Request))
+
+        active_token.refresh_from_db()
+        self.assertIsNotNone(active_token.revoked)
+
     def test_save_bearer_token__without_user__raises_fatal_client(self):
         token = {}
 

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -265,6 +265,43 @@ class TestOAuth2Validator(TransactionTestCase):
     def test_rotate_refresh_token__is_true(self):
         self.assertTrue(self.validator.rotate_refresh_token(mock.MagicMock()))
 
+    def test_validate_refresh_token_with_long_token(self):
+        long_token = "x" * 500
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="12345678901",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=long_token,
+            application=self.application,
+            access_token=access_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+
+        self.assertTrue(self.validator.validate_refresh_token(long_token, self.application, request))
+        self.assertEqual(request.user, self.user)
+        self.assertEqual(request.refresh_token, long_token)
+
+    def test_validate_refresh_token_with_unknown_token(self):
+        request = mock.MagicMock(wraps=Request)
+        self.assertFalse(self.validator.validate_refresh_token("unknown", self.application, request))
+
+    def test_revoke_token_with_long_refresh_token(self):
+        long_token = "x" * 500
+        refresh_token = RefreshToken.objects.create(
+            user=self.user,
+            token=long_token,
+            application=self.application,
+        )
+
+        self.validator.revoke_token(long_token, "refresh_token", mock.MagicMock(wraps=Request))
+
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+
     def test_save_bearer_token__without_user__raises_fatal_client(self):
         token = {}
 

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -152,6 +152,66 @@ class TestRevocationView(BaseTest):
         self.assertIsNotNone(refresh_token.revoked)
         self.assertFalse(AccessToken.objects.filter(pk=rtok.access_token.pk).exists())
 
+    def test_revoke_long_refresh_token(self):
+        """
+        Refresh tokens longer than 255 characters (e.g. issued by Microsoft)
+        are looked up via their SHA-256 checksum, see issue #1601.
+        """
+        tok = AccessToken.objects.create(
+            user=self.test_user,
+            token="1234567890",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+        rtok = RefreshToken.objects.create(
+            user=self.test_user, token="9" * 500, application=self.application, access_token=tok
+        )
+
+        data = {
+            "client_id": self.application.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "token": rtok.token,
+            "token_type_hint": "refresh_token",
+        }
+
+        url = reverse("oauth2_provider:revoke-token")
+        response = self.client.post(url, data=data)
+        self.assertEqual(response.status_code, 200)
+        refresh_token = RefreshToken.objects.filter(pk=rtok.pk).first()
+        self.assertIsNotNone(refresh_token.revoked)
+        self.assertFalse(AccessToken.objects.filter(pk=tok.pk).exists())
+
+    def test_revoke_long_refresh_token_with_wrong_hint(self):
+        """
+        A wrong hint (access_token) must fall back to searching refresh tokens,
+        also via the checksum lookup.
+        """
+        tok = AccessToken.objects.create(
+            user=self.test_user,
+            token="1234567890",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+        rtok = RefreshToken.objects.create(
+            user=self.test_user, token="9" * 500, application=self.application, access_token=tok
+        )
+
+        data = {
+            "client_id": self.application.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "token": rtok.token,
+            "token_type_hint": "access_token",
+        }
+
+        url = reverse("oauth2_provider:revoke-token")
+        response = self.client.post(url, data=data)
+        self.assertEqual(response.status_code, 200)
+        refresh_token = RefreshToken.objects.filter(pk=rtok.pk).first()
+        self.assertIsNotNone(refresh_token.revoked)
+        self.assertFalse(AccessToken.objects.filter(pk=tok.pk).exists())
+
     def test_revoke_refresh_token_with_revoked_access_token(self):
         tok = AccessToken.objects.create(
             user=self.test_user,


### PR DESCRIPTION
Fixes the `value too long for type character varying(255)` error when storing long refresh tokens (e.g. Microsoft's JWT refresh tokens).

Supersedes #1601.

## Description of the Change

Mirrors the `AccessToken.token_checksum` approach from #1447 on `RefreshToken`:

- `RefreshToken.token` becomes a `TextField`; a new SHA-256 `token_checksum` (`TokenChecksumField`, reused unchanged) is used for lookups.
- Uniqueness moves from `unique_together ("token", "revoked")` to `("token_checksum", "revoked")` — composite rather than globally unique, preserving the existing rotation/grace-period semantics where revoked rows with the same token value survive. Lookups stay indexed via the leading column of the composite unique index.
- `validate_refresh_token` and `revoke_token` (RFC 7009) look tokens up by checksum. As a bonus, the revocation endpoint's *access token* lookup — an unindexed `TextField` scan since 0012 — now uses `token_checksum` as well.
- Plaintext token storage is retained (parity with `AccessToken`); the grace-period path returns the previous refresh token's plaintext from the DB.

### Why not widen the CharField (#1601)?

`unique_together ("token", "revoked")` puts the token column in a composite unique index. A `CharField(8000)` in utf8mb4 (~32KB) exceeds MySQL/MariaDB InnoDB's 3072-byte index key limit (migration fails outright) and PostgreSQL btree's ~2700-byte limit.

### Migration design (with #1591 in mind)

`0015_refreshtoken_token_checksum` is staged like 0012 post-#1491, with lessons from #1591/#1678/#1652 applied:

1. Add `token_checksum` nullable
2. Drop the old `("token", "revoked")` unique constraint **before** widening `token` (MySQL cannot keep a `TEXT` column in an index without a prefix length)
3. `AlterField token → TextField`
4. Backfill: batched `bulk_update` (1000 rows/batch, sha256 computed in Python since `bulk_update` skips `pre_save`) with **all queries pinned to `schema_editor.connection.alias`**, so reads cannot be routed to a replica connection (the #1591 hang). Skipped entirely for swapped models, which must migrate in their own app (see CHANGELOG; the schema ops are skipped for them anyway — note `tests/migrations/0001_initial.py` creates swapped models as id-only stubs, so an unguarded backfill breaks under `swappable_dependency`)
5. Tighten `token_checksum` to non-null
6. Add the `("token_checksum", "revoked")` unique constraint over final data

### Verification beyond CI

Upgrades with pre-existing refresh-token rows were verified end-to-end (migrate to 0014, insert rows including a same-token revoked/active pair, migrate, assert checksums):

- SQLite: 5,002 rows backfilled in 0.7s
- **PostgreSQL 16 primary/replica with a read-to-replica router** (`docker-compose.postgres-pr.yml`, the #1591 topology): 20,002 rows in 2.8s, no hang. Side finding: this setup reproduces #1591 against the *shipped* 0012 even on an empty database, and passes with #1678's fix applied — independent confirmation that #1678 is correct.
- MySQL 8.4: 20,002 rows in 10.3s (validates the constraint-drop-before-widen ordering)
- `scenario-migrate-swapped-dj52-lite3` (swapped models) and `makemigrations --dry-run --check` pass

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated (CHANGELOG warning covers the swapped-model migration requirement)
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features (N/A)
- [ ] tests/app/rp updated to demonstrate new features (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)