### PR TITLE
security: stop exposing cleartext tokens and codes in the admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   available; the base64/unicode decode-failure paths log a generic message with no credential), so
   password-equivalent client secrets and raw credential strings no longer leak into log files or
   aggregators.
+* Stop exposing cleartext access tokens, refresh tokens, and authorization codes in the Django
+  admin. The default `AccessTokenAdmin`, `RefreshTokenAdmin`, and `GrantAdmin` classes listed the
+  raw `token`/`code` in `list_display` and included them in `search_fields`. Because these values
+  are stored in cleartext, any staff user with view access saw replayable credentials, and
+  searching placed them in the `?q=` query string (captured by access logs and browser history).
+  The columns are now masked (last characters only) and are no longer searchable (search is
+  available by application and user instead). The raw `token`/`code` field is also excluded from
+  the admin change/view form, which showed the editable cleartext field to any staff user with view
+  access; a masked read-only value is shown instead. Adding tokens/codes through the admin is now
+  disabled (`has_add_permission` returns `False` on the `AccessToken`, `RefreshToken`, `Grant`, and
+  `IDToken` admins) — these are issued by the OAuth flows and are not meant to be hand-created, and
+  the add form would otherwise present an editable cleartext field. Relatedly, the `AccessToken`,
+  `RefreshToken`, and `Grant` model `__str__` methods no longer return the raw token/code (which the
+  admin renders in a row's change-page title and breadcrumbs, and which also appears in `repr()` and
+  logs); they now return a `"<Model> #<pk>"` identifier.
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
   *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -17,6 +17,43 @@ from oauth2_provider.models import (
 
 has_email = hasattr(get_user_model(), "email")
 
+# Non-secret user identifiers used to keep the credential changelists searchable by user.
+# Always include the user model's USERNAME_FIELD (so custom user models without an ``email``
+# attribute still support "search by user"), plus ``email`` when it exists and differs from it.
+_username_field = get_user_model().USERNAME_FIELD
+USER_SEARCH_FIELDS = ("user__%s" % _username_field,)
+if has_email and _username_field != "email":
+    USER_SEARCH_FIELDS += ("user__email",)
+
+
+# Only reveal a short suffix of a credential, and only when the value is long enough
+# that the suffix is a small fraction of it. Shorter values are fully masked so a masked
+# value never exposes most of a (potentially low-entropy) secret.
+MASK_MIN_LENGTH = 16
+MASK_SUFFIX_LENGTH = 4
+
+
+def mask_credential(value):
+    """
+    Return a masked representation of a token/code that identifies a row in the
+    admin without exposing the usable credential.
+
+    Access/refresh tokens and authorization codes are stored in cleartext, so
+    showing them verbatim (or making them searchable) would expose live,
+    replayable credentials to any staff user with view access — and, for
+    ``search_fields``, would leak them into the ``?q=`` query string captured by
+    server access logs and browser history. Falsy values (``""``/``None``) are
+    returned unchanged. Non-empty values shorter than ``MASK_MIN_LENGTH``
+    characters are fully masked; values of at least that length reveal only
+    their last ``MASK_SUFFIX_LENGTH`` characters, which is enough to correlate a
+    row without meaningfully aiding a brute force of a high-entropy token.
+    """
+    if not value:
+        return value
+    if len(value) < MASK_MIN_LENGTH:
+        return "…"
+    return "…%s" % value[-MASK_SUFFIX_LENGTH:]
+
 
 class ApplicationAdmin(admin.ModelAdmin):
     list_display = ("pk", "name", "user", "client_type", "authorization_grant_type", "dcr_created")
@@ -35,33 +72,115 @@ class ApplicationAdmin(admin.ModelAdmin):
 
 
 class AccessTokenAdmin(admin.ModelAdmin):
-    list_display = ("token", "user", "application", "expires")
+    list_display = ("pk", "masked_token", "user", "application", "expires")
     list_select_related = ("application", "user")
     raw_id_fields = ("user", "source_refresh_token")
-    search_fields = ("token",) + (("user__email",) if has_email else ())
+    # Search by non-secret identifiers only; never by the token itself.
+    search_fields = ("application__client_id", "application__name") + USER_SEARCH_FIELDS
     list_filter = ("application",)
+
+    def has_add_permission(self, request):
+        # Access tokens are issued by the OAuth flows, not hand-created in the admin.
+        # Disabling add also removes the add form's editable (cleartext) token field.
+        return False
+
+    def get_exclude(self, request, obj=None):
+        # Hide the raw token on the change/view form (obj is set). Adding is disabled
+        # (see has_add_permission), so the add form is unreachable; guarding on obj keeps
+        # this correct if a subclass ever re-enables it. Extend, rather than replace, any
+        # exclude configured on a subclass.
+        exclude = tuple(super().get_exclude(request, obj) or ())
+        if obj is not None and "token" not in exclude:
+            exclude += ("token",)
+        return exclude
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = tuple(super().get_readonly_fields(request, obj))
+        if obj is not None and "masked_token" not in readonly_fields:
+            readonly_fields += ("masked_token",)
+        return readonly_fields
+
+    @admin.display(description="token")
+    def masked_token(self, obj):
+        return mask_credential(obj.token) if obj is not None else ""
 
 
 class GrantAdmin(admin.ModelAdmin):
-    list_display = ("code", "application", "user", "expires")
+    list_display = ("pk", "masked_code", "application", "user", "expires")
     raw_id_fields = ("user",)
-    search_fields = ("code",) + (("user__email",) if has_email else ())
+    # Search by non-secret identifiers only; never by the authorization code itself.
+    search_fields = ("application__client_id", "application__name") + USER_SEARCH_FIELDS
+
+    def has_add_permission(self, request):
+        # Authorization codes are issued by the OAuth flows, not hand-created in the admin.
+        return False
+
+    def get_exclude(self, request, obj=None):
+        # Hide the raw code on the change/view form. Adding is disabled (see
+        # has_add_permission), so the add form is unreachable; guarding on obj keeps this
+        # correct if a subclass ever re-enables it. Extend, rather than replace, any exclude
+        # configured on a subclass.
+        exclude = tuple(super().get_exclude(request, obj) or ())
+        if obj is not None and "code" not in exclude:
+            exclude += ("code",)
+        return exclude
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = tuple(super().get_readonly_fields(request, obj))
+        if obj is not None and "masked_code" not in readonly_fields:
+            readonly_fields += ("masked_code",)
+        return readonly_fields
+
+    @admin.display(description="code")
+    def masked_code(self, obj):
+        return mask_credential(obj.code) if obj is not None else ""
 
 
 class IDTokenAdmin(admin.ModelAdmin):
     list_display = ("jti", "user", "application", "expires")
     raw_id_fields = ("user",)
-    search_fields = ("user__email",) if has_email else ()
+    # Search by non-secret identifiers only, consistent with the other credential admins and
+    # resilient to custom user models without an ``email`` field (see USER_SEARCH_FIELDS).
+    search_fields = ("application__client_id", "application__name") + USER_SEARCH_FIELDS
     list_filter = ("application",)
     list_select_related = ("application", "user")
+
+    def has_add_permission(self, request):
+        # ID tokens are issued by the OIDC flows, not hand-created in the admin.
+        return False
 
 
 class RefreshTokenAdmin(admin.ModelAdmin):
-    list_display = ("token", "user", "application")
+    list_display = ("pk", "masked_token", "user", "application")
     list_select_related = ("application", "user")
     raw_id_fields = ("user", "access_token")
-    search_fields = ("token",) + (("user__email",) if has_email else ())
+    # Search by non-secret identifiers only; never by the token itself.
+    search_fields = ("application__client_id", "application__name") + USER_SEARCH_FIELDS
     list_filter = ("application",)
+
+    def has_add_permission(self, request):
+        # Refresh tokens are issued by the OAuth flows, not hand-created in the admin.
+        return False
+
+    def get_exclude(self, request, obj=None):
+        # Hide the raw token on the change/view form. Adding is disabled (see
+        # has_add_permission), so the add form is unreachable; guarding on obj keeps this
+        # correct if a subclass ever re-enables it. Extend, rather than replace, any exclude
+        # configured on a subclass.
+        exclude = tuple(super().get_exclude(request, obj) or ())
+        if obj is not None and "token" not in exclude:
+            exclude += ("token",)
+        return exclude
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly_fields = tuple(super().get_readonly_fields(request, obj))
+        if obj is not None and "masked_token" not in readonly_fields:
+            readonly_fields += ("masked_token",)
+        return readonly_fields
+
+    @admin.display(description="token")
+    def masked_token(self, obj):
+        return mask_credential(obj.token) if obj is not None else ""
 
 
 application_model = get_application_model()

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -367,7 +367,9 @@ class AbstractGrant(models.Model):
         return uri == self.redirect_uri
 
     def __str__(self):
-        return self.code
+        # Never render the authorization code itself: __str__ appears in the admin
+        # change page/breadcrumbs, in repr() within tracebacks, and in log output.
+        return "Grant #{self.pk}".format(self=self)
 
     class Meta:
         abstract = True
@@ -483,7 +485,9 @@ class AbstractAccessToken(models.Model):
         return {name: desc for name, desc in all_scopes.items() if name in token_scopes}
 
     def __str__(self):
-        return self.token
+        # Never render the token itself: __str__ appears in the admin change
+        # page/breadcrumbs, in repr() within tracebacks, and in log output.
+        return "AccessToken #{self.pk}".format(self=self)
 
     class Meta:
         abstract = True
@@ -555,7 +559,9 @@ class AbstractRefreshToken(models.Model):
             self.save()
 
     def __str__(self):
-        return self.token
+        # Never render the token itself: __str__ appears in the admin change
+        # page/breadcrumbs, in repr() within tracebacks, and in log output.
+        return "RefreshToken #{self.pk}".format(self=self)
 
     class Meta:
         abstract = True

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,136 @@
+"""
+Tests for the default admin classes, ensuring that cleartext bearer tokens and
+authorization codes are never exposed verbatim (in ``list_display``, in the
+change/view form, or via ``__str__``) nor made searchable (in ``search_fields``,
+which would leak them into the ``?q=`` query string and therefore into access
+logs / browser history).
+"""
+
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from oauth2_provider.admin import (
+    AccessTokenAdmin,
+    GrantAdmin,
+    IDTokenAdmin,
+    RefreshTokenAdmin,
+    mask_credential,
+)
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_grant_model,
+    get_id_token_model,
+    get_refresh_token_model,
+)
+
+
+def _admin_form_fields(admin_class, model, obj):
+    """
+    Return the fields the admin form would render. Pass ``obj=None`` for the add
+    form and an instance for the change/view form (the two can differ).
+    """
+    request = RequestFactory().get("/")
+    model_admin = admin_class(model, AdminSite())
+    return list(model_admin.get_form(request, obj=obj).base_fields)
+
+
+def test_mask_credential_hides_the_secret():
+    # A long value reveals only its last few characters.
+    assert mask_credential("abcdef1234567890") == "…7890"
+    # Short (non-empty) values are fully masked and reveal nothing.
+    assert mask_credential("short") == "…"
+    # Falsy values are returned unchanged (nothing to mask).
+    assert mask_credential("") == ""
+    assert mask_credential(None) is None
+    # Boundary: a value just over the old 6-char threshold must not reveal most of itself.
+    assert mask_credential("abcdefg") == "…"
+    # Boundary: just below the minimum reveal length is still fully masked.
+    assert mask_credential("a" * 15) == "…"
+    # At the minimum length only the last few characters are shown.
+    assert mask_credential("b" * 16) == "…bbbb"
+    # The full secret is never returned, regardless of length.
+    for secret in ("abcdefg", "supersecrettokenvalue", "x" * 40):
+        assert secret not in mask_credential(secret)
+
+
+def _assert_hidden_on_change_form(admin_class, model, field, masked_field):
+    site = AdminSite()
+    model_admin = admin_class(model, site)
+    request = RequestFactory().get("/")
+    obj = model()  # a (dummy) instance -> change-form context, not the add form
+    # The raw secret field is not rendered on the change/view form; a masked value is shown.
+    assert field not in _admin_form_fields(admin_class, model, obj=obj)
+    assert masked_field in model_admin.get_readonly_fields(request, obj=obj)
+    # masked_* must be safe to render even for an unsaved / None object.
+    assert getattr(model_admin, masked_field)(None) == ""
+    # Adding credentials via the admin is disabled; they are issued by the OAuth flows.
+    assert model_admin.has_add_permission(request) is False
+
+
+def test_credential_admins_disable_add():
+    """Credential models must not be hand-created in the admin (issued by the OAuth flows)."""
+    request = RequestFactory().get("/")
+    for admin_class, model in (
+        (AccessTokenAdmin, get_access_token_model()),
+        (RefreshTokenAdmin, get_refresh_token_model()),
+        (GrantAdmin, get_grant_model()),
+        (IDTokenAdmin, get_id_token_model()),
+    ):
+        model_admin = admin_class(model, AdminSite())
+        assert model_admin.has_add_permission(request) is False
+
+
+def test_admin_overrides_preserve_subclass_config():
+    """get_exclude/get_readonly_fields extend, rather than replace, a subclass's config."""
+
+    class CustomAccessTokenAdmin(AccessTokenAdmin):
+        exclude = ("expires",)
+        readonly_fields = ("created",)
+
+    model = get_access_token_model()
+    model_admin = CustomAccessTokenAdmin(model, AdminSite())
+    request = RequestFactory().get("/")
+    obj = model()
+
+    exclude = model_admin.get_exclude(request, obj=obj)
+    assert "expires" in exclude  # subclass configuration is preserved ...
+    assert "token" in exclude  # ... and our secret-hiding is still applied
+
+    readonly = model_admin.get_readonly_fields(request, obj=obj)
+    assert "created" in readonly
+    assert "masked_token" in readonly
+
+
+def _assert_searchable_by_app_and_user(admin_class):
+    # Search stays available by non-secret application identifiers ...
+    assert "application__client_id" in admin_class.search_fields
+    assert "application__name" in admin_class.search_fields
+    # ... and by a non-secret user identifier (the USERNAME_FIELD, e.g. "username").
+    assert any(field.startswith("user__") for field in admin_class.search_fields)
+
+
+def test_access_token_admin_does_not_expose_token():
+    assert "token" not in AccessTokenAdmin.list_display
+    assert "token" not in AccessTokenAdmin.search_fields
+    _assert_searchable_by_app_and_user(AccessTokenAdmin)
+    _assert_hidden_on_change_form(AccessTokenAdmin, get_access_token_model(), "token", "masked_token")
+
+
+def test_refresh_token_admin_does_not_expose_token():
+    assert "token" not in RefreshTokenAdmin.list_display
+    assert "token" not in RefreshTokenAdmin.search_fields
+    _assert_searchable_by_app_and_user(RefreshTokenAdmin)
+    _assert_hidden_on_change_form(RefreshTokenAdmin, get_refresh_token_model(), "token", "masked_token")
+
+
+def test_grant_admin_does_not_expose_code():
+    assert "code" not in GrantAdmin.list_display
+    assert "code" not in GrantAdmin.search_fields
+    _assert_searchable_by_app_and_user(GrantAdmin)
+    _assert_hidden_on_change_form(GrantAdmin, get_grant_model(), "code", "masked_code")
+
+
+def test_id_token_admin_searchable_by_app_and_user():
+    # IDTokenAdmin holds no cleartext replayable secret, but its search should stay
+    # consistent with the other credential admins (and non-empty on custom user models).
+    _assert_searchable_by_app_and_user(IDTokenAdmin)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -138,6 +138,45 @@ class TestModels(BaseTestModels):
         app.name = "test_app"
         self.assertEqual("%s" % app, "test_app")
 
