### PR TITLE
Honor OAUTH2_BACKEND_CLASS when introspecting a JSON body (#613)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (HTTP 500), when `request.auth` is not an OAuth2 access token. This lets them be
   composed with other permission classes (e.g. OR-ed) without a non-OAuth2 token
   turning into a server error.
+* #613 The token introspection endpoint (`IntrospectTokenView`) now reads the
+  `token` parameter from the request body through the configured
+  `OAUTH2_BACKEND_CLASS`, so a token supplied in a JSON body is parsed when
+  `JSONOAuthLibCore` is configured. Previously the token was read straight from
+  `request.POST`, which is empty for a JSON body.
 
 ## [3.4.0] - 2026-07-23
 

--- a/docs/resource_server.rst
+++ b/docs/resource_server.rst
@@ -51,6 +51,11 @@ Example Response::
 The ``aud`` field (audience) is included when the token has resource binding per RFC 8707.
 Tokens without resource restrictions will not include this field.
 
+By default the endpoint reads the ``token`` parameter from an
+``application/x-www-form-urlencoded`` request body (or the URL query string). If
+``OAUTH2_BACKEND_CLASS`` is set to ``oauth2_provider.oauth2_backends.JSONOAuthLibCore``,
+the ``token`` may also be supplied in an ``application/json`` request body.
+
 Setup the Resource Server
 -------------------------
 Setup the :term:`Resource Server` like the :term:`Authorization Server` as described in the :doc:`tutorial/tutorial`.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -204,7 +204,12 @@ validates every step of the OAuth2 process.
 OAUTH2_BACKEND_CLASS
 ~~~~~~~~~~~~~~~~~~~~
 The import string for the ``oauthlib_backend_class`` used in the ``OAuthLibMixin``,
-to get a ``Server`` instance.
+to get a ``Server`` instance. The default
+``oauth2_provider.oauth2_backends.OAuthLibCore`` reads request bodies as
+``application/x-www-form-urlencoded``. Set it to
+``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` to parse
+``application/json`` request bodies instead (for example, to send the token
+introspection ``token`` parameter as JSON).
 
 REFRESH_TOKEN_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -31,6 +31,14 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
                 {"error": "invalid_request", "error_description": "Token parameter is missing."},
                 status=400,
             )
+        if not isinstance(token_value, str):
+            # RFC 7662 defines `token` as a string. A JSON body (JSONOAuthLibCore)
+            # can deliver a non-string value (e.g. a number); reject it with a 400
+            # instead of raising an AttributeError on `token_value.encode()` below.
+            return JsonResponse(
+                {"error": "invalid_request", "error_description": "Token parameter must be a string."},
+                status=400,
+            )
         try:
             token_checksum = hashlib.sha256(token_value.encode("utf-8")).hexdigest()
             token = (

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -8,7 +8,6 @@ from django.views.decorators.csrf import csrf_exempt
 
 from ..compat import login_not_required
 from ..models import get_access_token_model
-from ..oauth2_backends import get_oauthlib_core
 from ..views.generic import ClientProtectedScopedResourceView
 
 
@@ -89,5 +88,5 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
         :param kwargs:
         :return:
         """
-        body = dict(get_oauthlib_core().extract_body(request))
+        body = dict(self.get_oauthlib_core().extract_body(request))
         return self.get_token_response(body.get("token", None))

--- a/oauth2_provider/views/introspect.py
+++ b/oauth2_provider/views/introspect.py
@@ -8,6 +8,7 @@ from django.views.decorators.csrf import csrf_exempt
 
 from ..compat import login_not_required
 from ..models import get_access_token_model
+from ..oauth2_backends import get_oauthlib_core
 from ..views.generic import ClientProtectedScopedResourceView
 
 
@@ -75,7 +76,12 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
 
     def post(self, request, *args, **kwargs):
         """
-        Get the token from the body form parameters.
+        Get the token from the request body.
+
+        The body is parsed through the configured ``OAUTH2_BACKEND_CLASS`` so the
+        ``token`` parameter is read whether the body is form-encoded (the default
+        backend) or JSON (``JSONOAuthLibCore``). Previously the token was read
+        straight from ``request.POST``, which is empty for a JSON body. See #613.
         Body: token=mF_9.B5f-4.1JqM
 
         :param request:
@@ -83,4 +89,5 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
         :param kwargs:
         :return:
         """
-        return self.get_token_response(request.POST.get("token", None))
+        body = dict(get_oauthlib_core().extract_body(request))
+        return self.get_token_response(body.get("token", None))

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -1,5 +1,6 @@
 import calendar
 import datetime
+import json
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -8,6 +9,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from oauth2_provider.models import get_access_token_model, get_application_model
+from oauth2_provider.oauth2_backends import JSONOAuthLibCore
 
 from . import presets
 from .common_testing import OAuth2ProviderTestCase as TestCase
@@ -224,6 +226,37 @@ class TestTokenIntrospectionViews(TestCase):
         self.assertEqual(response.status_code, 200)
         content = response.json()
         self.assertIsInstance(content, dict)
+        self.assertDictEqual(
+            content,
+            {
+                "active": True,
+                "scope": self.valid_token.scope,
+                "client_id": self.valid_token.application.client_id,
+                "username": self.valid_token.user.get_username(),
+                "exp": int(calendar.timegm(self.valid_token.expires.timetuple())),
+            },
+        )
+
+    def test_view_post_valid_token_json_body(self):
+        """
+        With ``OAUTH2_BACKEND_CLASS`` set to ``JSONOAuthLibCore``, a token supplied
+        in a JSON request body is parsed and introspected. The endpoint previously
+        read the token straight from ``request.POST``, which is empty for a JSON
+        body, so this returned "token missing". Regression test for #613.
+        """
+        self.oauth2_settings.OAUTH2_BACKEND_CLASS = JSONOAuthLibCore
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
+        }
+        response = self.client.post(
+            reverse("oauth2_provider:introspect"),
+            data=json.dumps({"token": self.valid_token.token}),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.json()
         self.assertDictEqual(
             content,
             {

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -288,6 +288,46 @@ class TestTokenIntrospectionViews(TestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()["error"], "invalid_request")
 
+    def test_view_post_malformed_json_body(self):
+        """
+        A malformed JSON body with ``JSONOAuthLibCore`` must return a 400, not a
+        500. ``extract_body()`` returns ``""`` on a JSON parse error and
+        ``dict("") == {}``, so the token reads as missing. See #613.
+        """
+        self.oauth2_settings.OAUTH2_BACKEND_CLASS = JSONOAuthLibCore
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
+        }
+        response = self.client.post(
+            reverse("oauth2_provider:introspect"),
+            data="{not valid json",
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "invalid_request")
+
+    def test_view_post_non_utf8_json_body(self):
+        """
+        A non-UTF8 body with ``JSONOAuthLibCore`` must return a 400, not a 500:
+        ``request.body.decode("utf-8")`` raises ``UnicodeDecodeError`` — a
+        ``ValueError`` subclass that ``extract_body()`` catches. See #613.
+        """
+        self.oauth2_settings.OAUTH2_BACKEND_CLASS = JSONOAuthLibCore
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
+        }
+        response = self.client.post(
+            reverse("oauth2_provider:introspect"),
+            data=b"\xff\xfe\x00token",
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "invalid_request")
+
     def test_view_post_invalid_token(self):
         """
         Test that when you pass an invalid token as form parameter,

--- a/tests/test_introspection_view.py
+++ b/tests/test_introspection_view.py
@@ -268,6 +268,26 @@ class TestTokenIntrospectionViews(TestCase):
             },
         )
 
+    def test_view_post_non_string_token_json_body(self):
+        """
+        A JSON body may carry a non-string ``token`` (e.g. a number). RFC 7662
+        defines ``token`` as a string, so this must return a 400, not a 500 from
+        ``token_value.encode()``. See #613.
+        """
+        self.oauth2_settings.OAUTH2_BACKEND_CLASS = JSONOAuthLibCore
+        auth_headers = {
+            "HTTP_AUTHORIZATION": "Bearer " + self.resource_server_token.token,
+        }
+        response = self.client.post(
+            reverse("oauth2_provider:introspect"),
+            data=json.dumps({"token": 12345}),
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "invalid_request")
+
     def test_view_post_invalid_token(self):
         """
         Test that when you pass an invalid token as form parameter,


### PR DESCRIPTION
Fixes #613

## Description of the Change

`IntrospectTokenView.post()` read the token straight from `request.POST`, which is empty when the request body is JSON. So configuring `JSONOAuthLibCore` as `OAUTH2_BACKEND_CLASS` did not let a client pass the token in a JSON body — the endpoint reported the token as missing. (Client authentication already went through the backend via `authenticate_client`; only the `token` parameter was affected.)

`post()` now parses the body through the inherited `self.get_oauthlib_core().extract_body(request)` (the view's `OAuthLibMixin`, so it reuses the cached core and respects `ALWAYS_RELOAD_OAUTHLIB_CORE`), so the `token` parameter is read for both form-encoded and JSON bodies. Form-encoded requests are unaffected: the default `OAuthLibCore.extract_body` still reads `request.POST`. The `GET` path (query-string `token`) is unchanged.

Because a JSON body can carry non-string values, `get_token_response()` now returns a `400 invalid_request` for a non-string `token` (RFC 7662 defines it as a string) instead of raising `AttributeError` on `.encode()`. Malformed/undecodable JSON already degrades to the existing "token missing" 400 (`extract_body` returns `""`, `dict("") == {}`).

### Tests
- `token` in a JSON body is introspected (fails on `master`, passes here);
- non-string JSON `token` → 400 (was a 500);
- malformed JSON text and non-UTF8 bytes → 400.

### Docs
`docs/resource_server.rst` and the `OAUTH2_BACKEND_CLASS` section of `docs/settings.rst` now note that `JSONOAuthLibCore` enables `application/json` request bodies.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn