### PR TITLE
Harmonize Bearer Authorization header parsing across the codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1635 Dynamic help text on the application form's `client_secret` field, warning users to copy the
   secret on creation and explaining it is hashed and unrecoverable when editing.
 
-### Changed
-* #1732 Bearer `Authorization` header parsing is now harmonized across the codebase via a shared
-  `oauth2_provider.utils.parse_bearer_token` helper implementing RFC 7235 / RFC 6750 semantics.
-  As a result, `OAuth2TokenMiddleware` and `OAuth2ExtraTokenMiddleware` now accept the scheme
-  case-insensitively (e.g. a lowercase `bearer` header, which is RFC-correct, is no longer
-  ignored) and no longer mis-parse non-Bearer schemes that merely start with `Bearer`
-  (e.g. `BearerX token` was previously treated as a Bearer token and is now rejected).
-
 ### Security
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
@@ -73,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   applied `0012` (any 3.x deployment) are unaffected.
 
 ### Changed
+* #1732 Bearer `Authorization` header parsing is now harmonized across the codebase via a shared
+  `oauth2_provider.utils.parse_bearer_token` helper implementing RFC 7235 / RFC 6750 semantics.
+  As a result, `OAuth2TokenMiddleware` and `OAuth2ExtraTokenMiddleware` now accept the scheme
+  case-insensitively (e.g. a lowercase `bearer` header, which is RFC-correct, is no longer
+  ignored) and no longer mis-parse non-Bearer schemes that merely start with `Bearer`
+  (e.g. `BearerX token` was previously treated as a Bearer token and is now rejected).
 * #1688 `cleartokens` now removes revoked refresh tokens once `REFRESH_TOKEN_GRACE_PERIOD_SECONDS`
   has passed, instead of keeping them until `REFRESH_TOKEN_EXPIRE_SECONDS`. When
   `REFRESH_TOKEN_REUSE_PROTECTION` is enabled, revoked tokens are still kept until they expire so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1635 Dynamic help text on the application form's `client_secret` field, warning users to copy the
   secret on creation and explaining it is hashed and unrecoverable when editing.
 
+### Changed
+* #1732 Bearer `Authorization` header parsing is now harmonized across the codebase via a shared
+  `oauth2_provider.utils.parse_bearer_token` helper implementing RFC 7235 / RFC 6750 semantics.
+  As a result, `OAuth2TokenMiddleware` and `OAuth2ExtraTokenMiddleware` now accept the scheme
+  case-insensitively (e.g. a lowercase `bearer` header, which is RFC-correct, is no longer
+  ignored) and no longer mis-parse non-Bearer schemes that merely start with `Bearer`
+  (e.g. `BearerX token` was previously treated as a Bearer token and is now rejected).
+
 ### Security
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error

--- a/oauth2_provider/middleware.py
+++ b/oauth2_provider/middleware.py
@@ -5,6 +5,7 @@ from django.contrib.auth import authenticate
 from django.utils.cache import patch_vary_headers
 
 from oauth2_provider.models import get_access_token_model
+from oauth2_provider.utils import parse_bearer_token
 
 
 log = logging.getLogger(__name__)
@@ -35,7 +36,7 @@ class OAuth2TokenMiddleware:
 
     def __call__(self, request):
         # do something only if request contains a Bearer token
-        if request.META.get("HTTP_AUTHORIZATION", "").startswith("Bearer"):
+        if parse_bearer_token(request.META.get("HTTP_AUTHORIZATION", "")):
             if not hasattr(request, "user") or request.user.is_anonymous:
                 user = authenticate(request=request)
                 if user:
@@ -51,10 +52,8 @@ class OAuth2ExtraTokenMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        authheader = request.META.get("HTTP_AUTHORIZATION", "")
-        splits = authheader.split(maxsplit=1)
-        if authheader.startswith("Bearer") and len(splits) == 2:
-            tokenstring = splits[1]
+        tokenstring = parse_bearer_token(request.META.get("HTTP_AUTHORIZATION", ""))
+        if tokenstring:
             AccessToken = get_access_token_model()
             try:
                 token_checksum = hashlib.sha256(tokenstring.encode("utf-8")).hexdigest()

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -23,7 +23,9 @@ def parse_bearer_token(auth_header):
     """
     if not auth_header:
         return None
-    splits = auth_header.split()
+    # maxsplit=2 bounds the work on arbitrarily long malformed headers: a third
+    # whitespace-separated part still fails the length check below either way.
+    splits = auth_header.split(maxsplit=2)
     if len(splits) != 2 or splits[0].lower() != "bearer":
         return None
     return splits[1]

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -23,8 +23,9 @@ def parse_bearer_token(auth_header):
     """
     if not auth_header:
         return None
