### PR TITLE
security: generate device user_code with a CSPRNG (secrets)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field and can be filtered in the Django admin.
 
 ### Security
+* Generate device-flow `user_code` values with the cryptographically secure `secrets` module
+  instead of the predictable `random` module (Mersenne Twister). The `user_code` is a device
+  authorization credential and must be unguessable per
+  [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) sections 5.1 and 5.2.
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
   *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -75,12 +75,14 @@ def user_code_generator(user_code_length: int = 8) -> str:
 
         e = 8 * log2(32) = 8 * 5 = 40 bits
 
-    i.e. _ _ _ _ - _ _ _ _  ->  32^8 == 2^40 possible codes.
+    i.e. there are 32^8 == 2^40 possible codes. (The generated code is a plain
+    string with no separator; any grouping/hyphenation is a presentation concern
+    for the UI, not part of the value.)
 
-    In other words an attacker would need to try up to 2^40 combinations to
-    exhaust the space. Combined with a short validity window and rate limiting
-    on the verification endpoint, a brute-force attack is extremely unlikely to
-    succeed.
+    An attacker would need to try up to 2^40 combinations to exhaust the space.
+    Note that this library does not itself rate-limit or expire the verification
+    step, so deployments should keep the code's validity window short and
+    rate-limit the verification endpoint to make brute-forcing impractical.
 
     The code is drawn from ``secrets`` (a CSPRNG) rather than ``random`` so
     that the ``user_code`` is unguessable, as required for device-flow

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -64,29 +64,23 @@ def user_code_generator(user_code_length: int = 8) -> str:
     Recommended user code that retains enough entropy but doesn't
     ruin the user experience of typing the code in.
 
-    the below is based off:
+    This follows the guidance in:
     https://datatracker.ietf.org/doc/html/rfc8628#section-5.1
-    but with added explanation as to where 34.5 bits of entropy is coming from
+    with an explanation of the entropy this implementation provides.
 
-    entropy (in bits) = length of user code * log2(length of set of chars)
-    e = 8 * log2(20)
-    e = 34.5
+    entropy (in bits) = length of user code * log2(size of the character set)
 
-    log2(20) is used here to say "you can make 20 yes/no decisions per user code single input character".
+    This implementation uses a 32-character (Base32) alphabet, so for the
+    default length of 8 characters:
 
-    _ _ _ _ - _ _ _ _ = 20^8 ~= 2^35.5
-    *
+        e = 8 * log2(32) = 8 * 5 = 40 bits
 
-    * you have 20 choices of chars to choose from (20 yes no decisions)
-    and so on for the other 7 spaces
+    i.e. _ _ _ _ - _ _ _ _  ->  32^8 == 2^40 possible codes.
 
-    in english this means an attacker would need to try
-    2^34.5 unique combinations to exhaust all possibilities.
-    however with a user code only being valid for 30 seconds
-    and rate limiting, a brute force attack is extremely unlikely
-    to work
-
-    for our function we'll be using a base 32 character set
+    In other words an attacker would need to try up to 2^40 combinations to
+    exhaust the space. Combined with a short validity window and rate limiting
+    on the verification endpoint, a brute-force attack is extremely unlikely to
+    succeed.
 
     The code is drawn from ``secrets`` (a CSPRNG) rather than ``random`` so
     that the ``user_code`` is unguessable, as required for device-flow

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -70,8 +70,8 @@ def user_code_generator(user_code_length: int = 8) -> str:
 
     entropy (in bits) = length of user code * log2(size of the character set)
 
-    This implementation uses a 32-character (Base32) alphabet, so for the
-    default length of 8 characters:
+    This implementation uses a 32-character (RFC 4648 Base32hex, ``0-9A-V``)
+    alphabet, so for the default length of 8 characters:
 
         e = 8 * log2(32) = 8 * 5 = 40 bits
 
@@ -80,9 +80,10 @@ def user_code_generator(user_code_length: int = 8) -> str:
     for the UI, not part of the value.)
 
     An attacker would need to try up to 2^40 combinations to exhaust the space.
-    Note that this library does not itself rate-limit or expire the verification
-    step, so deployments should keep the code's validity window short and
-    rate-limit the verification endpoint to make brute-forcing impractical.
+    The device grant does expire (its validity window is enforced), but this
+    library does not itself rate-limit the verification step, so deployments
+    should keep the code's validity window short and rate-limit the verification
+    endpoint to make brute-forcing impractical.
 
     The code is drawn from ``secrets`` (a CSPRNG) rather than ``random`` so
     that the ``user_code`` is unguessable, as required for device-flow

--- a/oauth2_provider/utils.py
+++ b/oauth2_provider/utils.py
@@ -1,5 +1,5 @@
 import functools
-import random
+import secrets
 
 from django.conf import settings
 from jwcrypto import jwk
@@ -87,6 +87,10 @@ def user_code_generator(user_code_length: int = 8) -> str:
     to work
 
     for our function we'll be using a base 32 character set
+
+    The code is drawn from ``secrets`` (a CSPRNG) rather than ``random`` so
+    that the ``user_code`` is unguessable, as required for device-flow
+    credentials by RFC 8628 sections 5.1 and 5.2.
     """
     if user_code_length < 1:
         raise ValueError("user_code_length needs to be greater than 0")
@@ -98,7 +102,7 @@ def user_code_generator(user_code_length: int = 8) -> str:
     user_code = [""] * user_code_length
 
     for i in range(user_code_length):
-        user_code[i] = random.choice(character_space)
+        user_code[i] = secrets.choice(character_space)
 
     return "".join(user_code)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,3 +86,19 @@ def test_user_code_generator():
     with pytest.raises(ValueError):
         utils.user_code_generator(user_code_length=0)
         utils.user_code_generator(user_code_length=-1)
+
+
+def test_user_code_generator_uses_csprng(mocker):
+    """
+    The device-flow user code must be drawn from a cryptographically secure
+    source (``secrets``), not the predictable ``random`` module, per RFC 8628
+    sections 5.1/5.2.
+    """
+    choice = mocker.patch("oauth2_provider.utils.secrets.choice", return_value="A")
+
+    user_code = utils.user_code_generator(user_code_length=8)
+
+    assert user_code == "AAAAAAAA"
+    assert choice.call_count == 8
+    # Guard against regressing to the non-cryptographic ``random`` module.
+    assert not hasattr(utils, "random")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -94,11 +94,12 @@ def test_user_code_generator_uses_csprng(mocker):
     source (``secrets``), not the predictable ``random`` module, per RFC 8628
     sections 5.1/5.2.
     """
-    choice = mocker.patch("oauth2_provider.utils.secrets.choice", return_value="A")
+    secrets_choice = mocker.patch("oauth2_provider.utils.secrets.choice", return_value="A")
+    random_choice = mocker.patch("random.choice")
 
     user_code = utils.user_code_generator(user_code_length=8)
 
     assert user_code == "AAAAAAAA"
-    assert choice.call_count == 8
-    # Guard against regressing to the non-cryptographic ``random`` module.
-    assert not hasattr(utils, "random")
+    assert secrets_choice.call_count == 8
+    # The predictable ``random`` module must not be used to generate the code.
+    random_choice.assert_not_called()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -95,11 +95,11 @@ def test_user_code_generator_uses_csprng(mocker):
     sections 5.1/5.2.
     """
     secrets_choice = mocker.patch("oauth2_provider.utils.secrets.choice", return_value="A")
-    random_choice = mocker.patch("random.choice")
 
     user_code = utils.user_code_generator(user_code_length=8)
 
+    # Every character comes from secrets.choice (a CSPRNG). This also guards against a
+    # regression to random.choice: if the generator used the predictable random module
+    # instead, secrets.choice would not be called and neither assertion would hold.
     assert user_code == "AAAAAAAA"
     assert secrets_choice.call_count == 8
-    # The predictable ``random`` module must not be used to generate the code.
-    random_choice.assert_not_called()


### PR DESCRIPTION
Fixes #

## Description of the Change

`oauth2_provider.utils.user_code_generator` — the default
`OAUTH_DEVICE_USER_CODE_GENERATOR` for the device authorization grant — built the
`user_code` with `random.choice`, backed by the non-cryptographic Mersenne Twister
PRNG. Its output is predictable once internal state can be inferred.

The `user_code` is a credential the user presents to bind a device authorization,
and the device views (`DeviceUserCodeView`, `DeviceConfirmView`,
`DeviceGrantStatusView`) look up grants solely by `user_code`, so a predictable
code weakens device-session security.

This draws each character from `secrets.choice` (a CSPRNG) instead, as required for
device-flow codes by [RFC 8628 §5.1/§5.2](https://datatracker.ietf.org/doc/html/rfc8628#section-5.1).
The character set, length, and public behaviour are unchanged. The docstring's
entropy explanation is also corrected to match the actual 32-character Base32
alphabet (8 · log2(32) = 40 bits for the default length).

A regression test asserts every character is drawn from `secrets.choice` (the
CSPRNG); this also fails if the generator ever regresses to `random.choice`.

This is one of a batch of five hardening PRs (H1–H5) from a security review of the
provider.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features
