### PR TITLE
Share client_secret help-text UX between the admin and front-end application forms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The dynamic `client_secret` help text (added in #1635) is now shared by the Django admin
   application form as well as the front-end register/edit views. The `ApplicationAdmin` uses
   `ApplicationForm`, and a shared `oauth2_provider/js/application_form.js` updates the help text
-  live as the `hash_client_secret` checkbox is toggled on either surface.
+  live as the `hash_client_secret` checkbox is toggled on either surface. The application form
+  (admin and front-end) also warns immediately when the `HS256` algorithm is selected while the
+  client secret is — or will be — hashed, instead of only surfacing the error on save.
 
 ### Security
 * Generate device-flow `user_code` values with the cryptographically secure `secrets` module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   field and can be filtered in the Django admin.
 * #1739 `ALLOW_LOCALHOST_LOOPBACK` setting to extend the RFC 8252 §7.3 any-port loopback exemption to `http://localhost` redirect URIs (opt-in, default `False`)
 
+### Changed
+* The dynamic `client_secret` help text (added in #1635) is now shared by the Django admin
+  application form as well as the front-end register/edit views. The `ApplicationAdmin` uses
+  `ApplicationForm`, and a shared `oauth2_provider/js/application_form.js` updates the help text
+  live as the `hash_client_secret` checkbox is toggled on either surface.
+
 ### Security
 * Generate device-flow `user_code` values with the cryptographically secure `secrets` module
   instead of the predictable `random` module (Mersenne Twister). The `user_code` is a device

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README.rst LICENSE
 recursive-include oauth2_provider/templates *.html
+recursive-include oauth2_provider/static *
 prune rfcs

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
 
+from oauth2_provider.forms import ApplicationForm
 from oauth2_provider.models import (
     get_access_token_admin_class,
     get_access_token_model,
@@ -56,6 +57,10 @@ def mask_credential(value):
 
 
 class ApplicationAdmin(admin.ModelAdmin):
+    # Reuse the front-end ApplicationForm so the admin gets the same
+    # hash_client_secret-driven client_secret help text (and the shared
+    # application_form.js that updates it live as the checkbox is toggled).
+    form = ApplicationForm
     list_display = ("pk", "name", "user", "client_type", "authorization_grant_type", "dcr_created")
     list_filter = ("client_type", "authorization_grant_type", "skip_authorization", "dcr_created")
     radio_fields = {

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -44,6 +44,12 @@ class ConfirmLogoutForm(forms.Form):
 class ApplicationForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        # These run independently: the client_secret help handling may short-circuit
+        # (e.g. an already-hashed secret), but the HS256 warning must still be wired.
+        self._init_client_secret_help()
+        self._init_hs256_warning()
+
+    def _init_client_secret_help(self):
         # This form is normally bound to the (swappable) application model via
         # ``modelform_factory``; guard against field sets that omit client_secret.
         if "client_secret" not in self.fields:
@@ -96,6 +102,30 @@ class ApplicationForm(forms.ModelForm):
                     "data-client-secret-help-when-unhashed": self.client_secret_help_when_unhashed,
                 }
             )
+
+    def _init_hs256_warning(self):
+        # HS256 uses the client secret as the HMAC signing key, so the secret must be
+        # stored unhashed; Application.clean() rejects HS256 + a hashed secret, but only
+        # at save time. Expose what the shared application_form.js needs to warn live
+        # (as the algorithm / hash checkbox / secret change) so the misconfiguration is
+        # visible immediately rather than only after a failed save. Unlike the
+        # client_secret help above, this is wired even when the secret is already hashed
+        # -- that is exactly the case that needs the warning.
+        if "algorithm" not in self.fields:
+            return
+        model = type(self.instance)
+        stored_hashed = bool(self.instance and self.instance.pk and _is_hashed(self.instance.client_secret))
+        self.fields["algorithm"].widget.attrs.update(
+            {
+                "data-hs256-value": model.HS256_ALGORITHM,
+                "data-client-secret-stored-hashed": "true" if stored_hashed else "false",
+                "data-hs256-hashed-secret-warning": _(
+                    "HS256 signs tokens with the client secret as the HMAC key, so the secret must "
+                    "be stored unhashed. Uncheck “Hash client secret” and set an unhashed "
+                    "client secret, or choose a different algorithm."
+                ),
+            }
+        )
 
     class Media:
         js = ("oauth2_provider/js/application_form.js",)

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -124,6 +124,12 @@ class ApplicationForm(forms.ModelForm):
                     "be stored unhashed. Uncheck “Hash client secret” and set an unhashed "
                     "client secret, or choose a different algorithm."
                 ),
+                # Shown next to the hash_client_secret checkbox as well, so the conflict is
+                # flagged from both fields (application_form.js renders both).
+                "data-hs256-hash-checkbox-warning": _(
+                    "HS256 requires an unhashed client secret. Uncheck this and set an unhashed "
+                    "client secret, or choose a different algorithm."
+                ),
             }
         )
 

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -83,6 +83,22 @@ class ApplicationForm(forms.ModelForm):
             if self._will_hash_client_secret()
             else self.client_secret_help_when_unhashed
         )
+        # Expose both variants on the hash_client_secret checkbox as data-attributes
+        # so the shared application_form.js can swap the client_secret help text live
+        # as the box is toggled. Rendered identically by the front-end views and the
+        # Django admin, so both surfaces behave the same. Only emitted while the
+        # secret is still readable; the already-hashed branch returns above (there is
+        # nothing to toggle), leaving the checkbox without these attributes.
+        if "hash_client_secret" in self.fields:
+            self.fields["hash_client_secret"].widget.attrs.update(
+                {
+                    "data-client-secret-help-when-hashed": self.client_secret_help_when_hashed,
+                    "data-client-secret-help-when-unhashed": self.client_secret_help_when_unhashed,
+                }
+            )
+
+    class Media:
+        js = ("oauth2_provider/js/application_form.js",)
 
     def _will_hash_client_secret(self):
         """Whether the client secret will be hashed on save.

--- a/oauth2_provider/static/oauth2_provider/js/application_form.js
+++ b/oauth2_provider/static/oauth2_provider/js/application_form.js
@@ -70,14 +70,40 @@
         sync();
     }
 
+    // Style inline and toggle via style.display (not the hidden attribute or a CSS
+    // class): the admin's .errornote rule sets display:block, which would override
+    // [hidden]{display:none} and leave the warning always visible. Inline styles win
+    // regardless of the surrounding stylesheet.
+    function makeWarning(text) {
+        var el = document.createElement("div");
+        el.className = "oauth2-hs256-warning";
+        el.setAttribute("role", "alert");
+        el.style.display = "none";
+        el.style.margin = "6px 0";
+        el.style.padding = "6px 10px";
+        el.style.color = "#a94442";
+        el.style.border = "1px solid #a94442";
+        el.style.borderRadius = "4px";
+        el.textContent = text;
+        return el;
+    }
+
+    // Place the warning on its own line beneath the field's row rather than inline
+    // beside it (the admin lays each field out in a flex row, so an element inserted
+    // right after the input sits to its right).
+    function insertUnder(field, el) {
+        var row = field.closest(".form-row, .control-group, .fieldBox");
+        (row || field).insertAdjacentElement("afterend", el);
+    }
+
     function initHs256Warning() {
         var algorithmField = document.getElementById("id_algorithm");
         if (!algorithmField) {
             return;
         }
         var hs256 = algorithmField.getAttribute("data-hs256-value");
-        var warningText = algorithmField.getAttribute("data-hs256-hashed-secret-warning");
-        if (!hs256 || !warningText) {
+        var algorithmText = algorithmField.getAttribute("data-hs256-hashed-secret-warning");
+        if (!hs256 || !algorithmText) {
             return;
         }
 
@@ -89,21 +115,19 @@
         var storedHashed = algorithmField.getAttribute("data-client-secret-stored-hashed") === "true";
         var originalSecret = secretField ? secretField.value : "";
 
-        // Style inline and toggle via style.display (not the hidden attribute or a
-        // CSS class): the admin's .errornote rule sets display:block, which would
-        // override [hidden]{display:none} and leave the warning always visible.
-        // Inline styles win regardless of the surrounding stylesheet.
-        var warning = document.createElement("div");
-        warning.className = "oauth2-hs256-warning";
-        warning.setAttribute("role", "alert");
-        warning.style.display = "none";
-        warning.style.color = "#a94442";
-        warning.style.marginTop = "6px";
-        warning.style.padding = "6px 10px";
-        warning.style.border = "1px solid #a94442";
-        warning.style.borderRadius = "4px";
-        warning.textContent = warningText;
-        algorithmField.insertAdjacentElement("afterend", warning);
+        // Flag the conflict from both sides: under the algorithm select and next to the
+        // hash_client_secret checkbox.
+        var warnings = [];
+        var algorithmWarning = makeWarning(algorithmText);
+        insertUnder(algorithmField, algorithmWarning);
+        warnings.push(algorithmWarning);
+
+        if (hashField) {
+            var hashText = algorithmField.getAttribute("data-hs256-hash-checkbox-warning") || algorithmText;
+            var hashWarning = makeWarning(hashText);
+            insertUnder(hashField, hashWarning);
+            warnings.push(hashWarning);
+        }
 
         function secretWillBeHashed() {
             if (hashField && hashField.checked) {
@@ -117,7 +141,9 @@
 
         function sync() {
             var invalid = algorithmField.value === hs256 && secretWillBeHashed();
-            warning.style.display = invalid ? "" : "none";
+            warnings.forEach(function (warning) {
+                warning.style.display = invalid ? "" : "none";
+            });
         }
 
         algorithmField.addEventListener("change", sync);

--- a/oauth2_provider/static/oauth2_provider/js/application_form.js
+++ b/oauth2_provider/static/oauth2_provider/js/application_form.js
@@ -89,13 +89,20 @@
         var storedHashed = algorithmField.getAttribute("data-client-secret-stored-hashed") === "true";
         var originalSecret = secretField ? secretField.value : "";
 
+        // Style inline and toggle via style.display (not the hidden attribute or a
+        // CSS class): the admin's .errornote rule sets display:block, which would
+        // override [hidden]{display:none} and leave the warning always visible.
+        // Inline styles win regardless of the surrounding stylesheet.
         var warning = document.createElement("div");
-        warning.className = "help-block errornote oauth2-hs256-warning";
+        warning.className = "oauth2-hs256-warning";
         warning.setAttribute("role", "alert");
+        warning.style.display = "none";
         warning.style.color = "#a94442";
-        warning.style.marginTop = "4px";
+        warning.style.marginTop = "6px";
+        warning.style.padding = "6px 10px";
+        warning.style.border = "1px solid #a94442";
+        warning.style.borderRadius = "4px";
         warning.textContent = warningText;
-        warning.hidden = true;
         algorithmField.insertAdjacentElement("afterend", warning);
 
         function secretWillBeHashed() {
@@ -109,7 +116,8 @@
         }
 
         function sync() {
-            warning.hidden = !(algorithmField.value === hs256 && secretWillBeHashed());
+            var invalid = algorithmField.value === hs256 && secretWillBeHashed();
+            warning.style.display = invalid ? "" : "none";
         }
 
         algorithmField.addEventListener("change", sync);

--- a/oauth2_provider/static/oauth2_provider/js/application_form.js
+++ b/oauth2_provider/static/oauth2_provider/js/application_form.js
@@ -1,11 +1,19 @@
-// Live client-secret help text for the Application form.
+// Live client-secret UX for the Application form.
 //
 // Shared by the front-end register/update views and the Django admin change
-// form so both surfaces behave identically. The two help variants are exposed
-// by ApplicationForm as data-attributes on the hash_client_secret checkbox; as
-// the box is toggled we swap the message shown next to the client_secret field.
-// When those attributes are absent (e.g. an already-hashed secret that can no
-// longer be reverted) the server-rendered help text is left untouched.
+// form so both surfaces behave identically. It does two things:
+//
+//   1. Client-secret help text: the two help variants are exposed by
+//      ApplicationForm as data-attributes on the hash_client_secret checkbox; as
+//      the box is toggled we swap the message shown next to the client_secret
+//      field. When those attributes are absent (e.g. an already-hashed secret
+//      that can no longer be reverted) the server-rendered help is left as-is.
+//
+//   2. HS256 warning: HS256 signs tokens with the client secret as the HMAC key,
+//      so the secret must be stored unhashed (Application.clean() rejects the
+//      combination, but only at save time). When the algorithm is set to HS256
+//      while the secret is -- or will be -- hashed, we show an inline warning
+//      immediately, updating as the algorithm/checkbox/secret change.
 (function () {
     "use strict";
 
@@ -35,7 +43,7 @@
         return help;
     }
 
-    function init() {
+    function initClientSecretHelp() {
         var hashField = document.getElementById("id_hash_client_secret");
         var secretField = document.getElementById("id_client_secret");
         if (!hashField || !secretField) {
@@ -60,6 +68,63 @@
 
         hashField.addEventListener("change", sync);
         sync();
+    }
+
+    function initHs256Warning() {
+        var algorithmField = document.getElementById("id_algorithm");
+        if (!algorithmField) {
+            return;
+        }
+        var hs256 = algorithmField.getAttribute("data-hs256-value");
+        var warningText = algorithmField.getAttribute("data-hs256-hashed-secret-warning");
+        if (!hs256 || !warningText) {
+            return;
+        }
+
+        var hashField = document.getElementById("id_hash_client_secret");
+        var secretField = document.getElementById("id_client_secret");
+        // Whether the *stored* secret is already a hash (server-provided). An already
+        // hashed value stays hashed unless the user replaces it with a new plaintext
+        // secret, so unchecking the box alone does not clear the misconfiguration.
+        var storedHashed = algorithmField.getAttribute("data-client-secret-stored-hashed") === "true";
+        var originalSecret = secretField ? secretField.value : "";
+
+        var warning = document.createElement("div");
+        warning.className = "help-block errornote oauth2-hs256-warning";
+        warning.setAttribute("role", "alert");
+        warning.style.color = "#a94442";
+        warning.style.marginTop = "4px";
+        warning.textContent = warningText;
+        warning.hidden = true;
+        algorithmField.insertAdjacentElement("afterend", warning);
+
+        function secretWillBeHashed() {
+            if (hashField && hashField.checked) {
+                return true;
+            }
+            if (storedHashed && secretField && secretField.value === originalSecret) {
+                return true;
+            }
+            return false;
+        }
+
+        function sync() {
+            warning.hidden = !(algorithmField.value === hs256 && secretWillBeHashed());
+        }
+
+        algorithmField.addEventListener("change", sync);
+        if (hashField) {
+            hashField.addEventListener("change", sync);
+        }
+        if (secretField) {
+            secretField.addEventListener("input", sync);
+        }
+        sync();
+    }
+
+    function init() {
+        initClientSecretHelp();
+        initHs256Warning();
     }
 
     if (document.readyState === "loading") {

--- a/oauth2_provider/static/oauth2_provider/js/application_form.js
+++ b/oauth2_provider/static/oauth2_provider/js/application_form.js
@@ -1,0 +1,70 @@
+// Live client-secret help text for the Application form.
+//
+// Shared by the front-end register/update views and the Django admin change
+// form so both surfaces behave identically. The two help variants are exposed
+// by ApplicationForm as data-attributes on the hash_client_secret checkbox; as
+// the box is toggled we swap the message shown next to the client_secret field.
+// When those attributes are absent (e.g. an already-hashed secret that can no
+// longer be reverted) the server-rendered help text is left untouched.
+(function () {
+    "use strict";
+
+    function findHelp(secretField) {
+        // Django admin renders <div class="help" id="<field-id>_helptext">.
+        var byId = document.getElementById(secretField.id + "_helptext");
+        if (byId) {
+            return byId;
+        }
+        // Front-end application_form.html renders <span class="help-block"> in
+        // the field's .controls wrapper.
+        var controls = secretField.closest(".controls");
+        if (controls) {
+            return controls.querySelector(".help-block");
+        }
+        return null;
+    }
+
+    function textTarget(help) {
+        // Newer Django admin wraps the help text in an inner <div>; write there
+        // so the surrounding markup is preserved. Older admin and the front-end
+        // put the text directly in the element itself.
+        var inner = help.firstElementChild;
+        if (inner && inner.tagName === "DIV") {
+            return inner;
+        }
+        return help;
+    }
+
+    function init() {
+        var hashField = document.getElementById("id_hash_client_secret");
+        var secretField = document.getElementById("id_client_secret");
+        if (!hashField || !secretField) {
+            return;
+        }
+
+        var whenHashed = hashField.getAttribute("data-client-secret-help-when-hashed");
+        var whenUnhashed = hashField.getAttribute("data-client-secret-help-when-unhashed");
+        if (whenHashed === null || whenUnhashed === null) {
+            return;
+        }
+
+        var help = findHelp(secretField);
+        if (!help) {
+            return;
+        }
+        var target = textTarget(help);
+
+        function sync() {
+            target.textContent = hashField.checked ? whenHashed : whenUnhashed;
+        }
+
+        hashField.addEventListener("change", sync);
+        sync();
+    }
+
+    if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", init);
+    } else {
+        init();
+    }
+})();

--- a/oauth2_provider/templates/oauth2_provider/application_form.html
+++ b/oauth2_provider/templates/oauth2_provider/application_form.html
@@ -43,33 +43,5 @@
         </form>
     </div>
 
-    {% if form.client_secret_help_when_hashed and form.client_secret_help_when_unhashed %}
-        {{ form.client_secret_help_when_hashed|json_script:"client-secret-help-when-hashed" }}
-        {{ form.client_secret_help_when_unhashed|json_script:"client-secret-help-when-unhashed" }}
-        <script>
-            (function () {
-                var hashField = document.getElementById("id_hash_client_secret");
-                var secretField = document.getElementById("id_client_secret");
-                if (!hashField || !secretField) {
-                    return;
-                }
-                var controls = secretField.closest(".controls");
-                var help = controls ? controls.querySelector(".help-block") : null;
-                if (!help) {
-                    return;
-                }
-                var whenHashed = JSON.parse(
-                    document.getElementById("client-secret-help-when-hashed").textContent
-                );
-                var whenUnhashed = JSON.parse(
-                    document.getElementById("client-secret-help-when-unhashed").textContent
-                );
-                function sync() {
-                    help.textContent = hashField.checked ? whenHashed : whenUnhashed;
-                }
-                hashField.addEventListener("change", sync);
-                sync();
-            })();
-        </script>
-    {% endif %}
+    {{ form.media }}
 {% endblock %}

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -392,6 +392,31 @@ class TestApplicationViews(BaseTest):
         self.assertFalse(_is_hashed("cleartext-secret"))  # unrecognized -> ValueError
         self.assertTrue(_is_hashed(make_password("cleartext-secret")))  # real hash
 
+    def test_hs256_warning_attrs_new_application(self):
+        # The algorithm field carries the data the live HS256 warning needs.
+        form = ApplicationRegistration().get_form_class()(instance=Application())
+        attrs = form.fields["algorithm"].widget.attrs
+        self.assertEqual(attrs.get("data-hs256-value"), Application.HS256_ALGORITHM)
+        self.assertEqual(attrs.get("data-client-secret-stored-hashed"), "false")
+        self.assertIn("must be stored unhashed", str(attrs.get("data-hs256-hashed-secret-warning")))
+
+    def test_hs256_warning_attrs_present_even_when_secret_hashed(self):
+        # Regression: an already-hashed secret short-circuits the client_secret help
+        # wiring, but the HS256 warning must still be wired -- that is exactly the case
+        # (edit an app whose secret is hashed, pick HS256) that needs it.
+        self.assertTrue(_is_hashed(self.app_foo_1.client_secret))  # hashed on create by default
+        form = ApplicationRegistration().get_form_class()(instance=self.app_foo_1)
+        attrs = form.fields["algorithm"].widget.attrs
+        self.assertEqual(attrs.get("data-hs256-value"), Application.HS256_ALGORITHM)
+        self.assertEqual(attrs.get("data-client-secret-stored-hashed"), "true")
+
+    def test_hs256_warning_rendered_on_register(self):
+        self.client.login(username="foo_user", password="123456")
+        response = self.client.get(reverse("oauth2_provider:register"))
+        self.assertContains(response, 'data-hs256-value="HS256"')
+        self.assertContains(response, "data-hs256-hashed-secret-warning")
+        self.assertContains(response, "oauth2_provider/js/application_form.js")
+
 
 class TestApplicationAdminHashClientSecretUX(BaseTest):
     """The admin change form must offer the same hash_client_secret-driven
