### PR TITLE
feat: add ALLOW_LOCALHOST_LOOPBACK for RFC 8252 loopback redirect URIs

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -101,6 +101,7 @@ Matej Spiller Muys
 Matias Seniquiel
 Michael Howitz
 Michael "Irish" O'Neill
+Nils Caspar
 Owen Gong
 Patrick Palacin
 Paul Dekkers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `DynamicClientRegistrationManagementView` with configurable permission classes and registration access
   tokens. Dynamically registered applications are flagged with a new `AbstractApplication.dcr_created`
   field and can be filtered in the Django admin.
+* #1739 `ALLOW_LOCALHOST_LOOPBACK` setting to extend the RFC 8252 §7.3 any-port loopback exemption to `http://localhost` redirect URIs (opt-in, default `False`)
 
 ### Security
 * Generate device-flow `user_code` values with the cryptographically secure `secrets` module

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -83,6 +83,29 @@ For example,
 This feature is useful for working with CI service such as cloudflare, netlify, and vercel that offer branch
 deployments for development previews and user acceptance testing.
 
+ALLOW_LOCALHOST_LOOPBACK
+~~~~~~~~~~~~~~~~~~~~~~~~~
+Default: ``False``
+
+`RFC 8252 section 7.3 <https://datatracker.ietf.org/doc/html/rfc8252#section-7.3>`_ requires the
+authorization server to accept any port on a loopback ``redirect_uri`` at request time, so a native
+app can bind whatever ephemeral port the OS assigns. The toolkit applies that exemption to the loopback
+IP literals ``127.0.0.1`` and ``[::1]`` unconditionally. `Section 8.3
+<https://datatracker.ietf.org/doc/html/rfc8252#section-8.3>`_ notes that ``localhost`` redirect URIs
+"function similarly" but that their use is NOT RECOMMENDED, so ``localhost`` is *not* granted the
+any-port exemption by default.
+
+Some native clients nonetheless register ``http://localhost/callback`` and then receive the callback on
+an ephemeral port. When set to ``True``, the ``http://localhost`` hostname is treated as loopback and
+granted the same any-port exemption as the IP literals. The hostname must still match exactly, so
+``localhost`` is never conflated with ``127.0.0.1`` / ``[::1]``, and scheme, path, and query matching
+are unchanged.
+
+SECURITY WARNING: Per RFC 8252 section 8.3, prefer registering the loopback IP literals over
+``localhost``: a ``localhost`` redirect can resolve to a non-loopback interface on a host with
+misconfigured name resolution, whereas ``127.0.0.1`` / ``[::1]`` cannot. Only enable this if you must
+support clients that register ``localhost``.
+
 ALLOWED_SCHEMES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Default: ``["https"]``

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1001,10 +1001,18 @@ def redirect_to_uri_allowed(uri, allowed_uris):
         # time of the request for loopback IP redirect URIs, to accommodate
         # clients that obtain an available ephemeral port from the operating
         # system at the time of the request.