-    # maxsplit=2 bounds the work on arbitrarily long malformed headers: a third
-    # whitespace-separated part still fails the length check below either way.
+    # maxsplit=2 (not 1) so whitespace inside the credentials produces a third
+    # element and fails the length check — a token68 value cannot contain
+    # whitespace — while still bounding the work on long malformed headers.
     splits = auth_header.split(maxsplit=2)
     if len(splits) != 2 or splits[0].lower() != "bearer":
         return None

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -13,18 +13,20 @@ def parse_bearer_token(auth_header):
     Implements RFC 7235 / RFC 6750 semantics: the scheme match is
     case-insensitive ("bearer", "Bearer" and "BEARER" are all accepted) and
     exact (schemes that merely start with "Bearer", e.g. "BearerX", are
-    rejected), any whitespace run between scheme and token is tolerated, and
-    the token is returned stripped of surrounding whitespace.
+    rejected), and any whitespace runs around the scheme and token are
+    tolerated. RFC 6750 Bearer credentials are a single ``token68`` value and
+    cannot contain whitespace, so values with more than one whitespace-separated
+    part after the scheme (e.g. "Bearer token extra") are rejected.
 
     Return the token string, or ``None`` if the header is not a well-formed
     Bearer authorization.
     """
     if not auth_header:
         return None
-    splits = auth_header.split(maxsplit=1)
+    splits = auth_header.split()
     if len(splits) != 2 or splits[0].lower() != "bearer":
         return None
-    return splits[1].strip() or None
+    return splits[1]
 
 
 @functools.lru_cache()

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -6,6 +6,27 @@ from jwcrypto import jwk
 from oauthlib.common import Request
 
 
+def parse_bearer_token(auth_header):
+    """
+    Extract the token from a Bearer ``Authorization`` header value.
+
+    Implements RFC 7235 / RFC 6750 semantics: the scheme match is
+    case-insensitive ("bearer", "Bearer" and "BEARER" are all accepted) and
+    exact (schemes that merely start with "Bearer", e.g. "BearerX", are
+    rejected), any whitespace run between scheme and token is tolerated, and
+    the token is returned stripped of surrounding whitespace.
+
+    Return the token string, or ``None`` if the header is not a well-formed
+    Bearer authorization.
+    """
+    if not auth_header:
+        return None
+    splits = auth_header.split(maxsplit=1)
+    if len(splits) != 2 or splits[0].lower() != "bearer":
+        return None
+    return splits[1].strip() or None
+
+
 @functools.lru_cache()
 def jwk_from_pem(pem_string):
     """

--- a/tests/test_auth_backends.py
+++ b/tests/test_auth_backends.py
@@ -139,6 +139,26 @@ class TestOAuth2Middleware(BaseTest):
         m(request)
         self.assertEqual(request.user, self.user)
 
+    def test_middleware_lowercase_bearer_scheme(self):
+        # RFC 7235: the Bearer scheme name is case-insensitive
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "bearer " + "tokstr",
+        }
+        request = self.factory.get("/a-resource", **auth_headers)
+        m(request)
+        self.assertEqual(request.user, self.user)
+
+    def test_middleware_scheme_starting_with_bearer_is_ignored(self):
+        # Schemes that merely start with "Bearer" (e.g. "BearerX") are not Bearer
+        m = OAuth2TokenMiddleware(self.dummy_get_response)
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "BearerX " + "tokstr",
+        }
+        request = self.factory.get("/a-resource", **auth_headers)
+        m(request)
+        self.assertFalse(hasattr(request, "user"))
+
     def test_middleware_response(self):
         m = OAuth2TokenMiddleware(self.dummy_get_response)
         auth_headers = {

--- a/tests/test_oauth2_provider_middleware.py
+++ b/tests/test_oauth2_provider_middleware.py
@@ -98,3 +98,50 @@ class TestOAuth2ExtraTokenMiddleware(TestCase):
 
         # Should not have access_token attribute
         self.assertFalse(hasattr(request, "access_token"))
+
+    def _create_access_token(self, token_string):
+        token_checksum = hashlib.sha256(token_string.encode("utf-8")).hexdigest()
+        return AccessToken.objects.create(
+            user=self.user,
+            scope="read",
+            expires=datetime.datetime.now() + datetime.timedelta(days=1),
+            token=token_string,
+            token_checksum=token_checksum,
+            application=self.application,
+        )
+
+    def test_case_insensitive_bearer_scheme(self):
+        """RFC 7235: the Bearer scheme name is case-insensitive"""
+        access_token = self._create_access_token("test-token-case")
+
+        for scheme in ("bearer", "BEARER", "BeArEr"):
+            with self.subTest(scheme=scheme):
+                request = self.factory.get("/", HTTP_AUTHORIZATION=f"{scheme} test-token-case")
+
+                _ = self.middleware(request)
+
+                self.assertTrue(hasattr(request, "access_token"))
+                self.assertEqual(request.access_token, access_token)
+
+    def test_scheme_starting_with_bearer_is_rejected(self):
+        """Schemes that merely start with 'Bearer' (e.g. 'BearerX') are not Bearer"""
+        self._create_access_token("test-token-schemes")
+
+        request = self.factory.get("/", HTTP_AUTHORIZATION="BearerX test-token-schemes")
+
+        _ = self.middleware(request)
+
+        self.assertFalse(hasattr(request, "access_token"))
+
+    def test_whitespace_variations(self):
+        """Whitespace runs between scheme and token, and around the token, are tolerated"""
+        access_token = self._create_access_token("test-token-ws")
+
+        for header in ("Bearer   test-token-ws", "Bearer\ttest-token-ws", "Bearer test-token-ws  "):
+            with self.subTest(header=header):
+                request = self.factory.get("/", HTTP_AUTHORIZATION=header)
+
+                _ = self.middleware(request)
+
+                self.assertTrue(hasattr(request, "access_token"))
+                self.assertEqual(request.access_token, access_token)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,39 @@ CQDpSvwIvDMSIQIJAMDk47DzG9FHAghtvg1TWpy3oQIJAL6NHlS+RBufAgkA6QLA
     assert jwk3 is not jwk1
 
 
+@pytest.mark.parametrize(
+    "auth_header, expected",
+    [
+        # RFC 7235: scheme match is case-insensitive
+        ("Bearer sometoken", "sometoken"),
+        ("bearer sometoken", "sometoken"),
+        ("BEARER sometoken", "sometoken"),
+        ("BeArEr sometoken", "sometoken"),
+        # any whitespace run between scheme and token is tolerated
+        ("Bearer   sometoken", "sometoken"),
+        ("Bearer\tsometoken", "sometoken"),
+        ("Bearer \t sometoken", "sometoken"),
+        # surrounding whitespace is stripped from the token
+        ("Bearer sometoken  ", "sometoken"),
+        ("  Bearer sometoken", "sometoken"),
+        # scheme must match exactly, not merely start with "Bearer"
+        ("BearerX sometoken", None),
+        ("Bearersometoken", None),
+        # other schemes are rejected
+        ("Basic dXNlcjpwYXNz", None),
+        # missing or empty token
+        ("Bearer", None),
+        ("Bearer ", None),
+        ("Bearer   ", None),
+        # empty/absent header
+        ("", None),
+        (None, None),
+    ],
+)
+def test_parse_bearer_token(auth_header, expected):
+    assert utils.parse_bearer_token(auth_header) == expected
+
+
 def test_user_code_generator():
     # Default argument, 8 characters
     user_code = utils.user_code_generator()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,11 @@ CQDpSvwIvDMSIQIJAMDk47DzG9FHAghtvg1TWpy3oQIJAL6NHlS+RBufAgkA6QLA
         # scheme must match exactly, not merely start with "Bearer"
         ("BearerX sometoken", None),
         ("Bearersometoken", None),
+        # RFC 6750 token68: a Bearer token cannot contain whitespace, so
+        # multi-part values are malformed and rejected
+        ("Bearer token extra", None),
+        ("Bearer token  extra", None),
+        ("Bearer token extra more", None),
         # other schemes are rejected
         ("Basic dXNlcjpwYXNz", None),
         # missing or empty token


### PR DESCRIPTION
Fixes #1732

## Description of the Change

Adds a shared `oauth2_provider.utils.parse_bearer_token(auth_header)` helper implementing RFC 7235 / RFC 6750 Bearer header semantics — case-insensitive **exact** scheme match, whitespace-bounded two-part split (RFC 6750 credentials are a single `token68` value, so values with whitespace inside the credentials such as `Bearer token extra` are rejected), and `None` on anything malformed — and adopts it in the first-party header parsing sites on master:

- **`OAuth2ExtraTokenMiddleware`**: replaces the case-sensitive `startswith("Bearer")` check + manual split. The middleware now accepts the RFC-correct lowercase `bearer` scheme and no longer mis-parses non-Bearer schemes that merely start with `Bearer` (previously `BearerX token` was treated as a Bearer token).
- **`OAuth2TokenMiddleware`**: its gate condition used the same case-sensitive `startswith("Bearer")` check, so a valid lowercase `bearer` header silently skipped OAuth2 authentication. oauthlib parses the scheme case-insensitively downstream, so with the harmonized gate a lowercase `bearer` header now authenticates end-to-end.

The DRF and Ninja integrations delegate header parsing entirely to oauthlib, so they need no changes. The helper's strict two-part split matches oauthlib's own `get_token_from_header` parsing.

The DCR management endpoint (#1728, not yet merged) already implements these semantics inline; it can switch to the shared helper once both changes land.

Behavior change (noted in `CHANGELOG.md` under *Changed*): the middlewares now accept lowercase/uppercase `bearer` schemes and reject `BearerX`-style schemes.

Tests cover `bearer`/`BEARER` acceptance, `BearerX` rejection, and whitespace variations, per the issue:
- 20 parametrized unit tests for the helper in `tests/test_utils.py`
- middleware-level tests in `tests/test_oauth2_provider_middleware.py` and `tests/test_auth_backends.py`

Full suite passes locally (625 passed, 1 skipped); `ruff format --check` and `ruff check` clean.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated (no docs describe the parsing details; `CHANGELOG.md` covers the behavior change)
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017f4ZoHbSRVoTd651wC5kTw