@@ -448,3 +473,16 @@ class TestApplicationAdminHashClientSecretUX(BaseTest):
         )
         self.assertContains(response, "can no longer be viewed")
         self.assertNotContains(response, "data-client-secret-help-when-hashed")
+
+    def test_admin_change_form_ships_hs256_warning(self):
+        # Editing an application whose secret is hashed (the default) and selecting
+        # HS256 is invalid; the admin must ship the data the live warning needs, even
+        # though the client_secret help toggle is (correctly) absent for a hashed secret.
+        self.client.login(username="admin_user", password="123456")
+        response = self.client.get(
+            reverse("admin:oauth2_provider_application_change", args=(self.hashed_app.pk,))
+        )
+        self.assertContains(response, 'data-hs256-value="HS256"')
+        self.assertContains(response, 'data-client-secret-stored-hashed="true"')
+        self.assertContains(response, "must be stored unhashed")
+        self.assertContains(response, "oauth2_provider/js/application_form.js")

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -393,12 +393,17 @@ class TestApplicationViews(BaseTest):
         self.assertTrue(_is_hashed(make_password("cleartext-secret")))  # real hash
 
     def test_hs256_warning_attrs_new_application(self):
-        # The algorithm field carries the data the live HS256 warning needs.
+        # The algorithm field carries the data the live HS256 warning needs, including
+        # the message shown next to the hash_client_secret checkbox.
         form = ApplicationRegistration().get_form_class()(instance=Application())
         attrs = form.fields["algorithm"].widget.attrs
         self.assertEqual(attrs.get("data-hs256-value"), Application.HS256_ALGORITHM)
         self.assertEqual(attrs.get("data-client-secret-stored-hashed"), "false")
         self.assertIn("must be stored unhashed", str(attrs.get("data-hs256-hashed-secret-warning")))
