### PR TITLE
docs: remove dead Heroku references from the tutorial

### DIFF
--- a/docs/tutorial/tutorial_01.rst
+++ b/docs/tutorial/tutorial_01.rst
@@ -7,8 +7,8 @@ You want to make your own :term:`Authorization Server` to issue access tokens to
 
 Start Your App
 --------------
-During this tutorial you will make an XHR POST from a Heroku deployed app to your localhost instance.
-Since the domain that will originate the request (the app on Heroku) is different from the destination domain (your local instance),
+During this tutorial you will make an XHR POST from a web app hosted on a different domain to your localhost instance.
+Since the domain that originates the request is different from the destination domain (your local instance),
 you will need to install the `django-cors-headers <https://github.com/adamchainz/django-cors-headers>`_ app.
 These "cross-domain" requests are by default forbidden by web browsers unless you use `CORS <http://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_.
 

--- a/docs/tutorial/tutorial_02.rst
+++ b/docs/tutorial/tutorial_02.rst
@@ -82,11 +82,13 @@ Time to make requests to your API.
 
 For a quick test, try accessing your app at the url ``/api/hello`` with your browser
 and verify that it responds with a ``403`` (in fact no ``HTTP_AUTHORIZATION`` header was provided).
-You can test your API with anything that can perform HTTP requests, but for this tutorial you can use the online
-`consumer client <http://django-oauth-toolkit.herokuapp.com/consumer/client>`_.
-Just fill the form with the URL of the API endpoint (i.e. http://localhost:8000/api/hello if you're on localhost) and
-the access token coming from the :doc:`part 1 of the tutorial <tutorial_01>`. Going in the Django admin and get the
-token from there is not considered cheating, so it's an option.
+You can test your API with anything that can perform HTTP requests, such as ``curl`` or a GUI client like Postman.
+Send a request to the API endpoint (i.e. http://localhost:8000/api/hello if you're on localhost) with the access token
+coming from the :doc:`part 1 of the tutorial <tutorial_01>` in the ``Authorization`` header, for example::
+
+    curl -H "Authorization: Bearer <your_access_token>" http://localhost:8000/api/hello
+
+Going into the Django admin and getting the token from there is not considered cheating, so it's an option.
 
 Try performing a request and check that your :term:`Resource Server` aka :term:`Authorization Server` correctly responds with
 an HTTP 200.


### PR DESCRIPTION
Fixes #1360

## Description of the Change

The getting-started tutorial referenced a Heroku-deployed demo app and an online "consumer client" hosted at `django-oauth-toolkit.herokuapp.com`, which no longer exists.

- `docs/tutorial/tutorial_01.rst`: reworded the intro so the cross-origin (CORS) scenario is described generically ("a web app hosted on a different domain") instead of a Heroku-deployed app.
- `docs/tutorial/tutorial_02.rst`: replaced the dead "consumer client" link with a concrete `curl` example for testing the API with an access token.

Documentation only — no code or behavior changes.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added — N/A (documentation only)
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes) — N/A (tutorial docs)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features — N/A
- [ ] tests/app/rp updated to demonstrate new features — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017LRjXdJWYE9vPABgA3RZu4)_