### PR TITLE
Add work-pr project skill for driving single-issue PRs

### DIFF
--- a/.claude/skills/work-pr/SKILL.md
+++ b/.claude/skills/work-pr/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: work-pr
+description: Open and drive a single-issue PR to merge-ready in django-oauth-toolkit. Use when implementing a bug/feature that ships as its own PR, or when babysitting an open PR through CI and Copilot review.
+---
+
+# Work a PR
+
+One issue → one branch → one PR. Drive to green CI with no open review threads.
+
+## Open
+1. Branch off `master`: `claude/fix-<issue>-<slug>`.
+2. Implement the smallest correct change. Add a regression test that **fails before, passes after**.
+3. Add a `## [unreleased]` entry in `CHANGELOG.md` referencing `#<issue>` (skip for changes that aren't user-relevant, e.g. tooling).
+4. Lint and run related tests locally: `ruff check` + `ruff format --check`, and `DJANGO_SETTINGS_MODULE=tests.settings python -m pytest <paths>`.
+5. Commit, push `-u`. Open the PR filling `.github/pull_request_template.md`; `Fixes #<issue>`.
+6. Request a Copilot review. Subscribe to PR activity. Arm a ~1h fallback check-in.
+
+## On each CI / review event
+- **Fix** if confident and small; **rebut** if the suggestion is wrong; **skip** duplicates/no-ops.
+- Push the fix (no force-push; use a follow-up commit).
+- **Reply on each review thread, then resolve it** — not a PR-level comment.
+- Re-request Copilot review. Repeat until **CI green and Copilot has no comments**.
+
+## Rules
+- Reply on threads only; no PR-level status comments.
+- End every GitHub post with the attribution footer.
+- Never `git add -A` (it swept a `.venv` in once) — stage explicit paths.
+- Don't poll with sleep; events + the fallback check-in wake you. Re-arm it silently if nothing changed.
+- Don't self-merge. A subscription ends only when the PR is merged/closed.

--- a/.claude/skills/work-pr/SKILL.md
+++ b/.claude/skills/work-pr/SKILL.md
@@ -21,9 +21,18 @@ One issue → one branch → one PR. Drive to green CI with no open review threa
 - **Reply on each review thread, then resolve it** — not a PR-level comment.
 - Re-request Copilot review. Repeat until **CI green and Copilot has no comments**.
 
+## When master advances
+If the base moves while the PR is open — a merge-conflict or base-recovered notice, or CI that ran against a stale base — rebase onto the latest master and force-push with lease:
+
+```
+git fetch origin master && git rebase origin/master
+# resolve conflicts, re-run the affected tests
+git push --force-with-lease
+```
+
 ## Rules
 - Reply on threads only; no PR-level status comments.
-- End every GitHub post with the attribution footer.
+- If your tooling requires an attribution footer on GitHub posts (e.g. Claude Code), include it; it's a tool requirement, not repo policy.
 - Never `git add -A` (it swept a `.venv` in once) — stage explicit paths.
 - Don't poll with sleep; events + the fallback check-in wake you. Re-arm it silently if nothing changed.
 - Don't self-merge. A subscription ends only when the PR is merged/closed.

--- a/.claude/skills/work-pr/SKILL.md
+++ b/.claude/skills/work-pr/SKILL.md
@@ -25,7 +25,8 @@ One issue → one branch → one PR. Drive to green CI with no open review threa
 If the base moves while the PR is open — a merge-conflict or base-recovered notice, or CI that ran against a stale base — rebase onto the latest master and force-push with lease:
 
 ```
-git fetch origin master && git rebase origin/master
+git fetch upstream
+git rebase --autostash upstream/master
 # resolve conflicts, re-run the affected tests
 git push --force-with-lease
 ```

--- a/.claude/skills/work-pr/SKILL.md
+++ b/.claude/skills/work-pr/SKILL.md
@@ -32,7 +32,6 @@ git push --force-with-lease
 
 ## Rules
 - Reply on threads only; no PR-level status comments.
-- If your tooling requires an attribution footer on GitHub posts (e.g. Claude Code), include it; it's a tool requirement, not repo policy.
 - Never `git add -A` (it swept a `.venv` in once) — stage explicit paths.
 - Don't poll with sleep; events + the fallback check-in wake you. Re-arm it silently if nothing changed.
 - Don't self-merge. A subscription ends only when the PR is merged/closed.

--- a/.claude/skills/work-pr/SKILL.md
+++ b/.claude/skills/work-pr/SKILL.md
@@ -22,7 +22,7 @@ One issue → one branch → one PR. Drive to green CI with no open review threa
 - Re-request Copilot review. Repeat until **CI green and Copilot has no comments**.
 
 ## When master advances
-If the base moves while the PR is open — a merge-conflict or base-recovered notice, or CI that ran against a stale base — rebase onto the latest master and force-push with lease:
+When the branch falls behind master while the PR is open — it shows merge conflicts against the base, or CI ran against a now-stale base — rebase onto the latest master and force-push with lease:
 
 ```
 git fetch upstream
@@ -33,6 +33,6 @@ git push --force-with-lease
 
 ## Rules
 - Reply on threads only; no PR-level status comments.
-- Never `git add -A` (it swept a `.venv` in once) — stage explicit paths.
+- Never `git add -A` — stage explicit paths, so stray untracked files (local venvs, build output, editor scratch) are never committed.
 - Don't poll with sleep; events + the fallback check-in wake you. Re-arm it silently if nothing changed.
 - Don't self-merge. A subscription ends only when the PR is merged/closed.

--- a/.claude/skills/work-pr/SKILL.md
+++ b/.claude/skills/work-pr/SKILL.md
@@ -17,7 +17,7 @@ One issue → one branch → one PR. Drive to green CI with no open review threa
 
 ## On each CI / review event
 - **Fix** if confident and small; **rebut** if the suggestion is wrong; **skip** duplicates/no-ops.
-- Push the fix (no force-push; use a follow-up commit).
+- Push the fix (prefer a follow-up commit; only force-push when you intentionally rebased, and always use `--force-with-lease`).
 - **Reply on each review thread, then resolve it** — not a PR-level comment.
 - Re-request Copilot review. Repeat until **CI green and Copilot has no comments**.
 

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ venv/
 /compliance-matrix.json
 /.rp-server.log
 /tests/e2e/reports/
+/.venv/


### PR DESCRIPTION
Fixes #

## Description of the Change

Adds a project-level [Claude Code skill](https://docs.claude.com/en/docs/claude-code/skills) at `.claude/skills/work-pr/SKILL.md` capturing this repo's single-issue PR workflow, so it's reproducible for anyone driving a fix to merge:

- one issue → one branch off `master` → one PR;
- smallest correct change plus a regression test that **fails before, passes after**;
- `CHANGELOG.md` `[unreleased]` entry, `ruff` + `pytest` locally;
- PR from `.github/pull_request_template.md`, request a Copilot review, subscribe to activity;
- reply on and resolve each review thread, re-request Copilot, repeat until CI is green with no open comments.

It also ignores the conventional local virtualenv directory `/.venv/` in `.gitignore`, alongside the existing `/venv/` and `/.e2e-venv/` entries.

This is dev-workflow tooling only — no library code changes and nothing user-facing, so no `CHANGELOG.md` entry.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [ ] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn

---
_Generated by [Claude Code](https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn)_