+    def test_credential_models_str_do_not_leak_secrets(self):
+        app = Application.objects.create(
+            name="test_app",
+            redirect_uris="http://example.org",
+            user=self.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            scope="read",
+            expires=timezone.now() + timedelta(seconds=60),
+            token="secret-access-token-value",
+            application=app,
+        )
+        refresh_token = RefreshToken.objects.create(
+            user=self.user,
+            token="secret-refresh-token-value",
+            application=app,
+            access_token=access_token,
+        )
+        grant = Grant.objects.create(
+            user=self.user,
+            code="secret-grant-code-value",
+            application=app,
+            expires=timezone.now() + timedelta(seconds=60),
+            redirect_uri="http://example.org",
+            scope="read",
+        )
+
+        # __str__ is rendered in the admin change page/breadcrumbs, repr(), and logs;
+        # it must identify the row by pk without exposing the credential.
+        self.assertNotIn("secret-access-token-value", str(access_token))
+        self.assertIn(str(access_token.pk), str(access_token))
+        self.assertNotIn("secret-refresh-token-value", str(refresh_token))
+        self.assertIn(str(refresh_token.pk), str(refresh_token))
+        self.assertNotIn("secret-grant-code-value", str(grant))
+        self.assertIn(str(grant.pk), str(grant))
+
     def test_scopes_property(self):
         self.client.login(username="test_user", password="123456")
 
