### PR TITLE
Fix ReadWriteScopedResourceMixin.__new__() rejecting any constructor argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Netlify deploy-preview URLs (`https://*--sitename.netlify.app`). The validator previously stripped
   only a single leading hyphen after removing the `*`, leaving a hostname that began with `-` and was
   rejected by `URIValidator`; it now strips up to two leading hyphens while rejecting longer runs.
+* #694 `ReadWriteScopedResourceMixin.__new__()` no longer forwards positional/keyword arguments to
+  `object.__new__()`, which raised `TypeError: object.__new__() takes exactly one argument` when
+  instantiating any view mixing this in with any argument at all — notably breaking Django REST
+  Framework's `cls(**initkwargs)` view instantiation.
 
 ### Security
 * Generate device-flow `user_code` values with the cryptographically secure `secrets` module

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -283,14 +283,13 @@ class ReadWriteScopedResourceMixin(ScopedResourceMixin, OAuthLibMixin):
                 ' to be in OAUTH2_PROVIDER["SCOPES"] list in settings'.format(read_write_scopes)
             )
 
-        # __new__ here only exists to run the validation above; it has
-        # no state of its own to construct, so it must not forward
-        # *args/**kwargs on to object.__new__() (via the MRO chain).
-        # object.__new__() only tolerates extra arguments when the
-        # instantiated class also overrides __init__ itself -- which
-        # this mixin does not -- so passing them through breaks
-        # instantiation with any positional or keyword argument for
-        # any class that mixes this in without its own __init__.
+        # This __new__ exists only to run the validation above; it
+        # constructs no state of its own, so it must forward nothing to
+        # the next __new__ in the MRO. Because we override __new__,
+        # object.__new__() rejects any extra positional/keyword argument
+        # outright ("takes exactly one argument"), so forwarding them
+        # breaks instantiation for any view mixing this in that is
+        # constructed with arguments -- e.g. DRF's cls(**initkwargs).
         # See GH #694.
         return super().__new__(cls)
 

--- a/oauth2_provider/views/mixins.py
+++ b/oauth2_provider/views/mixins.py
@@ -283,7 +283,16 @@ class ReadWriteScopedResourceMixin(ScopedResourceMixin, OAuthLibMixin):
                 ' to be in OAUTH2_PROVIDER["SCOPES"] list in settings'.format(read_write_scopes)
             )
 
-        return super().__new__(cls, *args, **kwargs)
+        # __new__ here only exists to run the validation above; it has
+        # no state of its own to construct, so it must not forward
+        # *args/**kwargs on to object.__new__() (via the MRO chain).
+        # object.__new__() only tolerates extra arguments when the
+        # instantiated class also overrides __init__ itself -- which
+        # this mixin does not -- so passing them through breaks
+        # instantiation with any positional or keyword argument for
+        # any class that mixes this in without its own __init__.
+        # See GH #694.
+        return super().__new__(cls)
 
     def dispatch(self, request, *args, **kwargs):
         if request.method.upper() in SAFE_HTTP_METHODS:

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -143,14 +143,14 @@ class TestReadWriteScopedResourceMixin(BaseTest):
     def test_instantiation_with_keyword_arguments(self):
         """
         __new__() must not forward extra keyword arguments down to
-        object.__new__() -- object.__new__() only tolerates them when
-        the class also overrides __init__ itself, which this mixin
-        does not. Passing them through broke instantiation with any
-        argument at all for classes mixing this in (notably Django
-        REST Framework's cls(**initkwargs) view instantiation, which
-        Django's own View.as_view() also uses), raising
-        "object.__new__() takes exactly one argument" instead of
-        constructing the instance normally.
+        object.__new__(). Because the mixin overrides __new__(),
+        object.__new__() rejects any extra argument outright, so
+        forwarding them broke instantiation with any argument at all
+        for classes mixing this in (notably Django REST Framework's
+        cls(**initkwargs) view instantiation, which Django's own
+        View.as_view() also uses), raising "object.__new__() takes
+        exactly one argument" instead of constructing the instance
+        normally.
         """
 
         class TestView(ReadWriteScopedResourceMixin, View):

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -158,6 +158,28 @@ class TestReadWriteScopedResourceMixin(BaseTest):
 
         TestView(some_kwarg="value")  # Just checking no crash.
 
