### PR TITLE
security: do not log client secrets on failed client authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of the predictable `random` module (Mersenne Twister). The `user_code` is a device
   authorization credential and must be unguessable per
   [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) sections 5.1 and 5.2.
+* Stop writing client secrets to the logs. On a failed client authentication the `OAuth2Validator`
+  logged the submitted `client_secret` (and, for Basic auth, the base64 `client_id:client_secret`
+  credential string) at `DEBUG` level. These messages now identify only the `client_id`, so
+  password-equivalent client secrets no longer leak into log files or aggregators.
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
   *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) sections 5.1 and 5.2.
 * Stop writing client secrets to the logs. On a failed client authentication, the `OAuth2Validator`
   logged the submitted `client_secret` (and, for Basic auth, the base64 `client_id:client_secret`
-  credential string) at `DEBUG` level. These messages now identify only the `client_id`, so
-  password-equivalent client secrets no longer leak into log files or aggregators.
+  credential string) at `DEBUG` level. These messages now log at most the `client_id` (when it is
+  available; the base64/unicode decode-failure paths log a generic message with no credential), so
+  password-equivalent client secrets and raw credential strings no longer leak into log files or
+  aggregators.
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
   *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of the predictable `random` module (Mersenne Twister). The `user_code` is a device
   authorization credential and must be unguessable per
   [RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628) sections 5.1 and 5.2.
-* Stop writing client secrets to the logs. On a failed client authentication the `OAuth2Validator`
+* Stop writing client secrets to the logs. On a failed client authentication, the `OAuth2Validator`
   logged the submitted `client_secret` (and, for Basic auth, the base64 `client_id:client_secret`
   credential string) at `DEBUG` level. These messages now identify only the `client_id`, so
   password-equivalent client secrets no longer leak into log files or aggregators.

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -177,7 +177,7 @@ class OAuth2Validator(RequestValidator):
         ):
             return True
         elif not self._check_secret(client_secret, request.client.client_secret):
-            log.debug("Failed basic auth: wrong client secret for client_id %s" % client_id)
+            log.debug("Failed basic auth: wrong client secret for client_id %s", client_id)
             return False
         else:
             return True
@@ -207,7 +207,7 @@ class OAuth2Validator(RequestValidator):
         ):
             return True
         elif not self._check_secret(client_secret, request.client.client_secret):
-            log.debug("Failed body auth: wrong client secret for client_id %s" % client_id)
+            log.debug("Failed body auth: wrong client secret for client_id %s", client_id)
             return False
         else:
             return True

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -148,13 +148,15 @@ class OAuth2Validator(RequestValidator):
         try:
             b64_decoded = base64.b64decode(auth_string)
         except (TypeError, binascii.Error):
-            log.debug("Failed basic auth: %r can't be decoded as base64", auth_string)
+            # auth_string is the base64 of "client_id:client_secret"; never log it.
+            log.debug("Failed basic auth: credentials can't be decoded as base64")
             return False
 
         try:
             auth_string_decoded = b64_decoded.decode(encoding)
         except UnicodeDecodeError:
-            log.debug("Failed basic auth: %r can't be decoded as unicode by %r", auth_string, encoding)
+            # auth_string is the base64 of "client_id:client_secret"; never log it.
+            log.debug("Failed basic auth: credentials can't be decoded as unicode by %r", encoding)
             return False
 
         try:
@@ -175,7 +177,7 @@ class OAuth2Validator(RequestValidator):
         ):
             return True
         elif not self._check_secret(client_secret, request.client.client_secret):
-            log.debug("Failed basic auth: wrong client secret %s" % client_secret)
+            log.debug("Failed basic auth: wrong client secret for client_id %s" % client_id)
             return False
         else:
             return True
@@ -205,7 +207,7 @@ class OAuth2Validator(RequestValidator):
         ):
             return True
         elif not self._check_secret(client_secret, request.client.client_secret):
-            log.debug("Failed body auth: wrong client secret %s" % client_secret)
+            log.debug("Failed body auth: wrong client secret for client_id %s" % client_id)
             return False
         else:
             return True

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -186,13 +186,21 @@ class TestOAuth2Validator(TransactionTestCase):
         self.request.headers = {"HTTP_AUTHORIZATION": "Basic not_base64"}
         with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
             self.assertFalse(self.validator._authenticate_basic_auth(self.request))
-        self.assertFalse(any("not_base64" in message for message in logs.output))
+        output = "\n".join(logs.output)
+        # Assert the base64-decode-failure branch actually ran (not some later path) ...
+        self.assertIn("can't be decoded as base64", output)
+        # ... and that it did not log the raw credential string.
+        self.assertNotIn("not_base64", output)
 
         # Valid base64 but not valid utf-8 -> hits the unicode decode failure branch.
         self.request.headers = {"HTTP_AUTHORIZATION": "Basic SECRETNEEDLE"}
         with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
             self.assertFalse(self.validator._authenticate_basic_auth(self.request))
-        self.assertFalse(any("SECRETNEEDLE" in message for message in logs.output))
+        output = "\n".join(logs.output)
+        # Assert the unicode-decode-failure branch actually ran ...
+        self.assertIn("can't be decoded as unicode", output)
+        # ... and that it did not log the raw credential string.
+        self.assertNotIn("SECRETNEEDLE", output)
 
     def test_authenticate_basic_auth_not_b64_auth_string(self):
         self.request.encoding = "utf-8"

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -192,15 +192,16 @@ class TestOAuth2Validator(TransactionTestCase):
         # ... and that it did not log the raw credential string.
         self.assertNotIn("not_base64", output)
 
