### PR TITLE
fix: build rw_protected_resource required scopes per request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   release.
 
 ### Fixed
+* Fix the `rw_protected_resource` decorator accumulating the read/write scope on a shared list
+  across requests. The required-scope list was built once at decoration time and appended to on
+  every request, so after a write (`POST`) request the `write` scope stayed in the list and a
+  subsequent read (`GET`) request with a read-only token was wrongly rejected. The behaviour was
+  request-order dependent, not thread-safe, and also mutated a caller-supplied `scopes` list. The
+  read/write scope is now added to a fresh per-request list.
 * #1693 `AbstractDeviceGrant.scope` is now a `TextField(blank=True)` like the other grant and token
   models, instead of `CharField(max_length=64, null=True)`. 64 characters is well below the limits
   common in the broader OAuth ecosystem (Okta allows 1024, Google 2048), so longer scope strings

--- a/oauth2_provider/decorators.py
+++ b/oauth2_provider/decorators.py
@@ -67,16 +67,19 @@ def rw_protected_resource(scopes=None, validator_cls=OAuth2Validator, server_cls
                     " to be in OAUTH2_PROVIDER['SCOPES'] list in settings".format(read_write_scopes)
                 )
 
-            # Check if method is safe
+            # Check if method is safe. Build a fresh list per request so the read/write
+            # scope is not appended to the shared, decoration-time `_scopes` list (which
+            # would accumulate across requests and eventually reject valid tokens, and
+            # would also mutate a caller-supplied `scopes` argument).
             if request.method.upper() in ["GET", "HEAD", "OPTIONS"]:
-                _scopes.append(oauth2_settings.READ_SCOPE)
+                required_scopes = _scopes + [oauth2_settings.READ_SCOPE]
             else:
-                _scopes.append(oauth2_settings.WRITE_SCOPE)
+                required_scopes = _scopes + [oauth2_settings.WRITE_SCOPE]
 
             # proceed with validation
             validator = validator_cls()
             core = OAuthLibCore(server_cls(validator))
-            valid, oauthlib_req = core.verify_request(request, scopes=_scopes)
+            valid, oauthlib_req = core.verify_request(request, scopes=required_scopes)
             if valid:
                 request.resource_owner = oauthlib_req.user
                 return view_func(request, *args, **kwargs)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -89,3 +89,49 @@ class TestProtectedResourceDecorator(TestCase):
         request = self.request_factory.get("/fake-resource", **auth_headers)
         response = scoped_view(request)
         self.assertEqual(response.status_code, 403)
+
+    def test_rw_protected_scopes_not_polluted_across_requests(self):
+        """
+        Regression test: the read/write scope must not accumulate on a shared list
+        across requests. A prior write (POST) request must not cause a later read
+        (GET) request made with a read-only token to be rejected.
+        """
+        self.access_token.scope = "exotic_scope read"
+        self.access_token.save()
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.access_token.token,
+        }
+
+        @rw_protected_resource(scopes=["exotic_scope"])
+        def scoped_view(request, *args, **kwargs):
+            return "protected contents"
+
+        # POST requires the write scope, which this token does not have -> denied.
+        request = self.request_factory.post("/fake-resource", **auth_headers)
+        response = scoped_view(request)
+        self.assertEqual(response.status_code, 403)
+
+        # A subsequent GET requires only the read scope, which this token has.
+        # With the scope-list-mutation bug, the "write" scope appended by the POST
+        # above would still be required here and this would wrongly return 403.
+        request = self.request_factory.get("/fake-resource", **auth_headers)
+        response = scoped_view(request)
+        self.assertEqual(response, "protected contents")
+
+    def test_rw_protected_does_not_mutate_scopes_argument(self):
+        """The caller-supplied ``scopes`` list must never be mutated by a request."""
+        scopes_arg = ["exotic_scope"]
+
+        @rw_protected_resource(scopes=scopes_arg)
+        def scoped_view(request, *args, **kwargs):
+            return "protected contents"
+
+        self.access_token.scope = "exotic_scope read"
+        self.access_token.save()
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.access_token.token,
+        }
+        request = self.request_factory.get("/fake-resource", **auth_headers)
+        scoped_view(request)
+
+        self.assertEqual(scopes_arg, ["exotic_scope"])


### PR DESCRIPTION
Fixes #

## Description of the Change

`rw_protected_resource` bound its required-scope list once at decoration time
(`_scopes = scopes or []`) and then appended the read or write scope to it on
**every** request. The list accumulated across requests: after a `POST` added
`write`, a later `GET` made with a read-only token was rejected because `write`
was still in the required list. The behaviour was request-order dependent, not
thread-safe, and additionally mutated any caller-supplied `scopes` list.

The read/write scope is now added to a fresh per-request list, leaving `_scopes`
untouched.

Regression tests cover both the cross-request pollution (a `POST` must not cause a
later read-only `GET` to fail) and the caller's `scopes` argument not being
mutated. Verified that both tests fail against the previous implementation.

One of a batch of five hardening PRs (H1–H5) from a security review of the provider.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features


---
_Generated by [Claude Code](https://claude.ai/code/session_01UGRuhUKB9BDp1pvwDf5i5o)_