-        allowed_uri_is_loopback = parsed_allowed_uri.scheme == "http" and parsed_allowed_uri.hostname in [
-            "127.0.0.1",
-            "::1",
-        ]
+        #
+        # Section 8.3 notes that "localhost" redirect URIs "function similarly
+        # to loopback IP redirects" but their use is NOT RECOMMENDED, so the
+        # port exemption is not extended to the "localhost" hostname by
+        # default.  Some native clients nonetheless register "localhost" and
+        # receive the callback on an ephemeral port; ALLOW_LOCALHOST_LOOPBACK
+        # opts in to treating it as loopback.  The hostname must still match
+        # exactly, so "localhost" is never conflated with the IP literals.
+        allowed_uri_is_loopback = parsed_allowed_uri.scheme == "http" and (
+            parsed_allowed_uri.hostname in ("127.0.0.1", "::1")
+            or (oauth2_settings.ALLOW_LOCALHOST_LOOPBACK and parsed_allowed_uri.hostname == "localhost")
+        )
         """ check port """
         if not allowed_uri_is_loopback and parsed_allowed_uri.port != parsed_uri.port:
             continue

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -83,6 +83,7 @@ DEFAULTS = {
     "ALLOWED_REDIRECT_URI_SCHEMES": ["http", "https"],
     "ALLOWED_SCHEMES": ["https"],
     "ALLOW_URI_WILDCARDS": False,
+    "ALLOW_LOCALHOST_LOOPBACK": False,
     "OIDC_ENABLED": False,
     "OIDC_ISS_ENDPOINT": "",
     "OIDC_USERINFO_ENDPOINT": "",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1124,3 +1124,48 @@ invalid_wildcard_redirect_to_params = [
 def test_wildcard_redirect_to_uri_allowed_invalid(uri, allowed_uri, oauth2_settings):
     oauth2_settings.ALLOW_URI_WILDCARDS = True
     assert not redirect_to_uri_allowed(uri, allowed_uri)
+
+
+def test_localhost_loopback_port_mismatch_rejected_by_default():
+    # Default (ALLOW_LOCALHOST_LOOPBACK off): only the 127.0.0.1/::1 literals
+    # get the RFC 8252 any-port exemption; "localhost" keeps strict matching.
+    assert not redirect_to_uri_allowed("http://localhost:49152/callback", ["http://localhost/callback"])
+    # ...and the IP literals keep the exemption regardless of the setting.
+    assert redirect_to_uri_allowed("http://127.0.0.1:49152/callback", ["http://127.0.0.1/callback"])
+    assert redirect_to_uri_allowed("http://[::1]:49152/callback", ["http://[::1]/callback"])
+
+
+valid_localhost_loopback_params = [
+    # RFC 8252 §7.3 any-port exemption, extended to "localhost" when enabled.
+    ("http://localhost:49152/callback", ["http://localhost/callback"]),
+    ("http://localhost/callback", ["http://localhost/callback"]),
+    # urlparse lowercases the hostname, so the match is case-insensitive.
+    ("http://LOCALHOST:49152/callback", ["http://localhost/callback"]),
+]
+
+
+@pytest.mark.parametrize("uri, allowed_uri", valid_localhost_loopback_params)
+def test_localhost_loopback_redirect_allowed_when_enabled(uri, allowed_uri, oauth2_settings):
+    oauth2_settings.ALLOW_LOCALHOST_LOOPBACK = True
+    assert redirect_to_uri_allowed(uri, allowed_uri)
+
+
+invalid_localhost_loopback_params = [
+    # Path stays strict — a different callback path is a different endpoint.
+    ("http://localhost:49152/other", ["http://localhost/callback"]),
+    # https is not the RFC 8252 loopback shape; the exemption is http-only.
+    ("https://localhost:49152/callback", ["https://localhost/callback"]),
+    # No cross-spelling, both directions: the hostname must still match
+    # exactly, so "localhost" is never conflated with the IP literals.
+    ("http://127.0.0.1:49152/callback", ["http://localhost/callback"]),
+    ("http://localhost:49152/callback", ["http://127.0.0.1/callback"]),
+    ("http://localhost:49152/callback", ["http://[::1]/callback"]),
+    # A hostname merely containing "localhost" is not loopback.
+    ("http://localhost.evil.example:49152/callback", ["http://localhost/callback"]),
+]
+
+
+@pytest.mark.parametrize("uri, allowed_uri", invalid_localhost_loopback_params)
+def test_localhost_loopback_redirect_rejected_when_enabled(uri, allowed_uri, oauth2_settings):
+    oauth2_settings.ALLOW_LOCALHOST_LOOPBACK = True
+    assert not redirect_to_uri_allowed(uri, allowed_uri)


### PR DESCRIPTION
## What this does

Adds an opt-in `ALLOW_LOCALHOST_LOOPBACK` setting (default `False`) that extends the RFC 8252 §7.3 any-port loopback exemption to `http://localhost`. From the discussion in #1416.

§7.3 wants the auth server to accept any port on a loopback `redirect_uri` so a native app can bind an OS-assigned port. DOT applies that to the IP literals `127.0.0.1` / `[::1]` only. §8.3 says `localhost` "functions similarly" but is NOT RECOMMENDED, so `localhost` gets strict port matching today, which is a fine default. This just makes it opt-in-able.

## Where we hit it

You added DCR in #1728. We run the same DCR, and on top of it CIMD (Client ID Metadata Documents), which DOT doesn't have yet.

CIMD fixes the problem of abandoned DCR clients piling up: instead of a stored client record per registration that nobody ever cleans up, the `client_id` is just an HTTPS URL and the server reads the client metadata (including `redirect_uris`) out of the document it points at, on demand. Every install of a client shares the one URL, so there's nothing to accumulate.

That's also where this bites. The doc is published ahead of time, so it can't know the ephemeral port the client will bind at runtime. It just lists `http://localhost/callback`, no port. Then the client (Claude Code, VS Code) grabs an OS-assigned port and calls back on `http://localhost:49152/callback`. The ports don't match, `localhost` isn't one of the exempted literals, so consent gets rejected and the flow dies.

Plain DCR doesn't hit this, the client registers at request time so it can hand over whatever redirect URI it's actually using. CIMD can't, the doc is static.

## Notes

- Default `False`, so nothing changes unless you turn it on. The §8.3 "NOT RECOMMENDED" default stays for everyone else.
- Mirrors `ALLOW_URI_WILDCARDS`: same shape, a permissive relaxation of redirect-URI matching, read inline in the matcher, documented with a security note.
- No cross-spelling. `localhost` still has to match exactly, so it never gets conflated with `127.0.0.1` / `[::1]` (tested both ways). `http`-only, path and query matching unchanged.

## tests/app/idp and tests/app/rp

Didn't touch these. They register fixed redirect URIs and run full flows, and this only shows up with an ephemeral loopback port those harnesses don't bind. It's covered by unit tests on `redirect_to_uri_allowed`, same place `ALLOW_URI_WILDCARDS` is tested. Happy to add a demo if you'd rather.

## Checklist

- [x] PR only contains one change
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features (N/A, see above)
- [ ] tests/app/rp updated to demonstrate new features (N/A, see above)