+    def test_instantiation_with_positional_and_keyword_arguments(self):
+        """
+        The originally reported reproduction (issue #694) instantiated
+        a subclass defining its own ``__init__(self, *args, **kwargs)``
+        with *both* a positional and a keyword argument. Django's
+        ``View.__init__`` does not accept positional arguments, so cover
+        that case directly with a view that does, ensuring ``__new__()``
+        forwards nothing to ``object.__new__()``.
+        """
+
+        class TestView(ReadWriteScopedResourceMixin, View):
+            required_scopes = ["read"]
+
+            def __init__(self, *args, **kwargs):
+                self.args = args
+                self.kwargs = kwargs
+                super().__init__()
+
+        test_view = TestView(True, some_kwarg="value")  # Just checking no crash.
+        self.assertEqual(test_view.args, (True,))
+        self.assertEqual(test_view.kwargs, {"some_kwarg": "value"})
+
 
 class TestProtectedResourceMixin(BaseTest):
     def test_options_shall_pass(self):

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -15,6 +15,7 @@ from oauth2_provider.views.mixins import (
     OIDCOnlyMixin,
     ProtectedResourceMetadataMixin,
     ProtectedResourceMixin,
+    ReadWriteScopedResourceMixin,
     ScopedResourceMixin,
 )
 
@@ -125,6 +126,37 @@ class TestScopedResourceMixin(BaseTest):
         test_view = TestView()
 
         self.assertEqual(test_view.get_scopes(), ["scope1", "scope2"])
+
+
+class TestReadWriteScopedResourceMixin(BaseTest):
+    """
+    Regression tests for
+    https://github.com/django-oauth/django-oauth-toolkit/issues/694
+    """
+
+    def test_instantiation_with_no_arguments_still_works(self):
+        class TestView(ReadWriteScopedResourceMixin, View):
+            required_scopes = ["read"]
+
+        TestView()  # Just checking no crash.
+
+    def test_instantiation_with_keyword_arguments(self):
+        """
+        __new__() must not forward extra keyword arguments down to
+        object.__new__() -- object.__new__() only tolerates them when
+        the class also overrides __init__ itself, which this mixin
+        does not. Passing them through broke instantiation with any
+        argument at all for classes mixing this in (notably Django
+        REST Framework's cls(**initkwargs) view instantiation, which
+        Django's own View.as_view() also uses), raising
+        "object.__new__() takes exactly one argument" instead of
+        constructing the instance normally.
+        """
+
+        class TestView(ReadWriteScopedResourceMixin, View):
+            required_scopes = ["read"]
+
+        TestView(some_kwarg="value")  # Just checking no crash.
 
 
 class TestProtectedResourceMixin(BaseTest):


### PR DESCRIPTION
Fixes #694.

`__new__()` forwarded `*args`/`**kwargs` on to `object.__new__()` via the MRO chain. `object.__new__()` only tolerates extra arguments when the class also overrides `__init__` itself; this mixin does not define `__init__` at all -- its `__new__` exists solely to validate that the configured `OAUTH2_PROVIDER["SCOPES"]` include the read/write scopes. Passing the arguments through therefore broke instantiation with any positional or keyword argument at all for any view mixing this in, most notably Django REST Framework's `cls(**initkwargs)` view instantiation (which Django's own `View.as_view()` also uses whenever extra kwargs are passed), raising:

```
TypeError: object.__new__() takes exactly one argument (the type to instantiate)
```

**Fix**: `__new__` has no state of its own to construct here, so it should just call `super().__new__(cls)` after its validation, letting `__init__` further down the MRO handle any arguments normally -- exactly the fix originally proposed in the issue.

**Testing**: verified with the issue's own minimal reproduction (a class mixing in `ReadWriteScopedResourceMixin`, instantiated with a positional argument and a keyword argument) and with a genuine Django REST Framework scenario (a view mixing this in, instantiated via `View.as_view(required_scopes=[...])` and dispatched against a real request through Django's actual view-instantiation code path): confirmed both reproduce the exact reported `TypeError` with the original code and are resolved by the fix. Also confirmed instantiation with no arguments at all (which already worked) continues to work correctly.

Added a new test class covering both the already-working no-argument case and the previously-broken keyword-argument case. I confirmed the keyword-argument test fails with the original code (exact reported `TypeError`) and passes with the fix. Ran the full existing `test_mixins.py` suite (21 passed: 19 baseline + 2 new) and the full project test suite (842 passed: 840 baseline + 2 new, 1 skipped), no regressions.