-        # Valid base64 but not valid utf-8 -> hits the unicode decode failure branch.
-        self.request.headers = {"HTTP_AUTHORIZATION": "Basic SECRETNEEDLE"}
+        # "test" b64-decodes to non-utf-8 bytes, so it deterministically hits the unicode
+        # decode failure branch (same known fixture as test_authenticate_basic_auth_not_utf8).
+        self.request.headers = {"HTTP_AUTHORIZATION": "Basic test"}
         with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
             self.assertFalse(self.validator._authenticate_basic_auth(self.request))
         output = "\n".join(logs.output)
         # Assert the unicode-decode-failure branch actually ran ...
         self.assertIn("can't be decoded as unicode", output)
         # ... and that it did not log the raw credential string.
-        self.assertNotIn("SECRETNEEDLE", output)
+        self.assertNotIn("test", output)
 
     def test_authenticate_basic_auth_not_b64_auth_string(self):
         self.request.encoding = "utf-8"

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -162,6 +162,38 @@ class TestOAuth2Validator(TransactionTestCase):
         self.request.headers = get_basic_auth_header("client_id", "wrong_secret")
         self.assertFalse(self.validator._authenticate_basic_auth(self.request))
 
+    def test_authenticate_basic_auth_wrong_client_secret_not_logged(self):
+        """The client secret must never be written to the logs (basic auth)."""
+        self.request.encoding = "utf-8"
+        self.request.headers = get_basic_auth_header("client_id", "super_secret_value")
+        with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
+            self.assertFalse(self.validator._authenticate_basic_auth(self.request))
+        self.assertFalse(any("super_secret_value" in message for message in logs.output))
+
+    def test_authenticate_request_body_wrong_client_secret_not_logged(self):
+        """The client secret must never be written to the logs (body auth)."""
+        self.request.client_id = "client_id"
+        self.request.client_secret = "super_secret_value"
+        with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
+            self.assertFalse(self.validator._authenticate_request_body(self.request))
+        self.assertFalse(any("super_secret_value" in message for message in logs.output))
+
+    def test_authenticate_basic_auth_undecodable_credentials_not_logged(self):
+        """The raw credential string must not be logged when base64/unicode decoding fails."""
+        self.request.encoding = "utf-8"
+
+        # Not valid base64 -> hits the base64 decode failure branch.
+        self.request.headers = {"HTTP_AUTHORIZATION": "Basic not_base64"}
+        with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
+            self.assertFalse(self.validator._authenticate_basic_auth(self.request))
+        self.assertFalse(any("not_base64" in message for message in logs.output))
+
+        # Valid base64 but not valid utf-8 -> hits the unicode decode failure branch.
+        self.request.headers = {"HTTP_AUTHORIZATION": "Basic SECRETNEEDLE"}
+        with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
+            self.assertFalse(self.validator._authenticate_basic_auth(self.request))
+        self.assertFalse(any("SECRETNEEDLE" in message for message in logs.output))
+
     def test_authenticate_basic_auth_not_b64_auth_string(self):
         self.request.encoding = "utf-8"
         # Can"t b64decode

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -168,7 +168,7 @@ class TestOAuth2Validator(TransactionTestCase):
         self.request.headers = get_basic_auth_header("client_id", "super_secret_value")
         with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
             self.assertFalse(self.validator._authenticate_basic_auth(self.request))
-        self.assertFalse(any("super_secret_value" in message for message in logs.output))
+        self.assertNotIn("super_secret_value", "\n".join(logs.output))
 
     def test_authenticate_request_body_wrong_client_secret_not_logged(self):
         """The client secret must never be written to the logs (body auth)."""
@@ -176,7 +176,7 @@ class TestOAuth2Validator(TransactionTestCase):
         self.request.client_secret = "super_secret_value"
         with self.assertLogs("oauth2_provider", level="DEBUG") as logs:
             self.assertFalse(self.validator._authenticate_request_body(self.request))
-        self.assertFalse(any("super_secret_value" in message for message in logs.output))
+        self.assertNotIn("super_secret_value", "\n".join(logs.output))
 
     def test_authenticate_basic_auth_undecodable_credentials_not_logged(self):
         """The raw credential string must not be logged when base64/unicode decoding fails."""


### PR DESCRIPTION
Fixes #

## Description of the Change

On failed client authentication, `OAuth2Validator` logged the submitted
`client_secret` at `DEBUG` level in both `_authenticate_basic_auth` and
`_authenticate_request_body`, and logged the raw base64 `client_id:client_secret`
string when it could not be decoded. `DEBUG` logging is commonly enabled in
staging and during incident triage, so these messages could leak
password-equivalent client credentials into log files and aggregators
(cf. RFC 9700 §2 / OWASP secret-handling).

These log paths now identify only the `client_id` (or emit a generic message), so
the secret and the raw credential string are never written to the logs.

Tests assert that neither the secret nor the raw base64 credential string appears
in the log output.

One of a batch of five hardening PRs (H1–H5) from a security review of the provider.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGRuhUKB9BDp1pvwDf5i5o)_