### PR TITLE
Reject bearer tokens of an unusable application (#1260)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `client_credentials` application) is driven through a flow that needs a default
   redirect URI. `Application.default_redirect_uri` now raises
   `oauthlib`'s `MissingRedirectURIError`, consistent with the multiple-URI case.
+* #1260 `OAuth2Validator.validate_bearer_token` now rejects a token whose
+  application is not usable (`Application.is_usable()` returns `False`) with an
+  `invalid_token` error, mirroring the check the issuance path already performs
+  in `_load_application`. The default `is_usable()` returns `True`, so this only
+  affects swapped Application models that override it.
 
 ## [3.4.0] - 2026-07-23
 

--- a/docs/resource_server.rst
+++ b/docs/resource_server.rst
@@ -180,3 +180,17 @@ To disable automatic validation entirely, set the validator to ``None``:
     OAUTH2_PROVIDER = {
         'RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR': None,
     }
+
+Rejecting tokens of an unusable application
+-------------------------------------------
+``Application.is_usable(request)`` is a hook you can override on a
+:ref:`swapped application model <extend_app_model>` to disable an application
+dynamically — for example to freeze a deactivated account or enforce an IP allowlist. It
+returns ``True`` by default.
+
+``is_usable()`` is enforced on **both** sides of the flow: the authorization server checks it
+at token issuance, and the resource server checks it in ``validate_bearer_token()``. A token
+whose application returns ``is_usable() == False`` is therefore rejected with an
+``invalid_token`` error even if the token itself is otherwise valid and unexpired. If you
+override ``is_usable()``, keep in mind that returning ``False`` immediately stops the
+application's existing access tokens from authenticating, not just new issuance.

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -655,6 +655,21 @@ class OAuth2Validator(RequestValidator):
                     )
                     return False
 
+            # Reject tokens whose application is no longer usable, mirroring the
+            # is_usable() check the issuance path performs in _load_application.
+            # The default is_usable() returns True, so this is a no-op unless a
+            # swapped Application model overrides it (e.g. to disable an app or
+            # gate on request attributes). See #1260.
+            application = access_token.application
+            if application is not None and not application.is_usable(request):
+                request.oauth2_error = OrderedDict(
+                    [
+                        ("error", "invalid_token"),
+                        ("error_description", _("The access token is invalid.")),
+                    ]
+                )
+                return False
+
             request.client = access_token.application
             request.user = access_token.user
             request.scopes = list(access_token.scopes)

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -725,6 +725,56 @@ class TestOAuth2ValidatorProvidesErrorData(TransactionTestCase):
             },
         )
 
+    def test_validate_bearer_token_rejects_token_when_application_not_usable(self):
+        """
+        A valid token whose application is no longer usable must be rejected with
+        an ``invalid_token`` error, mirroring the ``is_usable()`` check the
+        issuance path performs in ``_load_application``. Regression test for #1260.
+        """
+        access_token = AccessToken.objects.create(
+            token="usable_check_token",
+            user=self.user,
+            expires=timezone.now() + datetime.timedelta(seconds=60),
+            application=self.application,
+            scope="read",
+        )
+        with mock.patch.object(Application, "is_usable", return_value=False):
+            self.assertFalse(
+                self.validator.validate_bearer_token(
+                    access_token.token,
+                    ["read"],
+                    self.request,
+                )
+            )
+        self.assertDictEqual(
+            self.request.oauth2_error,
+            {
+                "error": "invalid_token",
+                "error_description": "The access token is invalid.",
+            },
+        )
+
+    def test_validate_bearer_token_accepts_token_when_application_usable(self):
+        """
+        The default ``is_usable()`` returns True, so the added check is a no-op
+        for a valid token and it still validates. Guards against #1260's fix
+        rejecting ordinary tokens.
+        """
+        access_token = AccessToken.objects.create(
+            token="usable_check_token_ok",
+            user=self.user,
+            expires=timezone.now() + datetime.timedelta(seconds=60),
+            application=self.application,
+            scope="read",
+        )
+        self.assertTrue(
+            self.validator.validate_bearer_token(
+                access_token.token,
+                ["read"],
+                self.request,
+            )
+        )
+
     def test_validate_bearer_token_adds_error_to_the_request_when_a_valid_token_has_insufficient_scope(self):
         access_token = AccessToken.objects.create(
             token="some_valid_token",


### PR DESCRIPTION
Fixes #1260

## Description of the Change

`OAuth2Validator.validate_bearer_token` loaded and validated the access token but never checked `Application.is_usable(request)`. The **issuance** path already enforces `is_usable()` via `_load_application`, but the **resource** path did not — so a token issued to an application that a swapped model later marks unusable (a disabled account, an IP allowlist, etc.) still passed resource-server authentication.

This adds the `is_usable(request)` check after the token is validated (and after the RFC 8707 audience check), returning an `invalid_token` error when it fails — mirroring the issuance-side behavior.

`Application.is_usable()` returns `True` by default, so **behavior is unchanged for the built-in Application model**; this only affects swapped models that override it (the documented extension point the issue relies on).

Two tests are added: one that a valid token is rejected when `is_usable()` is `False` (fails on `master`, passes here), and one that a valid token still validates under the default `is_usable()` (guards against over-rejecting). `docs/resource_server.rst` documents that `is_usable()` now gates resource authentication as well as issuance.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn