### PR TITLE
Deny instead of asserting on non-OAuth2 token in DRF permissions (#1169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `invalid_token` error, mirroring the check the issuance path already performs
   in `_load_application`. The default `is_usable()` returns `True`, so this only
   affects swapped Application models that override it.
+* #1169 The DRF `TokenHasScope` and `TokenMatchesOASRequirements` permissions now
+  deny (return `False`) and log a warning, instead of raising an `AssertionError`
+  (HTTP 500), when `request.auth` is not an OAuth2 access token. This lets them be
+  composed with other permission classes (e.g. OR-ed) without a non-OAuth2 token
+  turning into a server error.
 
 ## [3.4.0] - 2026-07-23
 

--- a/oauth2_provider/contrib/rest_framework/permissions.py
+++ b/oauth2_provider/contrib/rest_framework/permissions.py
@@ -52,7 +52,7 @@ class TokenHasScope(BasePermission):
         # uncaught AssertionError / HTTP 500. See #1169.
         log.warning(
             "TokenHasScope requires the "
-            "`oauth2_provider.rest_framework.OAuth2Authentication` authentication "
+            "`oauth2_provider.contrib.rest_framework.OAuth2Authentication` authentication "
             "class to be used."
         )
         return False
@@ -177,7 +177,7 @@ class TokenMatchesOASRequirements(BasePermission):
         # is not an OAuth2 access token, so this permission composes cleanly.
         log.warning(
             "TokenMatchesOASRequirements requires the "
-            "`oauth2_provider.rest_framework.OAuth2Authentication` authentication "
+            "`oauth2_provider.contrib.rest_framework.OAuth2Authentication` authentication "
             "class to be used."
         )
         return False

--- a/oauth2_provider/contrib/rest_framework/permissions.py
+++ b/oauth2_provider/contrib/rest_framework/permissions.py
@@ -45,11 +45,17 @@ class TokenHasScope(BasePermission):
 
             return False
 
-        assert False, (
-            "TokenHasScope requires the"
+        # request.auth is not an OAuth2 access token (it has no `scope` attribute),
+        # e.g. it came from a different authentication class in a composed
+        # permission. Deny the request instead of raising, so this permission can be
+        # combined (AND/OR) with others without turning a non-OAuth2 request into an
+        # uncaught AssertionError / HTTP 500. See #1169.
+        log.warning(
+            "TokenHasScope requires the "
             "`oauth2_provider.rest_framework.OAuth2Authentication` authentication "
             "class to be used."
         )
+        return False
 
     def get_scopes(self, request, view):
         try:
@@ -167,11 +173,14 @@ class TokenMatchesOASRequirements(BasePermission):
                 log.warning("no scope alternates defined for method {0}".format(m))
                 return False
 
-        assert False, (
-            "TokenMatchesOASRequirements requires the"
+        # See TokenHasScope above and #1169: deny rather than raise when the token
+        # is not an OAuth2 access token, so this permission composes cleanly.
+        log.warning(
+            "TokenMatchesOASRequirements requires the "
             "`oauth2_provider.rest_framework.OAuth2Authentication` authentication "
             "class to be used."
         )
+        return False
 
     def get_required_alternate_scopes(self, request, view):
         try:

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -264,7 +264,7 @@ class TestOAuth2Authentication(TestCase):
             response = self.client.get("/oauth2-scoped-missing-auth/", HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, 403)
         self.assertTrue(
-            any("`oauth2_provider.rest_framework.OAuth2Authentication`" in msg for msg in logs.output)
+            any("`oauth2_provider.contrib.rest_framework.OAuth2Authentication`" in msg for msg in logs.output)
         )
 
     def test_authenticated_or_scoped_permission_allow(self):
@@ -473,7 +473,7 @@ class TestOAuth2Authentication(TestCase):
             response = self.client.get("/oauth2-method-scope-missing-auth/", HTTP_AUTHORIZATION=auth)
         self.assertEqual(response.status_code, 403)
         self.assertTrue(
-            any("`oauth2_provider.rest_framework.OAuth2Authentication`" in msg for msg in logs.output)
+            any("`oauth2_provider.contrib.rest_framework.OAuth2Authentication`" in msg for msg in logs.output)
         )
 
     def test_authentication_none(self):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -256,10 +256,16 @@ class TestOAuth2Authentication(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_scope_missing_scope_attr(self):
+        # A token without a `scope` attribute (wrong authentication class) must deny
+        # the request rather than raise an AssertionError, so TokenHasScope can be
+        # composed with other permissions. Regression test for #1169.
         auth = self._create_authorization_header("fake-token")
-        with self.assertRaises(AssertionError) as e:
-            self.client.get("/oauth2-scoped-missing-auth/", HTTP_AUTHORIZATION=auth)
-        self.assertTrue("`oauth2_provider.rest_framework.OAuth2Authentication`" in str(e.exception))
+        with self.assertLogs("oauth2_provider", level="WARNING") as logs:
+            response = self.client.get("/oauth2-scoped-missing-auth/", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(
+            any("`oauth2_provider.rest_framework.OAuth2Authentication`" in msg for msg in logs.output)
+        )
 
     def test_authenticated_or_scoped_permission_allow(self):
         self.access_token.scope = "scope1"
@@ -460,10 +466,15 @@ class TestOAuth2Authentication(TestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_method_scope_alt_missing_scope_attr(self):
+        # As with TokenHasScope, a token lacking a `scope` attribute must deny
+        # rather than raise, so TokenMatchesOASRequirements composes. See #1169.
         auth = self._create_authorization_header("fake-token")
-        with self.assertRaises(AssertionError) as e:
-            self.client.get("/oauth2-method-scope-missing-auth/", HTTP_AUTHORIZATION=auth)
-        self.assertTrue("`oauth2_provider.rest_framework.OAuth2Authentication`" in str(e.exception))
+        with self.assertLogs("oauth2_provider", level="WARNING") as logs:
+            response = self.client.get("/oauth2-method-scope-missing-auth/", HTTP_AUTHORIZATION=auth)
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(
+            any("`oauth2_provider.rest_framework.OAuth2Authentication`" in msg for msg in logs.output)
+        )
 
     def test_authentication_none(self):
         auth = self._create_authorization_header(self.access_token.token)


### PR DESCRIPTION
Fixes #1169

## Description of the Change

`TokenHasScope` and `TokenMatchesOASRequirements` raised a bare `assert False` when `request.auth` had no `scope` attribute — i.e. the request was authenticated by a **different** authentication class. Inside a composed DRF permission (`&`/`|`-ed with others), that `AssertionError` propagated as an **HTTP 500** instead of the operand simply denying, which is what the reporter hit when combining `TokenHasScope` with another permission via the bitwise operators.

Both permissions now `log.warning(...)` and `return False` in that case, so they compose cleanly. Behavior for a real OAuth2 token is unchanged.

The two existing tests that asserted the `AssertionError` (`test_scope_missing_scope_attr`, `test_method_scope_alt_missing_scope_attr`) are updated to expect a `403` and the logged warning; both fail on `master` and pass here.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn

---
_Generated by [Claude Code](https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn)_