### PR TITLE
security: reject HS256 signing with a hashed client secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   relying party holding the real (plaintext) secret could never verify the signature — and a
   password hash was misused as a MAC key. `HS256` now requires `hash_client_secret=False`:
   `Application.clean()` rejects the combination, and `jwk_key` raises `ImproperlyConfigured`
-  rather than emit an unverifiable token. See the breaking-changes note below.
+  rather than emit an unverifiable token. `HS256` with an empty client secret is likewise rejected
+  (an empty HMAC key would make ID tokens trivially forgeable). See the breaking-changes note below.
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
   *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken`, and `Grant` model `__str__` methods no longer return the raw token/code (which the
   admin renders in a row's change-page title and breadcrumbs, and which also appears in `repr()` and
   logs); they now return a `"<Model> #<pk>"` identifier.
+* Fix HS256-signed ID tokens being signed with the *hashed* client secret. When an application
+  used the `HS256` algorithm with `hash_client_secret=True` (the default), the ID token was signed
+  with the stored password-hash string as the HMAC key instead of the shared client secret, so a
+  relying party holding the real (plaintext) secret could never verify the signature — and a
+  password hash was misused as a MAC key. `HS256` now requires `hash_client_secret=False`:
+  `Application.clean()` rejects the combination, and `jwk_key` raises `ImproperlyConfigured`
+  rather than emit an unverifiable token. See the breaking-changes note below.
 * Fix an unauthenticated open redirect from the authorization endpoint. A `prompt=none` request from
   an unauthenticated user was redirected to the supplied `redirect_uri` with a `login_required` error
   *before* the client and `redirect_uri` were validated, allowing an attacker to redirect a victim's
@@ -60,6 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Reported by Brian Lee (SSLab, Georgia Tech).
 
 ### WARNING - POTENTIAL BREAKING CHANGES
+* Applications using the `HS256` signing algorithm must now be configured with
+  `hash_client_secret=False`. Previously such applications signed ID tokens with the hashed client
+  secret, producing tokens that relying parties could not verify. `Application.clean()` now raises a
+  `ValidationError` for `HS256` + `hash_client_secret=True`, and `Application.jwk_key` raises
+  `ImproperlyConfigured` at signing time if the secret is hashed. To migrate an affected
+  application, recreate it (or reset its secret) with `hash_client_secret=False` so the plaintext
+  secret is stored and can be used as the shared HMAC key.
 * Changes to the `AbstractRefreshToken` model require doing a `manage.py migrate` after upgrading.
 * If you use a swapped refresh token model (`OAUTH2_PROVIDER_REFRESH_TOKEN_MODEL`) you will need to
   update your custom model with `manage.py makemigrations`. If your table already contains refresh

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -263,12 +263,17 @@ class AbstractApplication(models.Model):
                 )
             ):
                 raise ValidationError(_("You cannot use HS256 with public grants or clients"))
-            if self.hash_client_secret:
+            # For HS256 the client secret is the shared HMAC signing key, so it must be stored
+            # unhashed. Reject both the intent to hash (the flag) and an already-hashed stored
+            # value (e.g. the flag was toggled after the secret was hashed, or a legacy row), so
+            # the misconfiguration surfaces here instead of only failing later at signing time.
+            if self.hash_client_secret or self._client_secret_is_hashed(self.client_secret):
                 raise ValidationError(
                     _(
                         "You cannot use HS256 with a hashed client secret. For HS256 the client "
                         "secret is the shared signing key and must be stored unhashed so the relying "
-                        "party can verify the token; set hash_client_secret=False on this application."
+                        "party can verify the token; set hash_client_secret=False and store an "
+                        "unhashed client_secret on this application."
                     )
                 )
 
@@ -293,6 +298,15 @@ class AbstractApplication(models.Model):
         """
         return True
 
+    @staticmethod
+    def _client_secret_is_hashed(client_secret):
+        """Return True if the stored client secret is a Django password hash."""
+        try:
+            identify_hasher(client_secret)
+        except ValueError:
+            return False
+        return True
+
     @property
     def jwk_key(self):
         if self.algorithm == AbstractApplication.RS256_ALGORITHM:
@@ -300,18 +314,15 @@ class AbstractApplication(models.Model):
                 raise ImproperlyConfigured("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm")
             return jwk_from_pem(oauth2_settings.OIDC_RSA_PRIVATE_KEY)
         elif self.algorithm == AbstractApplication.HS256_ALGORITHM:
-            try:
-                identify_hasher(self.client_secret)
-            except ValueError:
-                # Not hashed: the secret is usable directly as the HS256 shared signing key.
-                return jwk.JWK(kty="oct", k=base64url_encode(self.client_secret))
             # A hashed secret would sign tokens with the password hash string as the HMAC key,
             # which the relying party (holding the plaintext secret) can never verify.
-            raise ImproperlyConfigured(
-                "HS256 signing requires the plaintext client secret as the HMAC key, but this "
-                "application's client secret is hashed. Recreate the application with "
-                "hash_client_secret=False."
-            )
+            if self._client_secret_is_hashed(self.client_secret):
+                raise ImproperlyConfigured(
+                    "HS256 signing requires the plaintext client secret as the HMAC key, but this "
+                    "application's client secret is hashed. Recreate the application with "
+                    "hash_client_secret=False."
+                )
+            return jwk.JWK(kty="oct", k=base64url_encode(self.client_secret))
         raise ImproperlyConfigured("This application does not support signed tokens")
 
 

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -263,6 +263,10 @@ class AbstractApplication(models.Model):
                 )
             ):
                 raise ValidationError(_("You cannot use HS256 with public grants or clients"))
+            if not self.client_secret:
+                raise ValidationError(
+                    _("You cannot use HS256 without a client secret; it is the HMAC signing key.")
+                )
             # For HS256 the client secret is the shared HMAC signing key, so it must be stored
             # unhashed. Reject both the intent to hash (the flag) and an already-hashed stored
             # value (e.g. the flag was toggled after the secret was hashed, or a legacy row), so
@@ -314,6 +318,12 @@ class AbstractApplication(models.Model):
                 raise ImproperlyConfigured("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm")
             return jwk_from_pem(oauth2_settings.OIDC_RSA_PRIVATE_KEY)
         elif self.algorithm == AbstractApplication.HS256_ALGORITHM:
+            # An empty secret would sign tokens with an empty HMAC key, which is trivially
+            # forgeable by anyone.
+            if not self.client_secret:
+                raise ImproperlyConfigured(
+                    "HS256 signing requires a non-empty client secret to use as the HMAC key."
+                )
             # A hashed secret would sign tokens with the password hash string as the HMAC key,
             # which the relying party (holding the plaintext secret) can never verify.
             if self._client_secret_is_hashed(self.client_secret):

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -263,6 +263,14 @@ class AbstractApplication(models.Model):
                 )
             ):
                 raise ValidationError(_("You cannot use HS256 with public grants or clients"))
+            if self.hash_client_secret:
+                raise ValidationError(
+                    _(
+                        "You cannot use HS256 with a hashed client secret. For HS256 the client "
+                        "secret is the shared signing key and must be stored unhashed so the relying "
+                        "party can verify the token; set hash_client_secret=False on this application."
+                    )
+                )
 
     def get_absolute_url(self):
         return reverse("oauth2_provider:detail", args=[str(self.pk)])
@@ -292,7 +300,18 @@ class AbstractApplication(models.Model):
                 raise ImproperlyConfigured("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm")
             return jwk_from_pem(oauth2_settings.OIDC_RSA_PRIVATE_KEY)
         elif self.algorithm == AbstractApplication.HS256_ALGORITHM:
-            return jwk.JWK(kty="oct", k=base64url_encode(self.client_secret))
+            try:
+                identify_hasher(self.client_secret)
+            except ValueError:
+                # Not hashed: the secret is usable directly as the HS256 shared signing key.
+                return jwk.JWK(kty="oct", k=base64url_encode(self.client_secret))
+            # A hashed secret would sign tokens with the password hash string as the HMAC key,
+            # which the relying party (holding the plaintext secret) can never verify.
+            raise ImproperlyConfigured(
+                "HS256 signing requires the plaintext client secret as the HMAC key, but this "
+                "application's client secret is hashed. Recreate the application with "
+                "hash_client_secret=False."
+            )
         raise ImproperlyConfigured("This application does not support signed tokens")
 
 

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -319,8 +319,8 @@ class AbstractApplication(models.Model):
             if self._client_secret_is_hashed(self.client_secret):
                 raise ImproperlyConfigured(
                     "HS256 signing requires the plaintext client secret as the HMAC key, but this "
-                    "application's client secret is hashed. Recreate the application with "
-                    "hash_client_secret=False."
+                    "application's client secret is hashed. Set hash_client_secret=False and reset "
+                    "the client_secret (or recreate the application) so the plaintext secret is stored."
                 )
             return jwk.JWK(kty="oct", k=base64url_encode(self.client_secret))
         raise ImproperlyConfigured("This application does not support signed tokens")

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -11,7 +11,8 @@ from django.test import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.crypto import get_random_string
-from jwcrypto import jwt
+from jwcrypto import jwk, jwt
+from jwcrypto.common import base64url_encode
 from oauthlib.oauth2.rfc6749 import errors as oauthlib_errors
 
 from oauth2_provider.models import (
@@ -2037,6 +2038,10 @@ class TestOIDCAuthorizationCodeHSAlgorithm(BaseAuthorizationCodeTokenView):
     def setUpTestData(cls):
         super().setUpTestData()
         cls.application.algorithm = Application.HS256_ALGORITHM
+        # HS256 uses the client secret as the HMAC signing key, so it must be stored
+        # unhashed for the relying party to be able to verify the ID token.
+        cls.application.hash_client_secret = False
+        cls.application.client_secret = CLEARTEXT_SECRET
         cls.application.save()
 
     def setUp(self):
@@ -2076,6 +2081,13 @@ class TestOIDCAuthorizationCodeHSAlgorithm(BaseAuthorizationCodeTokenView):
         jwt_token = jwt.JWT(key=key, jwt=content["id_token"])
         claims = json.loads(jwt_token.claims)
         assert claims["sub"] == str(self.test_user.pk)
+
+        # The ID token must be verifiable by a relying party holding the *plaintext* client
+        # secret (the shared HS256 key), not just by the server's own jwk_key. This fails if
+        # the token was signed with a hashed secret.
+        rp_key = jwk.JWK(kty="oct", k=base64url_encode(CLEARTEXT_SECRET))
+        rp_verified = jwt.JWT(key=rp_key, jwt=content["id_token"])
+        assert json.loads(rp_verified.claims)["sub"] == str(self.test_user.pk)
 
 
 @pytest.mark.oauth2_settings(presets.DEFAULT_SCOPES_RW)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -899,10 +899,25 @@ def test_application_key(oauth2_settings, application):
         application.jwk_key
     assert "You must set OIDC_RSA_PRIVATE_KEY" in str(exc.value)
 
-    # HS256 key
+    # HS256 key: the secret is the signing key, so it must be stored unhashed.
     application.algorithm = Application.HS256_ALGORITHM
+    application.hash_client_secret = False
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()
     key = application.jwk_key
     assert key.kty == "oct"
+
+    # HS256 with a hashed secret must fail loudly instead of signing a token the relying
+    # party (which holds the plaintext secret) could never verify.
+    application.hash_client_secret = True
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()
+    with pytest.raises(ImproperlyConfigured) as exc:
+        application.jwk_key
+    assert "hash_client_secret=False" in str(exc.value)
+    application.hash_client_secret = False
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()
 
     # No algorithm
     application.algorithm = Application.NO_ALGORITHM
@@ -923,9 +938,17 @@ def test_application_clean(oauth2_settings, application):
         application.clean()
     assert "You must set OIDC_RSA_PRIVATE_KEY" in str(exc.value)
 
-    # HS256 algorithm, auth code + confidential -> allowed
+    # HS256 algorithm, auth code + confidential, unhashed secret -> allowed
     application.algorithm = Application.HS256_ALGORITHM
+    application.hash_client_secret = False
     application.clean()
+
+    # HS256 with a hashed client secret -> forbidden (the secret is the HS256 signing key)
+    application.hash_client_secret = True
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert "hashed client secret" in str(exc.value)
+    application.hash_client_secret = False
 
     # HS256, auth code + public -> forbidden
     application.client_type = Application.CLIENT_PUBLIC

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -919,6 +919,15 @@ def test_application_key(oauth2_settings, application):
     application.client_secret = CLEARTEXT_SECRET
     application.save()
 
+    # HS256 with an empty secret must fail loudly rather than sign with an empty (forgeable) key.
+    application.client_secret = ""
+    application.save()
+    with pytest.raises(ImproperlyConfigured) as exc:
+        application.jwk_key
+    assert "non-empty client secret" in str(exc.value)
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()
+
     # No algorithm
     application.algorithm = Application.NO_ALGORITHM
     with pytest.raises(ImproperlyConfigured) as exc:
@@ -959,6 +968,14 @@ def test_application_clean(oauth2_settings, application):
     with pytest.raises(ValidationError) as exc:
         application.clean()
     assert "hashed client secret" in str(exc.value)
+
+    # HS256 with an empty client secret -> forbidden (the secret is the HMAC signing key)
+    application.hash_client_secret = False
+    application.client_secret = ""
+    application.save()
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert "without a client secret" in str(exc.value)
 
     # restore an unhashed secret for the remaining assertions
     application.client_secret = CLEARTEXT_SECRET

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -941,14 +941,28 @@ def test_application_clean(oauth2_settings, application):
     # HS256 algorithm, auth code + confidential, unhashed secret -> allowed
     application.algorithm = Application.HS256_ALGORITHM
     application.hash_client_secret = False
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()
     application.clean()
 
-    # HS256 with a hashed client secret -> forbidden (the secret is the HS256 signing key)
+    # HS256 with hash_client_secret=True -> forbidden (the secret is the HS256 signing key)
     application.hash_client_secret = True
     with pytest.raises(ValidationError) as exc:
         application.clean()
     assert "hashed client secret" in str(exc.value)
+
+    # HS256 with an already-hashed stored secret is rejected even when the flag is False
+    # (e.g. the flag was toggled after the secret had already been hashed).
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()  # hash_client_secret is still True here, so this stores a hashed secret
     application.hash_client_secret = False
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert "hashed client secret" in str(exc.value)
+
+    # restore an unhashed secret for the remaining assertions
+    application.client_secret = CLEARTEXT_SECRET
+    application.save()
 
     # HS256, auth code + public -> forbidden
     application.client_type = Application.CLIENT_PUBLIC


### PR DESCRIPTION
Fixes #

## Description of the Change

For HS256, the client secret is the shared HMAC signing key. With the default
`hash_client_secret=True`, the secret is stored as a Django password hash, so
`Application.jwk_key` signed ID tokens with the **hash string** as the HMAC key. A
relying party holding the real (plaintext) secret can never verify that signature,
and a password hash is misused as a MAC key (OIDC Core §16.19 / RFC 7515).

This went unnoticed because the project's own HS256 test only ever verified with
`jwk_key` — i.e. the same hashed key the server signed with — never from the RP's
perspective.

### Change

HS256 now requires `hash_client_secret=False`:

- `Application.clean()` raises a `ValidationError` for `HS256` + hashed secret.
- `Application.jwk_key` raises `ImproperlyConfigured` (instead of emitting an
  unverifiable token) if the stored secret is hashed.

The HS256 tests now provision the application with an unhashed secret and
additionally verify the ID token with a key constructed independently from the
plaintext secret (the relying party's view), so an unverifiable token would fail
the test.

> **Note — behaviour change.** Existing applications using HS256 with the default
> hashed secret must be recreated (or have their secret reset) with
> `hash_client_secret=False`. This is documented under
> *WARNING - POTENTIAL BREAKING CHANGES* in `CHANGELOG.md`. Happy to adjust the
> approach (e.g. a deprecation cycle, or auto-coercing the flag) if you'd prefer a
> softer migration path for the 3.4 milestone.

One of a batch of five hardening PRs (H1–H5) from a security review of the provider.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGRuhUKB9BDp1pvwDf5i5o)_