### PR TITLE
Advertise the DCR registration_endpoint in the RFC 8414 server metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tokens. Dynamically registered applications are flagged with `AbstractApplication.registration_source`
   set to `"dcr"` and can be filtered in the Django admin.
 * #1739 `ALLOW_LOCALHOST_LOOPBACK` setting to extend the RFC 8252 §7.3 any-port loopback exemption to `http://localhost` redirect URIs (opt-in, default `False`)
+* #1751 Advertise the Dynamic Client Registration endpoint as `registration_endpoint` in the RFC 8414
+  authorization server metadata document when `DCR_ENABLED` is on
 * #1626 RFC 8707 "Resource Indicators" support
   - clients can optionally specify `resource` parameter during authorization or access token requests
   - Resource binding stored in Grant, AccessToken and RefreshToken models

--- a/docs/oauth2_server_metadata.rst
+++ b/docs/oauth2_server_metadata.rst
@@ -104,6 +104,11 @@ Example response::
 configured (see :ref:`OIDC_RSA_PRIVATE_KEY <oidc-rsa-private-key>`). When OIDC
 is disabled, ``jwks_uri`` is omitted since the JWKS endpoint is not reachable.
 
+``registration_endpoint`` (the :doc:`Dynamic Client Registration
+<views/dynamic_client_registration>` endpoint, RFC 7591) is only included when
+``DCR_ENABLED`` is on; while disabled the endpoint returns 404, so it is not
+advertised.
+
 The issuer URL is derived from the incoming request by default, by splitting the
 request URL around the ``/.well-known/oauth-authorization-server`` marker:
 

--- a/docs/views/dynamic_client_registration.rst
+++ b/docs/views/dynamic_client_registration.rst
@@ -8,6 +8,11 @@ Registration Management Protocol (`RFC 7592 <https://datatracker.ietf.org/doc/ht
 These views are automatically available when you use
 ``include("oauth2_provider.urls")``.
 
+When ``DCR_ENABLED`` is on, the registration endpoint is advertised as
+``registration_endpoint`` in the :doc:`RFC 8414 authorization server metadata
+document </oauth2_server_metadata>`, so clients can discover it without
+out-of-band configuration.
+
 
 Endpoints
 ---------

--- a/oauth2_provider/views/metadata.py
+++ b/oauth2_provider/views/metadata.py
@@ -72,6 +72,14 @@ class OAuthServerMetadataView(ServerMetadataViewMixin, View):
             if url:
                 data[key] = url
 
+        # The DCR URL pattern is always registered while the view itself 404s
+        # when DCR is off, so gate the advertisement on the setting rather
+        # than on reverse() succeeding.
+        if oauth2_settings.DCR_ENABLED:
+            registration_url = self._get_endpoint_url(request, "dcr-register")
+            if registration_url:
+                data["registration_endpoint"] = registration_url
+
         # Capability fields describe a specific endpoint, so only advertise them
         # when that endpoint is actually present.
         if "authorization_endpoint" in data:

--- a/tests/e2e/rfc8414_as_metadata/test_authorization_server_metadata.py
+++ b/tests/e2e/rfc8414_as_metadata/test_authorization_server_metadata.py
@@ -54,3 +54,10 @@ def test_metadata_advertises_response_types_and_pkce(metadata):
 @pytest.mark.compliance("RFC 8414", "2", "scopes_supported")
 def test_metadata_advertises_configured_scopes(metadata):
     assert set(c.E2E_SCOPES) <= set(metadata["scopes_supported"])
+
+
+@pytest.mark.compliance("RFC 8414", "2", "registration_endpoint")
+def test_metadata_advertises_registration_endpoint(metadata):
+    # The demo IdP runs with DCR enabled, so the RFC 7591 registration
+    # endpoint must be discoverable from the metadata document.
+    assert metadata["registration_endpoint"].endswith("/o/register/")

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -1240,6 +1240,18 @@ class TestOAuthServerMetadataView(TestCase):
         self.assertEqual(response.status_code, 200)
         assert response["Access-Control-Allow-Origin"] == "*"
 
+    def test_get_oauth_server_metadata_advertises_registration_endpoint(self):
+        self.oauth2_settings.DCR_ENABLED = True
+        response = self.client.get(reverse("oauth2_provider:oauth-server-metadata"))
+        self.assertEqual(response.status_code, 200)
+        assert response.json()["registration_endpoint"] == "http://localhost/o/register/"
+
+    def test_get_oauth_server_metadata_omits_registration_endpoint_when_dcr_disabled(self):
+        # DCR_ENABLED defaults to False; the endpoint 404s, so it must not be advertised.
+        response = self.client.get(reverse("oauth2_provider:oauth-server-metadata"))
+        self.assertEqual(response.status_code, 200)
+        assert "registration_endpoint" not in response.json()
+
     def test_get_oauth_server_metadata_oidc_disabled(self):
         """RFC 8414 metadata endpoint is available even when OIDC is disabled."""
         self.oauth2_settings.OIDC_ENABLED = False


### PR DESCRIPTION
## What this does

When `DCR_ENABLED` is on, the RFC 8414 authorization server metadata document now includes `registration_endpoint` pointing at the RFC 7591 registration view, so clients can discover it instead of needing out-of-band configuration.

The advertisement is gated on the setting rather than on URL registration, since the DCR URL patterns are always mounted and the view 404s dynamically when disabled: with DCR off the field is omitted.

The OIDC discovery document is deliberately left unchanged: `registration_endpoint` there implies OpenID Connect Dynamic Client Registration semantics, which is a separate conversation.

## Checklist

- [x] PR only contains one change
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features (N/A: the IdP already runs with DCR enabled; the rfc8414 e2e package now asserts the advertisement)
- [ ] tests/app/rp updated to demonstrate new features (N/A)
