### PR TITLE
Revoke refresh token when access token is revoked (#1510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the
   interrelated token models together.
+
 ### Fixed
 * #958 Return a spec-compliant 400 instead of raising an uncaught `AssertionError`
   (HTTP 500) when an application without any registered `redirect_uris` (e.g. a
@@ -35,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (HTTP 500), when `request.auth` is not an OAuth2 access token. This lets them be
   composed with other permission classes (e.g. OR-ed) without a non-OAuth2 token
   turning into a server error.
+
+### Security
+* #1510 Revoking an access token from the authorized-tokens page
+  (`AuthorizedTokenDeleteView`) now also revokes the refresh token issued
+  alongside it. Previously only the access token was deleted, leaving the
+  refresh token usable to mint a fresh access token and defeating the
+  revocation (a regression from 2.3.0). Per :rfc:`7009#section-2.1` an access
+  token revocation may also revoke the respective refresh token; for a
+  user-initiated revocation that is now the behavior.
 
 ## [3.4.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`AuthorizedTokenDeleteView`) now also revokes the refresh token issued
   alongside it. Previously only the access token was deleted, leaving the
   refresh token usable to mint a fresh access token and defeating the
-  revocation (a regression from 2.3.0). Per :rfc:`7009#section-2.1` an access
-  token revocation may also revoke the respective refresh token; for a
+  revocation (a regression from 2.3.0). Per
+  [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) an
+  access token revocation may also revoke the respective refresh token; for a
   user-initiated revocation that is now the behavior.
 
 ## [3.4.0] - 2026-07-23

--- a/oauth2_provider/views/token.py
+++ b/oauth2_provider/views/token.py
@@ -51,7 +51,7 @@ class AuthorizedTokenDeleteView(LoginRequiredMixin, DeleteView):
         whose name depends on the ``related_name`` a swapped refresh token model may
         override.
         """
-        access_token = self.get_object()
+        access_token = self.object
         refresh_token = get_refresh_token_model().objects.filter(access_token=access_token).first()
 
         if refresh_token is not None:

--- a/oauth2_provider/views/token.py
+++ b/oauth2_provider/views/token.py
@@ -1,4 +1,6 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core.exceptions import ObjectDoesNotExist
+from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import DeleteView, ListView
 
@@ -32,3 +34,28 @@ class AuthorizedTokenDeleteView(LoginRequiredMixin, DeleteView):
 
     def get_queryset(self):
         return super().get_queryset().filter(user=self.request.user)
+
+    def form_valid(self, form):
+        """
+        Revoke the access token and its associated refresh token.
+
+        Deleting the access token on its own leaves the refresh token usable
+        (the ``RefreshToken.access_token`` FK is ``SET_NULL``), so it can still be
+        exchanged for a fresh access token, defeating the revocation. Per
+        :rfc:`7009#section-2.1` revoking an access token may also revoke the
+        respective refresh token; for a user-initiated "revoke access" action that
+        is the only unsurprising behavior. Revoking the refresh token also deletes
+        the bound access token, so it covers both.
+        """
+        access_token = self.get_object()
+        try:
+            refresh_token = access_token.refresh_token
+        except ObjectDoesNotExist:
+            refresh_token = None
+
+        if refresh_token is not None:
+            refresh_token.revoke()
+        else:
+            access_token.revoke()
+
+        return HttpResponseRedirect(self.get_success_url())

--- a/oauth2_provider/views/token.py
+++ b/oauth2_provider/views/token.py
@@ -1,10 +1,9 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import DeleteView, ListView
 
-from ..models import get_access_token_model
+from ..models import get_access_token_model, get_refresh_token_model
 
 
 class AuthorizedTokensListView(LoginRequiredMixin, ListView):
@@ -46,12 +45,14 @@ class AuthorizedTokenDeleteView(LoginRequiredMixin, DeleteView):
         respective refresh token; for a user-initiated "revoke access" action that
         is the only unsurprising behavior. Revoking the refresh token also deletes
         the bound access token, so it covers both.
+
+        The bound refresh token is looked up with a forward query on the refresh
+        token model rather than the reverse ``access_token.refresh_token`` accessor,
+        whose name depends on the ``related_name`` a swapped refresh token model may
+        override.
         """
         access_token = self.get_object()
-        try:
-            refresh_token = access_token.refresh_token
-        except ObjectDoesNotExist:
-            refresh_token = None
+        refresh_token = get_refresh_token_model().objects.filter(access_token=access_token).first()
 
         if refresh_token is not None:
             refresh_token.revoke()

--- a/tests/test_token_view.py
+++ b/tests/test_token_view.py
@@ -4,13 +4,18 @@ from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django.utils import timezone
 
-from oauth2_provider.models import get_access_token_model, get_application_model
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_application_model,
+    get_refresh_token_model,
+)
 
 from .common_testing import OAuth2ProviderTestCase as TestCase
 
 
 Application = get_application_model()
 AccessToken = get_access_token_model()
+RefreshToken = get_refresh_token_model()
 UserModel = get_user_model()
 
 
@@ -208,3 +213,52 @@ class TestAuthorizedTokenDeleteView(TestAuthorizedTokenViews):
         response = self.client.post(url)
         self.assertTrue(AccessToken.objects.exists())
         self.assertEqual(response.status_code, 404)
+
+    def test_delete_view_also_revokes_refresh_token(self):
+        """
+        Revoking an access token from this view must also revoke the refresh token
+        issued alongside it, otherwise the refresh token can still be exchanged for a
+        new access token (regression, see issue #1510).
+        """
+        self.token = AccessToken.objects.create(
+            user=self.foo_user,
+            token="1234567890",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+        refresh_token = RefreshToken.objects.create(
+            user=self.foo_user,
+            token="abcdefghij",
+            application=self.application,
+            access_token=self.token,
+        )
+
+        self.client.login(username="foo_user", password="123456")
+        url = reverse("oauth2_provider:authorized-token-delete", kwargs={"pk": self.token.pk})
+        response = self.client.post(url)
+        self.assertRedirects(response, reverse("oauth2_provider:authorized-token-list"))
+
+        self.assertFalse(AccessToken.objects.filter(pk=self.token.pk).exists())
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(refresh_token.revoked)
+        self.assertIsNone(refresh_token.access_token)
+
+    def test_delete_view_without_refresh_token_still_deletes(self):
+        """
+        Tokens without an associated refresh token (e.g. client-credentials) are still
+        deleted when revoked from this view.
+        """
+        self.token = AccessToken.objects.create(
+            user=self.foo_user,
+            token="1234567890",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+
+        self.client.login(username="foo_user", password="123456")
+        url = reverse("oauth2_provider:authorized-token-delete", kwargs={"pk": self.token.pk})
+        response = self.client.post(url)
+        self.assertRedirects(response, reverse("oauth2_provider:authorized-token-list"))
+        self.assertFalse(AccessToken.objects.filter(pk=self.token.pk).exists())


### PR DESCRIPTION
Fixes #1510

## Description of the Change

Revoking an access token from the authorized-tokens page (`AuthorizedTokenDeleteView`) deleted **only** the access token. Because `RefreshToken.access_token` is `on_delete=SET_NULL`, the refresh token issued alongside it was left with `revoked=None` — still usable. A client could then exchange that refresh token for a fresh access + refresh token pair, defeating the user's revocation. This was a regression from 2.3.0 (which killed both).

Note the two refresh-token links are distinct: the exchangeable token is the reverse of `RefreshToken.access_token` (`access_token.refresh_token`), **not** `access_token.source_refresh_token` (the already-consumed token that minted this access token). The fix targets the former.

The view now, in `form_valid`:
- revokes the bound refresh token via `RefreshToken.revoke()` when one exists — that call also deletes the associated access token, so both tokens die; or
- falls back to `access_token.revoke()` when there is no refresh token (e.g. client-credentials / implicit tokens).

This makes access-token revocation symmetric with `RefreshToken.revoke()`, which already revokes its bound access token. Per [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1), revoking an access token *may* also revoke the respective refresh token; for a user-initiated "revoke access" action that is the only unsurprising behavior. Scope is intentionally limited to the active bound token — token-family / grace-period behavior is tracked separately in #1617.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

### Testing
Added `test_delete_view_also_revokes_refresh_token` (fails before, passes after) and `test_delete_view_without_refresh_token_still_deletes`. Confirmed the new regression test fails on the unpatched view (`AssertionError: unexpectedly None`). Full `tests/test_token_view.py`, `test_token_revocation.py`, and `test_authorization_code.py` pass (102 tests); `ruff check` / `ruff format --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5nbZ25qTxm7Q4mHxywwx8)_