### PR TITLE
ci: cut redundant test-suite work without losing version coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -203,7 +203,10 @@ jobs:
     - name: Tox tests
       run: tox -v -e ${{ matrix.toxenv }}
 
+    # Coverage is collected only on the representative cell (see tox.ini
+    # [testenv:py312-dj52-lite3]); only that cell produces coverage.xml and uploads.
     - name: Upload coverage
+      if: matrix.toxenv == 'py312-dj52-lite3'
       uses: codecov/codecov-action@v5
       with:
         name: Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,10 +102,18 @@ show_missing = true
 [tool.pytest.ini_options]
 django_find_project = false
 addopts = [
-    "--cov=oauth2_provider",
-    "--cov-report=",
-    "--cov-append",
-    "-s",
+    # Run the suite in parallel across all available cores. pytest-xdist is a
+    # declared test dependency; pytest-cov combines per-worker coverage data at the
+    # end, so coverage (enabled only on the designated cell via PYTEST_ADDOPTS in
+    # tox) still works under xdist.
+    #
+    # `--dist loadfile` keeps every test in a given file on the same worker and runs
+    # them in collection order. Several test modules mutate process-global state
+    # (e.g. swapping OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL via override_settings), so the
+    # suite relies on within-file ordering; loadfile preserves that while still
+    # parallelizing across files.
+    "-n", "auto",
+    "--dist", "loadfile",
     # The black-box end-to-end / compliance suite boots a live server and is run
     # separately via `tox -e e2e` (which clears addopts). Keep it out of the
     # in-process unit-test collection.

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 import django
+from django.conf import global_settings
 
 
 ADMINS = ()
@@ -95,7 +96,7 @@ INSTALLED_APPS = (
 # test_models.py exercises CLIENT_SECRET_HASHER="fast_pbkdf2".
 PASSWORD_HASHERS = (
     ["django.contrib.auth.hashers.MD5PasswordHasher"]
-    + list(django.conf.settings.PASSWORD_HASHERS)
+    + list(global_settings.PASSWORD_HASHERS)
     + ["tests.custom_hasher.MyPBKDF2PasswordHasher"]
 )
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -89,7 +89,15 @@ INSTALLED_APPS = (
     "tests",
 )
 
-PASSWORD_HASHERS = django.conf.settings.PASSWORD_HASHERS + ["tests.custom_hasher.MyPBKDF2PasswordHasher"]
+# Use a fast (insecure) hasher by default so the ~260 user/secret hashes the suite
+# performs don't pay the full PBKDF2 cost on every run. The stock hashers are kept
+# registered (just not first), and MyPBKDF2PasswordHasher must stay in the list because
+# test_models.py exercises CLIENT_SECRET_HASHER="fast_pbkdf2".
+PASSWORD_HASHERS = (
+    ["django.contrib.auth.hashers.MD5PasswordHasher"]
+    + list(django.conf.settings.PASSWORD_HASHERS)
+    + ["tests.custom_hasher.MyPBKDF2PasswordHasher"]
+)
 
 LOGGING = {
     "version": 1,

--- a/tox.ini
+++ b/tox.ini
@@ -23,19 +23,24 @@ envlist =
     docs,
     lint,
     sphinxlint,
-    py{310,311,312}-dj42-lite3,
-    py{310,311,312,313}-dj50-lite3,
-    py{310,311,312,313}-dj51-lite3,
-    py{310,311,312,313,314}-dj52-lite3,
-    py{312,313,314}-dj60-lite3,
-    py{312,313,314}-djmain-lite3,
+    # SQLite matrix trimmed to a version-covering set: both Python boundaries of each
+    # Django row, plus every supported Python (3.10-3.14) exercised at least once
+    # (3.11 via dj51). py312-dj52 is retained as the coverage cell.
+    py{310,312}-dj42-lite3,
+    py{310,313}-dj50-lite3,
+    py{310,311,313}-dj51-lite3,
+    py{310,312,314}-dj52-lite3,
+    py{312,314}-dj60-lite3,
+    py{312,314}-djmain-lite3,
     py312-dj42-multi-db,
 
 [testenv]
+# Coverage is collected on a single representative cell only (see
+# [testenv:py312-dj52-lite3]); the covered source is identical across cells, so
+# collecting it on every one is redundant tracer overhead. The default cell just
+# runs the tests.
 commands =
     pytest {posargs}
-    coverage report
-    coverage xml
 extras = test
 setenv =
     DJANGO_SETTINGS_MODULE = tests.settings
@@ -53,7 +58,18 @@ passenv =
     POSTGRES_*
     MYSQL_*
 
-[testenv:py{310,311,312,313,314}-djmain-lite3]
+[testenv:py312-dj52-lite3]
+# The single cell that collects and reports coverage. PYTEST_ADDOPTS composes with
+# the global `-n auto`; pytest-cov combines per-worker data before `coverage report`.
+setenv =
+    {[testenv]setenv}
+    PYTEST_ADDOPTS = --cov=oauth2_provider --cov-report=
+commands =
+    pytest {posargs}
+    coverage report
+    coverage xml
+
+[testenv:py{312,314}-djmain-lite3]
 ignore_errors = true
 ignore_outcome = true
 
@@ -143,6 +159,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = tests.postgres_settings
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
+    PYTEST_ADDOPTS = --reuse-db
 deps =
     {[testenv]deps}
     psycopg[binary]>=3.2
@@ -152,6 +169,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = tests.postgres_pr_settings
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
+    PYTEST_ADDOPTS = --reuse-db
 deps =
     {[testenv]deps}
     psycopg[binary]>=3.2
@@ -161,6 +179,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = tests.mysql_settings
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
+    PYTEST_ADDOPTS = --reuse-db
 deps =
     {[testenv]deps}
     PyMySQL>=1.1
@@ -170,6 +189,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = tests.mysql_pr_settings
     PYTHONPATH = {toxinidir}
     PYTHONWARNINGS = all
+    PYTEST_ADDOPTS = --reuse-db
 deps =
     {[testenv]deps}
     PyMySQL>=1.1


### PR DESCRIPTION
Fixes #

## Description of the Change

CI ran ~45 parallel jobs, each re-executing the full 754-test suite **single-process while collecting coverage**, fanned across a 22-cell SQLite matrix plus 12 DB jobs. This removes the biggest redundancies while still exercising every supported/compatible Python and Django version.

- **Enable pytest-xdist** (`-n auto --dist loadfile` in `pyproject.toml` addopts). xdist was already a declared test dependency but never activated, so every job ran serially. `--dist loadfile` keeps each test file on a single worker in collection order — several modules mutate process-global state (e.g. swapping `OAUTH2_PROVIDER_ACCESS_TOKEN_MODEL` via `override_settings`) and the suite relies on within-file ordering, which plain `-n auto`/`--dist loadscope` break. loadfile still parallelizes across the ~37 files. Also dropped the stray `-s`.
- **Fast default test password hasher.** `tests/settings.py` appended the fast hasher, leaving full-strength PBKDF2 as the default, so the ~260 user/secret hashes per run paid full cost. MD5 is now the default; the stock hashers and `fast_pbkdf2` stay registered (the latter is exercised by `test_models.py`).
- **Collect coverage on one representative cell** (`py312-dj52-lite3`) instead of all ~45 jobs. There are no interpreter/Django version gates in `oauth2_provider/`, so source coverage is identical across cells. The Codecov upload step is gated to that cell; `codecov.yml` `manual_trigger` fan-in and the `success` gate are unaffected.
- **Trim the SQLite matrix 22 → 14 cells** as a version-covering set: both Python boundaries of each Django row, with every supported Python 3.10–3.14 run at least once (3.11 via dj51) and every Django 4.2/5.0/5.1/5.2/6.0/main still present. Also narrowed the `djmain` override header so the matrix-discovery job actually drops the extra djmain cells (it was factor-expanding to all five regardless of `envlist`).
- **`--reuse-db`** added to the Postgres/MySQL test envs.

Verified locally: full unit suite green under xdist loadfile (804 passed, 1 skipped) at ~3× parallelism; the coverage cell reports 98% and writes `coverage.xml`; the multi-db env passes under xdist; and the discovery script builds a valid 14-cell core matrix covering all versions. Deeper test refactors (properly fixing the global-state leakage so plain `-n auto` works, `TransactionTestCase`→`TestCase`, `setUp`→`setUpTestData`, `bulk_create`) are intentionally left out of scope.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added — N/A (CI/test-infrastructure change; existing tests are the coverage)
- [ ] documentation updated — N/A
- [ ] `CHANGELOG.md` updated (only for user relevant changes) — N/A (not user-facing)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features — N/A
- [ ] tests/app/rp updated to demonstrate new features — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MQJurg1GyobetLhByzH4SY)_