@@ -284,8 +323,10 @@ class TestGrantModel(BaseTestModels):
         )
 
     def test_str(self):
+        # __str__ must identify the row without exposing the authorization code.
         grant = Grant(code="test_code")
-        self.assertEqual("%s" % grant, grant.code)
+        self.assertNotIn("test_code", "%s" % grant)
+        self.assertEqual("%s" % grant, "Grant #{}".format(grant.pk))
 
     def test_expires_can_be_none(self):
         grant = Grant(code="test_code")
@@ -313,8 +354,10 @@ class TestGrantModel(BaseTestModels):
 
 class TestAccessTokenModel(BaseTestModels):
     def test_str(self):
+        # __str__ must identify the row without exposing the token.
         access_token = AccessToken(token="test_token")
-        self.assertEqual("%s" % access_token, access_token.token)
+        self.assertNotIn("test_token", "%s" % access_token)
+        self.assertEqual("%s" % access_token, "AccessToken #{}".format(access_token.pk))
 
     def test_user_can_be_none(self):
         app = Application.objects.create(
@@ -357,8 +400,10 @@ class TestRefreshTokenModel(BaseTestModels):
         )
 
     def test_str(self):
+        # __str__ must identify the row without exposing the token.
         refresh_token = RefreshToken(token="test_token")