+        self.assertIn(
+            "HS256 requires an unhashed client secret",
+            str(attrs.get("data-hs256-hash-checkbox-warning")),
+        )
 
     def test_hs256_warning_attrs_present_even_when_secret_hashed(self):
         # Regression: an already-hashed secret short-circuits the client_secret help
@@ -415,6 +420,7 @@ class TestApplicationViews(BaseTest):
         response = self.client.get(reverse("oauth2_provider:register"))
         self.assertContains(response, 'data-hs256-value="HS256"')
         self.assertContains(response, "data-hs256-hashed-secret-warning")
+        self.assertContains(response, "data-hs256-hash-checkbox-warning")
         self.assertContains(response, "oauth2_provider/js/application_form.js")
 
 

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -359,25 +359,26 @@ class TestApplicationViews(BaseTest):
         self.assertIn("stores the secret unhashed", form.fields["client_secret"].help_text)
 
     def test_client_secret_help_text_live_toggle_rendered_on_register(self):
-        # The register page must ship both help variants plus the checkbox-driven
-        # script so the message updates live as hash_client_secret is toggled,
-        # rather than being frozen at the server-rendered value.
+        # The register page must ship both help variants (as checkbox data-attributes)
+        # plus the shared application_form.js so the message updates live as
+        # hash_client_secret is toggled, rather than being frozen at the
+        # server-rendered value.
         self.client.login(username="foo_user", password="123456")
         response = self.client.get(reverse("oauth2_provider:register"))
-        self.assertContains(response, 'id="client-secret-help-when-hashed"')
-        self.assertContains(response, 'id="client-secret-help-when-unhashed"')
+        self.assertContains(response, "data-client-secret-help-when-hashed")
+        self.assertContains(response, "data-client-secret-help-when-unhashed")
         self.assertContains(response, "it will be hashed and cannot be recovered")
         self.assertContains(response, "stores the secret unhashed")
         self.assertContains(response, "id_hash_client_secret")
-        self.assertContains(response, "addEventListener")
+        self.assertContains(response, "oauth2_provider/js/application_form.js")
 
     def test_client_secret_help_text_no_live_toggle_when_already_hashed(self):
         # An already-hashed secret cannot be reverted by unchecking the box, so the
-        # toggle script must not be rendered on that edit page.
+        # toggle data-attributes must not be rendered on that edit page.
         self.client.login(username="foo_user", password="123456")
         response = self.client.get(reverse("oauth2_provider:update", args=(self.app_foo_1.pk,)))
         self.assertContains(response, "can no longer be viewed")
-        self.assertNotContains(response, 'id="client-secret-help-when-hashed"')
+        self.assertNotContains(response, "data-client-secret-help-when-hashed")
 
     def test_application_form_without_client_secret_field(self):
         # ApplicationForm must not assume client_secret / hash_client_secret are
