### PR TITLE
Create GitHub release with changelog notes after PyPI publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,3 +35,49 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_PUBLISH_TOKEN }}
+
+  github-release:
+    name: Create GitHub release
+    if: github.repository == 'django-oauth/django-oauth-toolkit'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract changelog for ${{ github.ref_name }}
+        run: |
+          awk -v ver="$GITHUB_REF_NAME" '
+            /^## \[/ {
+              if (found) exit
+              if (substr($0, 1, length("## [" ver "]")) == "## [" ver "]") { found = 1; next }
+            }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if ! grep -q '[^[:space:]]' release-notes.md; then
+            echo "::error::No '## [$GITHUB_REF_NAME]' section found in CHANGELOG.md." >&2
+            echo "Add the section and re-run this job to create the GitHub release." >&2
+            exit 1
+          fi
+          echo "Release notes for $GITHUB_REF_NAME:"
+          cat release-notes.md
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists; skipping."
+            exit 0
+          fi
+          prerelease=""
+          if [[ "$GITHUB_REF_NAME" == *[a-zA-Z]* ]]; then
+            prerelease="--prerelease"
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --verify-tag \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            $prerelease

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,8 @@ jobs:
 
       - name: Extract changelog for ${{ github.ref_name }}
         run: |
-          awk -v ver="$GITHUB_REF_NAME" '
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
             /^## \[/ {
               if (found) exit
               if (substr($0, 1, length("## [" ver "]")) == "## [" ver "]") { found = 1; next }
@@ -57,8 +58,8 @@ jobs:
             found { print }
           ' CHANGELOG.md > release-notes.md
           if ! grep -q '[^[:space:]]' release-notes.md; then
-            echo "::error::No '## [$GITHUB_REF_NAME]' section found in CHANGELOG.md." >&2
-            echo "Add the section and re-run this job to create the GitHub release." >&2
+            echo "::error::No release notes for $version in CHANGELOG.md: the '## [$version]' section is missing or empty." >&2
+            echo "Add the release notes and re-run this job to create the GitHub release." >&2
             exit 1
           fi
           echo "Release notes for $GITHUB_REF_NAME:"
@@ -72,8 +73,9 @@ jobs:
             echo "Release $GITHUB_REF_NAME already exists; skipping."
             exit 0
           fi
+          # PEP 440 pre-release/dev markers, e.g. 4.0.0a1, 4.0.0b2, 4.0.0rc1, 4.0.0.dev1
           prerelease=""
-          if [[ "$GITHUB_REF_NAME" == *[a-zA-Z]* ]]; then
+          if [[ "${GITHUB_REF_NAME#v}" =~ (a|b|rc|dev)[0-9] ]]; then
             prerelease="--prerelease"
           fi
           gh release create "$GITHUB_REF_NAME" \

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -443,6 +443,11 @@ and rtfd.io. This checklist is a reminder of the required steps.
 - Once the final PR is merged, create and push a tag for the release. You'll shortly
   get a notification of the availability of two pypi packages (source tgz
   and wheel). Download these locally before releasing them.
+- After the packages are published to pypi.org, the release workflow automatically
+  creates a `GitHub release <https://github.com/django-oauth/django-oauth-toolkit/releases>`_
+  for the tag, using that version's section of :file:`CHANGELOG.md` as the release
+  notes. If the workflow fails because the CHANGELOG is missing a
+  ``## [<version>]`` section, add the section and re-run the failed job.
 - Do a ``tox -e build`` and extract the downloaded and built wheel zip and tgz files into
   temp directories and do a ``diff -r`` to make sure they have the same content.
   (Unfortunately the checksums do not match due to timestamps in the metadata


### PR DESCRIPTION
After the PyPI upload succeeds, a new github-release job extracts the
tag's section from CHANGELOG.md and creates a GitHub release for the
tag with those notes. The job fails with a clear error if the CHANGELOG
has no section for the version, skips if the release already exists
(so re-runs are safe), and marks tags containing letters (rc/a/b/dev)
as prereleases.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MELuprRcoFtSd6rhmAqCV9