### PR TITLE
Refactor dcr_created boolean into a registration_source enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   secret on creation and explaining it is hashed and unrecoverable when editing.
 * #670 Dynamic Client Registration Protocol (RFC 7591 / RFC 7592) — `DynamicClientRegistrationView` and
   `DynamicClientRegistrationManagementView` with configurable permission classes and registration access
-  tokens. Dynamically registered applications are flagged with a new `AbstractApplication.dcr_created`
-  field and can be filtered in the Django admin.
+  tokens. Dynamically registered applications are flagged with `AbstractApplication.registration_source`
+  set to `"dcr"` and can be filtered in the Django admin.
 * #1739 `ALLOW_LOCALHOST_LOOPBACK` setting to extend the RFC 8252 §7.3 any-port loopback exemption to `http://localhost` redirect URIs (opt-in, default `False`)
 
 ### Changed
+* Replaced the unreleased `AbstractApplication.dcr_created` `BooleanField` (added in #670) with a
+  `registration_source` `CharField` enum (`AbstractApplication.RegistrationSource`, values `manual`,
+  `dcr`, `cimd`; default `manual`). This records client provenance as a single value instead of
+  accumulating one boolean per registration mechanism. `dcr_created=True` becomes
+  `registration_source="dcr"`. As `dcr_created` was never released (latest tag is 3.3.0), the change
+  ships with no deprecation.
 * The dynamic `client_secret` help text (added in #1635) is now shared by the Django admin
   application form as well as the front-end register/edit views. The `ApplicationAdmin` uses
   `ApplicationForm`, and a shared `oauth2_provider/js/application_form.js` updates the help text
@@ -98,10 +104,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TextField` → backfill → make checksum non-nullable → add the `("token_checksum", "revoked")`
   unique constraint.
 * If you use a swapped application model (`OAUTH2_PROVIDER_APPLICATION_MODEL`), run
-  `manage.py makemigrations` after upgrading: `AbstractApplication` gained a new
-  `dcr_created` `BooleanField` (default `False`) to mark applications registered via
-  Dynamic Client Registration (#670). Installs using the built-in Application model
-  just need `manage.py migrate` (migration `0017`).
+  `manage.py makemigrations` after upgrading: `AbstractApplication` gained a
+  `registration_source` `CharField` (choices `manual`/`dcr`/`cimd`, default `manual`) to mark
+  how an application was registered — for example via Dynamic Client Registration (#670). This
+  replaces the never-released `dcr_created` `BooleanField`. Installs using the built-in Application
+  model just need `manage.py migrate` (migration `0019`).
 * If you use a swapped device grant model (`OAUTH2_PROVIDER_DEVICE_GRANT_MODEL`), run
   `manage.py makemigrations` after upgrading: the redundant field-level `unique=True` was removed
   from `AbstractDeviceGrant.device_code` (#1656), and `AbstractDeviceGrant.scope` changed from

--- a/docs/views/dynamic_client_registration.rst
+++ b/docs/views/dynamic_client_registration.rst
@@ -44,9 +44,10 @@ Creates a new OAuth2 application (RFC 7591).  Authentication is controlled by
      "registration_client_uri": "https://example.com/o/register/abc123/"
    }
 
-Applications created through this endpoint are flagged with ``dcr_created=True`` on the
-``Application`` model, so dynamically registered clients can be distinguished from manually
-provisioned ones — the Django admin's application list can be filtered on this field.
+Applications created through this endpoint are flagged with ``registration_source="dcr"`` on
+the ``Application`` model, so dynamically registered clients can be distinguished from manually
+provisioned ones (``registration_source="manual"``) — the Django admin's application list can be
+filtered on this field.
 
 GET/PUT/DELETE /o/register/{client_id}/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -61,19 +61,19 @@ class ApplicationAdmin(admin.ModelAdmin):
     # hash_client_secret-driven client_secret help text (and the shared
     # application_form.js that updates it live as the checkbox is toggled).
     form = ApplicationForm
-    list_display = ("pk", "name", "user", "client_type", "authorization_grant_type", "dcr_created")
-    list_filter = ("client_type", "authorization_grant_type", "skip_authorization", "dcr_created")
+    list_display = ("pk", "name", "user", "client_type", "authorization_grant_type", "registration_source")
+    list_filter = ("client_type", "authorization_grant_type", "skip_authorization", "registration_source")
     radio_fields = {
         "client_type": admin.HORIZONTAL,
         "authorization_grant_type": admin.VERTICAL,
     }
     search_fields = ("name",) + (("user__email",) if has_email else ())
     raw_id_fields = ("user",)
-    # dcr_created is a security boundary: the RFC 7592 management endpoint only
-    # operates on applications where it is True. It reflects how the client was
-    # created and must not be editable in the admin, or a manually provisioned
-    # application could be made manageable by flipping it.
-    readonly_fields = ("dcr_created",)
+    # registration_source is a security boundary: the RFC 7592 management endpoint
+    # only operates on applications registered via DCR. It reflects how the client
+    # was created and must not be editable in the admin, or a manually provisioned
+    # application could be made manageable by flipping it to "dcr".
+    readonly_fields = ("registration_source",)
 
 
 class AccessTokenAdmin(admin.ModelAdmin):

--- a/oauth2_provider/migrations/0019_application_registration_source.py
+++ b/oauth2_provider/migrations/0019_application_registration_source.py
@@ -1,21 +1,31 @@
 from django.db import migrations, models
 
+from oauth2_provider.settings import oauth2_settings
+
 
 def forwards_set_dcr_source(apps, schema_editor):
     """Preserve provenance: applications flagged dcr_created become source="dcr"."""
-    Application = apps.get_model("oauth2_provider", "Application")
+    Application = apps.get_model(oauth2_settings.APPLICATION_MODEL)
+    if Application._meta.label_lower != "oauth2_provider.application":
+        # The application model is swapped out. The schema operations in this
+        # migration are skipped for swapped models, so the swapped app has to add
+        # registration_source and backfill it in its own migration (see CHANGELOG).
+        return
     Application.objects.filter(dcr_created=True).update(registration_source="dcr")
 
 
 def reverse_set_dcr_created(apps, schema_editor):
     """Restore the boolean from the enum so the migration is reversible."""
-    Application = apps.get_model("oauth2_provider", "Application")
+    Application = apps.get_model(oauth2_settings.APPLICATION_MODEL)
+    if Application._meta.label_lower != "oauth2_provider.application":
+        return
     Application.objects.filter(registration_source="dcr").update(dcr_created=True)
 
 
 class Migration(migrations.Migration):
     dependencies = [
         ("oauth2_provider", "0018_resource_indicators"),
+        migrations.swappable_dependency(oauth2_settings.APPLICATION_MODEL),
     ]
 
     operations = [

--- a/oauth2_provider/migrations/0019_application_registration_source.py
+++ b/oauth2_provider/migrations/0019_application_registration_source.py
@@ -11,7 +11,8 @@ def forwards_set_dcr_source(apps, schema_editor):
         # migration are skipped for swapped models, so the swapped app has to add
         # registration_source and backfill it in its own migration (see CHANGELOG).
         return
-    Application.objects.filter(dcr_created=True).update(registration_source="dcr")
+    db_alias = schema_editor.connection.alias
+    Application._default_manager.using(db_alias).filter(dcr_created=True).update(registration_source="dcr")
 
 
 def reverse_set_dcr_created(apps, schema_editor):
@@ -19,7 +20,8 @@ def reverse_set_dcr_created(apps, schema_editor):
     Application = apps.get_model(oauth2_settings.APPLICATION_MODEL)
     if Application._meta.label_lower != "oauth2_provider.application":
         return
-    Application.objects.filter(registration_source="dcr").update(dcr_created=True)
+    db_alias = schema_editor.connection.alias
+    Application._default_manager.using(db_alias).filter(registration_source="dcr").update(dcr_created=True)
 
 
 class Migration(migrations.Migration):

--- a/oauth2_provider/migrations/0019_application_registration_source.py
+++ b/oauth2_provider/migrations/0019_application_registration_source.py
@@ -1,0 +1,41 @@
+from django.db import migrations, models
+
+
+def forwards_set_dcr_source(apps, schema_editor):
+    """Preserve provenance: applications flagged dcr_created become source="dcr"."""
+    Application = apps.get_model("oauth2_provider", "Application")
+    Application.objects.filter(dcr_created=True).update(registration_source="dcr")
+
+
+def reverse_set_dcr_created(apps, schema_editor):
+    """Restore the boolean from the enum so the migration is reversible."""
+    Application = apps.get_model("oauth2_provider", "Application")
+    Application.objects.filter(registration_source="dcr").update(dcr_created=True)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oauth2_provider", "0018_resource_indicators"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="application",
+            name="registration_source",
+            field=models.CharField(
+                choices=[
+                    ("manual", "Manual"),
+                    ("dcr", "Dynamic Client Registration"),
+                    ("cimd", "Client Initiated Metadata Discovery"),
+                ],
+                default="manual",
+                help_text="How this application was registered (manual, DCR per RFC 7591, or CIMD)",
+                max_length=32,
+            ),
+        ),
+        migrations.RunPython(forwards_set_dcr_source, reverse_set_dcr_created),
+        migrations.RemoveField(
+            model_name="application",
+            name="dcr_created",
+        ),
+    ]

--- a/oauth2_provider/migrations/0019_application_registration_source.py
+++ b/oauth2_provider/migrations/0019_application_registration_source.py
@@ -38,7 +38,7 @@ class Migration(migrations.Migration):
                 choices=[
                     ("manual", "Manual"),
                     ("dcr", "Dynamic Client Registration"),
-                    ("cimd", "Client Initiated Metadata Discovery"),
+                    ("cimd", "Client ID Metadata Document"),
                 ],
                 default="manual",
                 help_text="How this application was registered (manual, DCR per RFC 7591, or CIMD)",

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -106,13 +106,13 @@ class AbstractApplication(models.Model):
                                   for manually created Applications, ``dcr`` for
                                   those registered via Dynamic Client
                                   Registration (RFC 7591), ``cimd`` for Client
-                                  Initiated Metadata Discovery
+                                  ID Metadata Document
     """
 
     class RegistrationSource(models.TextChoices):
         MANUAL = "manual", _("Manual")
         DCR = "dcr", _("Dynamic Client Registration")
-        CIMD = "cimd", _("Client Initiated Metadata Discovery")
+        CIMD = "cimd", _("Client ID Metadata Document")
         # FEDERATION (OpenID Federation) reserved for future use
 
     CLIENT_CONFIDENTIAL = "confidential"

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -102,10 +102,18 @@ class AbstractApplication(models.Model):
     * :attr:`client_secret` Confidential secret issued to the client during
                             the registration process as described in :rfc:`2.2`
     * :attr:`name` Friendly name for the Application
-    * :attr:`dcr_created` True if the Application was registered via Dynamic
-                          Client Registration (RFC 7591), False for manually
-                          created Applications
+    * :attr:`registration_source` How the Application was registered: ``manual``
+                                  for manually created Applications, ``dcr`` for
+                                  those registered via Dynamic Client
+                                  Registration (RFC 7591), ``cimd`` for Client
+                                  Initiated Metadata Discovery
     """
+
+    class RegistrationSource(models.TextChoices):
+        MANUAL = "manual", _("Manual")
+        DCR = "dcr", _("Dynamic Client Registration")
+        CIMD = "cimd", _("Client Initiated Metadata Discovery")
+        # FEDERATION (OpenID Federation) reserved for future use
 
     CLIENT_CONFIDENTIAL = "confidential"
     CLIENT_PUBLIC = "public"
@@ -178,9 +186,11 @@ class AbstractApplication(models.Model):
         help_text=_("Allowed origins list to enable CORS, space separated"),
         default="",
     )
-    dcr_created = models.BooleanField(
-        default=False,
-        help_text=_("True if this application was registered via Dynamic Client Registration (RFC 7591)"),
+    registration_source = models.CharField(
+        max_length=32,
+        choices=RegistrationSource.choices,
+        default=RegistrationSource.MANUAL,
+        help_text=_("How this application was registered (manual, DCR per RFC 7591, or CIMD)"),
     )
 
     class Meta:

--- a/oauth2_provider/views/dynamic_client_registration.py
+++ b/oauth2_provider/views/dynamic_client_registration.py
@@ -298,7 +298,11 @@ class DynamicClientRegistrationView(View):
 
         Application = get_application_model()
         user = request.user if request.user.is_authenticated else None
-        application = Application(user=user, dcr_created=True, **app_kwargs)
+        application = Application(
+            user=user,
+            registration_source=Application.RegistrationSource.DCR,
+            **app_kwargs,
+        )
 
         # Capture the raw secret before save() hashes it
         raw_secret = application.client_secret if application.client_type == "confidential" else None
@@ -377,8 +381,11 @@ class DynamicClientRegistrationManagementView(View):
         # This stops a regular access token that happens to carry
         # DCR_REGISTRATION_SCOPE (e.g. through scope misconfiguration) from
         # being used to reconfigure or delete a manually provisioned
-        # application.
-        if not application.dcr_created:
+        # application. This must be an equality check against DCR: the other
+        # registration_source values ("manual", "cimd") are truthy strings, so
+        # a "not application.registration_source" test would let every
+        # application through the management endpoint.
+        if application.registration_source != application.RegistrationSource.DCR:
             return None, _error_response(
                 "invalid_token",
                 "Token was not issued by the registration endpoint",

--- a/tests/migrations/0015_registration_source.py
+++ b/tests/migrations/0015_registration_source.py
@@ -19,7 +19,7 @@ REGISTRATION_SOURCE_FIELD = models.CharField(
     choices=[
         ("manual", "Manual"),
         ("dcr", "Dynamic Client Registration"),
-        ("cimd", "Client Initiated Metadata Discovery"),
+        ("cimd", "Client ID Metadata Document"),
     ],
     default="manual",
     help_text="How this application was registered (manual, DCR per RFC 7591, or CIMD)",

--- a/tests/migrations/0015_registration_source.py
+++ b/tests/migrations/0015_registration_source.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+
+
+def forwards_set_dcr_source(apps, schema_editor):
+    for model_name in ("BaseTestApplication", "SampleApplication"):
+        Model = apps.get_model("tests", model_name)
+        Model.objects.filter(dcr_created=True).update(registration_source="dcr")
+
+
+def reverse_set_dcr_created(apps, schema_editor):
+    for model_name in ("BaseTestApplication", "SampleApplication"):
+        Model = apps.get_model("tests", model_name)
+        Model.objects.filter(registration_source="dcr").update(dcr_created=True)
+
+
+REGISTRATION_SOURCE_FIELD = models.CharField(
+    choices=[
+        ("manual", "Manual"),
+        ("dcr", "Dynamic Client Registration"),
+        ("cimd", "Client Initiated Metadata Discovery"),
+    ],
+    default="manual",
+    help_text="How this application was registered (manual, DCR per RFC 7591, or CIMD)",
+    max_length=32,
+)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tests", "0014_custompkaccesstoken_resource_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="basetestapplication",
+            name="registration_source",
+            field=REGISTRATION_SOURCE_FIELD,
+        ),
+        migrations.AddField(
+            model_name="sampleapplication",
+            name="registration_source",
+            field=REGISTRATION_SOURCE_FIELD,
+        ),
+        migrations.RunPython(forwards_set_dcr_source, reverse_set_dcr_created),
+        migrations.RemoveField(
+            model_name="basetestapplication",
+            name="dcr_created",
+        ),
+        migrations.RemoveField(
+            model_name="sampleapplication",
+            name="dcr_created",
+        ),
+    ]

--- a/tests/migrations/0015_registration_source.py
+++ b/tests/migrations/0015_registration_source.py
@@ -2,15 +2,17 @@ from django.db import migrations, models
 
 
 def forwards_set_dcr_source(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     for model_name in ("BaseTestApplication", "SampleApplication"):
         Model = apps.get_model("tests", model_name)
-        Model.objects.filter(dcr_created=True).update(registration_source="dcr")
+        Model._default_manager.using(db_alias).filter(dcr_created=True).update(registration_source="dcr")
 
 
 def reverse_set_dcr_created(apps, schema_editor):
+    db_alias = schema_editor.connection.alias
     for model_name in ("BaseTestApplication", "SampleApplication"):
         Model = apps.get_model("tests", model_name)
-        Model.objects.filter(registration_source="dcr").update(dcr_created=True)
+        Model._default_manager.using(db_alias).filter(registration_source="dcr").update(dcr_created=True)
 
 
 REGISTRATION_SOURCE_FIELD = models.CharField(

--- a/tests/test_dcr_views.py
+++ b/tests/test_dcr_views.py
@@ -73,10 +73,10 @@ class TestDynamicClientRegistration(TestCase):
         assert "registration_client_uri" in body
         assert body["grant_types"] == ["authorization_code", "refresh_token"]
         app = Application.objects.get(client_id=body["client_id"])
-        assert app.dcr_created is True
+        assert app.registration_source == Application.RegistrationSource.DCR
 
-    def test_manually_created_application_is_not_dcr_created(self):
-        """Applications created outside DCR default to dcr_created=False."""
+    def test_manually_created_application_registration_source_is_manual(self):
+        """Applications created outside DCR default to registration_source="manual"."""
         app = Application.objects.create(
             name="Manual App",
             user=self.user,
@@ -84,21 +84,21 @@ class TestDynamicClientRegistration(TestCase):
             authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
             redirect_uris="https://example.com/cb",
         )
-        assert app.dcr_created is False
+        assert app.registration_source == Application.RegistrationSource.MANUAL
 
-    def test_dcr_created_is_readonly_in_admin(self):
-        """dcr_created is a security boundary and must be read-only in the admin.
+    def test_registration_source_is_readonly_in_admin(self):
+        """registration_source is a security boundary and must be read-only in the admin.
 
-        The RFC 7592 management endpoint only operates on dcr_created
-        applications; an editable admin field would let it be flipped on a
-        manually provisioned client and defeat that protection.
+        The RFC 7592 management endpoint only operates on applications whose
+        registration_source is "dcr"; an editable admin field would let it be
+        flipped on a manually provisioned client and defeat that protection.
         """
         from django.contrib.admin.sites import AdminSite
 
         from oauth2_provider.admin import ApplicationAdmin
 
         model_admin = ApplicationAdmin(Application, AdminSite())
-        assert "dcr_created" in model_admin.get_readonly_fields(request=None)
+        assert "registration_source" in model_admin.get_readonly_fields(request=None)
 
     def test_register_with_client_name(self):
         """client_name is mapped to Application.name."""
@@ -515,6 +515,59 @@ class TestDynamicClientRegistrationManagement(TestCase):
         response = self.client.delete(_management_url(manual_app.client_id), **_bearer(stray_token.token))
         assert response.status_code == 401
         assert Application.objects.filter(pk=manual_app.pk).exists()
+
+    def test_non_dcr_registration_source_is_rejected_by_management_endpoint(self):
+        """Only registration_source="dcr" applications are manageable via RFC 7592.
+
+        The management gate is an equality check against DCR, not a truthiness
+        test: "manual" and "cimd" are non-empty strings, so a
+        ``not application.registration_source`` guard would wrongly let both
+        through. Every non-DCR source must be rejected (401) on GET, PUT and
+        DELETE even when the presented token carries DCR_REGISTRATION_SCOPE.
+        """
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        for source in (
+            Application.RegistrationSource.MANUAL,
+            Application.RegistrationSource.CIMD,
+        ):
+            app = Application.objects.create(
+                name=f"{source} App",
+                user=self.user,
+                client_type=Application.CLIENT_CONFIDENTIAL,
+                authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+                redirect_uris="https://example.com/cb",
+                registration_source=source,
+            )
+            token = AccessToken.objects.create(
+                application=app,
+                user=self.user,
+                token=f"stray-token-{source}",
+                expires=timezone.now() + timedelta(hours=1),
+                scope=self.oauth2_settings.DCR_REGISTRATION_SCOPE,
+            )
+            url = _management_url(app.client_id)
+
+            get_response = self.client.get(url, **_bearer(token.token))
+            assert get_response.status_code == 401, source
+            assert get_response.json()["error"] == "invalid_token"
+
+            put_response = self.client.put(
+                url,
+                data=json.dumps(
+                    {"redirect_uris": ["https://example.com/new"], "grant_types": ["authorization_code"]}
+                ),
+                content_type="application/json",
+                **_bearer(token.token),
+            )
+            assert put_response.status_code == 401, source
+
+            delete_response = self.client.delete(url, **_bearer(token.token))
+            assert delete_response.status_code == 401, source
+            # The application must survive every rejected management call.
+            assert Application.objects.filter(pk=app.pk).exists()
 
     def test_get_tolerates_extra_whitespace_in_authorization_header(self):
         """Bearer parsing tolerates any whitespace run between scheme and token."""


### PR DESCRIPTION
Fixes #

## Description of the Change

**Precursor refactor for CIMD (#1744).** This PR is a standalone refactor and adds no CIMD functionality — #1744 is expected to rebase onto it.

DCR (#670) added an unreleased `AbstractApplication.dcr_created` boolean. CIMD (#1744, in review) would add a parallel `cimd_created` boolean. Rather than accumulate one boolean per registration mechanism, this collapses client provenance into a single enum. Crucially, 3.4 has **not** been released (latest tag is `3.3.0`), so `dcr_created` has never shipped — the conversion costs zero deprecation and needs to land before 3.4.

Changes:

- **Model** (`oauth2_provider/models.py`): add `AbstractApplication.RegistrationSource` (`TextChoices`) with members `MANUAL = "manual"`, `DCR = "dcr"`, `CIMD = "cimd"`, plus a comment reserving `FEDERATION` (OpenID Federation) for future use without shipping an unused enum value. Replace the `dcr_created` `BooleanField` with `registration_source = CharField(max_length=32, choices=…, default=MANUAL)`. `dcr_created` is removed entirely — no backward-compat shim, since nothing shipped it. Defining `CIMD` now means the CIMD PR won't need a migration just to add the choice value.
- **Migrations**: new `oauth2_provider/migrations/0019_application_registration_source.py` with three ordered operations — `AddField` `registration_source` (default `"manual"`), a reversible `RunPython` that maps `dcr_created=True` rows to `"dcr"` (and back on reverse), then `RemoveField` `dcr_created`. `0017` is left untouched so other branches can keep depending on it by name. A parallel `tests/migrations/0015_registration_source.py` covers the swapped-model test setup.
- **Admin** (`oauth2_provider/admin.py`): swap `dcr_created` for `registration_source` in `list_display`, `list_filter`, and `readonly_fields`. It stays read-only — it's a security boundary.
- **RFC 7592 management gate** (`oauth2_provider/views/dynamic_client_registration.py`): the creation site now sets `registration_source = DCR`, and the management guard is an **equality check** (`application.registration_source != RegistrationSource.DCR`) rather than a truthiness test. A `not application.registration_source` test would let every application through, since `"manual"`/`"cimd"` are truthy strings — that would be a security bug.
- **Tests** (`tests/test_dcr_views.py`): existing assertions updated to the enum, plus a new test that a `MANUAL` and a `CIMD` application are rejected (401) by the RFC 7592 GET/PUT/DELETE endpoints even with a token carrying `DCR_REGISTRATION_SCOPE`, locking in the equality-gate fix.
- **Docs/CHANGELOG**: `docs/views/dynamic_client_registration.rst` prose updated, and a CHANGELOG entry added under the unreleased section (including the swapped-model `makemigrations` note).

Verification: full suite green (805 passed, 1 skipped), `makemigrations --check --dry-run` clean for the default model and the swapped-model test setup, and the data migration confirmed reversible on a persistent DB. `ruff format --check` and `ruff check` pass.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwDSx1AhuazxQ3Z7FsV6At

---
_Generated by [Claude Code](https://claude.ai/code/session_01TwDSx1AhuazxQ3Z7FsV6At)_