@@ -390,3 +391,60 @@ class TestApplicationViews(BaseTest):
         self.assertFalse(_is_hashed(None))  # None (guards against identify_hasher TypeError)
         self.assertFalse(_is_hashed("cleartext-secret"))  # unrecognized -> ValueError
         self.assertTrue(_is_hashed(make_password("cleartext-secret")))  # real hash
+
+
+class TestApplicationAdminHashClientSecretUX(BaseTest):
+    """The admin change form must offer the same hash_client_secret-driven
+    client_secret help text (and live toggle) as the front-end views."""
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.admin_user = UserModel.objects.create_superuser("admin_user", "admin@example.com", "123456")
+        cls.hashed_app = Application.objects.create(
+            name="hashed app",
+            redirect_uris="http://example.com",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=cls.foo_user,
+        )
+        cls.unhashed_app = Application.objects.create(
+            name="unhashed app",
+            redirect_uris="http://example.com",
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            user=cls.foo_user,
+            hash_client_secret=False,
+            client_secret="cleartext-secret",
+        )
+
+    def test_admin_add_form_ships_live_toggle(self):
+        # A new application's secret is still readable, so the admin add form must
+        # expose both help variants and load the shared toggle script.
+        self.client.login(username="admin_user", password="123456")
+        response = self.client.get(reverse("admin:oauth2_provider_application_add"))
+        self.assertContains(response, "data-client-secret-help-when-hashed")
+        self.assertContains(response, "data-client-secret-help-when-unhashed")
+        self.assertContains(response, "it will be hashed and cannot be recovered")
+        self.assertContains(response, "oauth2_provider/js/application_form.js")
+
+    def test_admin_change_form_unhashed_shows_toggle(self):
+        # An application that stores its secret unhashed keeps a readable secret,
+        # so the admin edit form must still ship the live toggle.
+        self.client.login(username="admin_user", password="123456")
+        response = self.client.get(
+            reverse("admin:oauth2_provider_application_change", args=(self.unhashed_app.pk,))
+        )
+        self.assertContains(response, "data-client-secret-help-when-hashed")
+        self.assertContains(response, "stores its client secret unhashed")
+        self.assertContains(response, "oauth2_provider/js/application_form.js")
+
+    def test_admin_change_form_hashed_has_no_toggle(self):
+        # An already-hashed secret cannot be reverted, so no live toggle is offered;
+        # the admin shows the same static "cannot be viewed" message as the front-end.
+        self.client.login(username="admin_user", password="123456")
+        response = self.client.get(
+            reverse("admin:oauth2_provider_application_change", args=(self.hashed_app.pk,))
+        )
+        self.assertContains(response, "can no longer be viewed")
+        self.assertNotContains(response, "data-client-secret-help-when-hashed")