-        self.assertEqual("%s" % refresh_token, refresh_token.token)
+        self.assertNotIn("test_token", "%s" % refresh_token)
+        self.assertEqual("%s" % refresh_token, "RefreshToken #{}".format(refresh_token.pk))
 
     def test_token_checksum_field(self):
         token = secrets.token_urlsafe(32)


### PR DESCRIPTION
Fixes #

## Description of the Change

`AccessTokenAdmin`, `RefreshTokenAdmin`, and `GrantAdmin` listed the raw
`token`/`code` in `list_display` and included them in `search_fields`. These
values are stored in cleartext, so any staff user with view access saw live,
replayable bearer credentials — and searching by them placed the secret in the
`?q=` query string, which is captured by web-server access logs and browser
history. The raw secret was also reachable on the change/view form (the model
field is editable) and via the models' `__str__`.

### Changes

* **List view:** the `token`/`code` columns are now masked (a non-editable
  display method that reveals only a short suffix of long values and fully masks
  short ones) and removed from `search_fields`.
* **Change/view form:** the raw `token`/`code` field is excluded and only the
  masked read-only value is shown. These overrides *extend* rather than replace
  any `exclude`/`readonly_fields` configured on a subclass.
* **Add form:** `has_add_permission()` returns `False` on every credential admin
  (`AccessTokenAdmin`, `RefreshTokenAdmin`, `GrantAdmin`, `IDTokenAdmin`) —
  tokens/codes/ID tokens are issued by the OAuth/OIDC flows, not hand-created in
  the admin, so there is no add form on which a cleartext field could appear.
* **`__str__`:** `AccessToken`, `RefreshToken`, and `Grant` no longer return the
  raw secret (which surfaced in the admin change-page header/breadcrumbs); they
  return a `"<Model> #<pk>"` identifier instead.
* **Search:** stays available by non-secret identifiers only — application
  `client_id`/`name` and a user identifier (the `USERNAME_FIELD`, with `email`
  when present) via the shared `USER_SEARCH_FIELDS`. `IDTokenAdmin.search_fields`
  is switched to the same helper so search stays consistent and non-empty on
  custom user models without an `email` field.

Unit tests assert the raw fields are absent from `list_display`/`search_fields`,
that the raw field is excluded from the change form while the masked read-only
value is shown, that the masking never returns the full secret (including
boundary lengths), that adding is disabled on every credential admin, and that
the form overrides preserve a subclass's own `exclude`/`readonly_fields`.

One of a batch of five hardening PRs (H1–H5) from a security review of the provider.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGRuhUKB9BDp1pvwDf5i5o)_