### PR DESCRIPTION
Fixes #

## Description of the Change

Two related improvements to the application form UX around `hash_client_secret`, shared across the Django admin and the front-end register/edit views behind a single implementation.

### 1. Share the `client_secret` help text between admin and front-end

The dynamic `client_secret` help text added in #1635 — which swaps between "copy it now, it will be hashed and cannot be recovered" and "stored unhashed" as the `hash_client_secret` checkbox is toggled — previously existed **only** on the front-end views, as an inline `<script>` in `application_form.html`. The Django admin used a plain auto-generated `ModelForm` with no guidance.

- `ApplicationForm` exposes both help variants as `data-*` attributes on the `hash_client_secret` checkbox and pulls in a shared static script via a `Media` class.
- `oauth2_provider/static/oauth2_provider/js/application_form.js` (new) performs the live swap. It is DOM-agnostic: it resolves either the admin's help element (`id_client_secret_helptext`) or the front-end's `.help-block`.
- `application_form.html` replaces its bespoke inline script with `{{ form.media }}`.
- `ApplicationAdmin` sets `form = ApplicationForm`.

### 2. Warn immediately when HS256 is selected with a hashed secret

`Application.clean()` (added in #1737) rejects `HS256` + a hashed client secret — the secret is the HMAC signing key and must be stored unhashed — but only at save time. Selecting HS256 while "Hash client secret" is checked gave no feedback until the save failed.

- `ApplicationForm.__init__` is split into `_init_client_secret_help()` and `_init_hs256_warning()` so the HS256 wiring is independent of the client-secret help, which short-circuits for an already-hashed secret — exactly the case (editing a default application, whose secret is hashed, and picking HS256) that needs the warning.
- The algorithm field carries the HS256 value, whether the stored secret is already hashed, and the warning text as `data-*` attributes.
- `application_form.js` inserts an inline warning after the algorithm select and toggles it as the algorithm / checkbox / secret change.

No model, migration, or public-API changes; server-side validation is unchanged (this is a live UX layer on top of it). `MANIFEST.in` packages the new `static/` directory.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)