### PR TITLE
Deprecate JSONOAuthLibCore (#1773)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a
-  `DeprecationWarning`. It makes the OAuth token, authorization, introspection, and
+  `DeprecationWarning`. It makes the OAuth token, introspection, and
   revocation endpoints read `application/json` bodies, but those endpoints are defined to
   use `application/x-www-form-urlencoded` (RFC 6749, RFC 7662, RFC 7009); the JSON mode is
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the
   interrelated token models together.
-
+### Deprecated
+* #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
+  `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a
+  `DeprecationWarning`. It makes the OAuth token, authorization, introspection, and
+  revocation endpoints read `application/json` bodies, but those endpoints are defined to
+  use `application/x-www-form-urlencoded` (RFC 6749, RFC 7662, RFC 7009); the JSON mode is
+  non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
+  removal in 4.0.
 ### Fixed
 * #958 Return a spec-compliant 400 instead of raising an uncaught `AssertionError`
   (HTTP 500) when an application without any registered `redirect_uris` (e.g. a

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -204,7 +204,17 @@ validates every step of the OAuth2 process.
 OAUTH2_BACKEND_CLASS
 ~~~~~~~~~~~~~~~~~~~~
 The import string for the ``oauthlib_backend_class`` used in the ``OAuthLibMixin``,
-to get a ``Server`` instance.
+to get a ``Server`` instance. Defaults to
+``oauth2_provider.oauth2_backends.OAuthLibCore``, which reads request bodies as
+``application/x-www-form-urlencoded`` as required by the OAuth specifications.
+
+.. deprecated:: 3.5
+    ``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` is deprecated and will be removed
+    in 4.0. It makes the OAuth token, authorization, introspection, and revocation endpoints
+    read ``application/json`` request bodies, but those endpoints are defined to use
+    ``application/x-www-form-urlencoded`` (RFC 6749, RFC 7662, RFC 7009). The JSON mode is
+    non-standard and breaks interoperability with spec-compliant clients; every client can
+    send a form-encoded body, so it provides no capability that the default backend lacks.
 
 REFRESH_TOKEN_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -210,7 +210,7 @@ to get a ``Server`` instance. Defaults to
 
 .. deprecated:: 3.5
     ``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` is deprecated and will be removed
-    in 4.0. It makes the OAuth token, authorization, introspection, and revocation endpoints
+    in 4.0. It makes the OAuth token, introspection, and revocation endpoints
     read ``application/json`` request bodies, but those endpoints are defined to use
     ``application/x-www-form-urlencoded`` (RFC 6749, RFC 7662, RFC 7009). The JSON mode is
     non-standard and breaks interoperability with spec-compliant clients; every client can

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -208,7 +208,7 @@ to get a ``Server`` instance. Defaults to
 ``oauth2_provider.oauth2_backends.OAuthLibCore``, which reads request bodies as
 ``application/x-www-form-urlencoded`` as required by the OAuth specifications.
 
-.. deprecated:: 3.5
+.. deprecated:: 3.4.1
     ``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` is deprecated and will be removed
     in 4.0. It makes the OAuth token, introspection, and revocation endpoints
     read ``application/json`` request bodies, but those endpoints are defined to use

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -208,9 +208,10 @@ to get a ``Server`` instance. Defaults to
 ``oauth2_provider.oauth2_backends.OAuthLibCore``, which reads request bodies as
 ``application/x-www-form-urlencoded`` as required by the OAuth specifications.
 
-.. deprecated:: 3.4.1
-    ``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` is deprecated and will be removed
-    in 4.0. It makes the OAuth token, introspection, and revocation endpoints
+.. note::
+    The ``oauth2_provider.oauth2_backends.JSONOAuthLibCore`` backend value is deprecated
+    (since 3.4.1) and will be removed in 4.0. It makes the OAuth token, introspection, and
+    revocation endpoints
     read ``application/json`` request bodies, but those endpoints are defined to use
     ``application/x-www-form-urlencoded`` (RFC 6749, RFC 7662, RFC 7009). The JSON mode is
     non-standard and breaks interoperability with spec-compliant clients; every client can

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -308,7 +308,10 @@ class JSONOAuthLibCore(OAuthLibCore):
             "introspection, and revocation endpoints are defined to use "
             "application/x-www-form-urlencoded request bodies (RFC 6749, RFC 7662, RFC 7009); "
             "reading application/json on them is non-standard and breaks interoperability "
-            "with spec-compliant clients.",
+            "with spec-compliant clients. To migrate, remove the "
+            "OAUTH2_PROVIDER['OAUTH2_BACKEND_CLASS'] override (the default "
+            "'oauth2_provider.oauth2_backends.OAuthLibCore' reads form-encoded bodies) and "
+            "have clients send application/x-www-form-urlencoded request bodies.",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -293,7 +293,7 @@ class JSONOAuthLibCore(OAuthLibCore):
     Extends the default OAuthLibCore to parse ``application/json`` request bodies.
 
     .. deprecated:: 3.5
-        The OAuth token, authorization, introspection, and revocation endpoints are
+        The OAuth token, introspection, and revocation endpoints are
         defined to use ``application/x-www-form-urlencoded`` request bodies
         (RFC 6749, RFC 7662, RFC 7009). Reading ``application/json`` on these
         endpoints is non-standard and breaks interoperability with spec-compliant
@@ -304,7 +304,7 @@ class JSONOAuthLibCore(OAuthLibCore):
         warnings.warn(
             "JSONOAuthLibCore (OAUTH2_PROVIDER['OAUTH2_BACKEND_CLASS'] = "
             "'oauth2_provider.oauth2_backends.JSONOAuthLibCore') is deprecated and will be "
-            "removed in django-oauth-toolkit 4.0. The OAuth token, authorization, "
+            "removed in django-oauth-toolkit 4.0. The OAuth token, "
             "introspection, and revocation endpoints are defined to use "
             "application/x-www-form-urlencoded request bodies (RFC 6749, RFC 7662, RFC 7009); "
             "reading application/json on them is non-standard and breaks interoperability "

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 from urllib.parse import parse_qsl, urlparse, urlunparse
 from urllib.parse import urlencode as stdlib_urlencode
 
@@ -289,8 +290,29 @@ class OAuthLibCore:
 
 class JSONOAuthLibCore(OAuthLibCore):
     """
-    Extends the default OAuthLibCore to parse correctly application/json requests
+    Extends the default OAuthLibCore to parse ``application/json`` request bodies.
+
+    .. deprecated:: 3.5
+        The OAuth token, authorization, introspection, and revocation endpoints are
+        defined to use ``application/x-www-form-urlencoded`` request bodies
+        (RFC 6749, RFC 7662, RFC 7009). Reading ``application/json`` on these
+        endpoints is non-standard and breaks interoperability with spec-compliant
+        clients. Scheduled for removal in 4.0 (see #1773).
     """
+
+    def __init__(self, server=None):
+        warnings.warn(
+            "JSONOAuthLibCore (OAUTH2_PROVIDER['OAUTH2_BACKEND_CLASS'] = "
+            "'oauth2_provider.oauth2_backends.JSONOAuthLibCore') is deprecated and will be "
+            "removed in django-oauth-toolkit 4.0. The OAuth token, authorization, "
+            "introspection, and revocation endpoints are defined to use "
+            "application/x-www-form-urlencoded request bodies (RFC 6749, RFC 7662, RFC 7009); "
+            "reading application/json on them is non-standard and breaks interoperability "
+            "with spec-compliant clients.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(server)
 
     def extract_body(self, request):
         """

--- a/oauth2_provider/oauth2_backends.py
+++ b/oauth2_provider/oauth2_backends.py
@@ -292,7 +292,7 @@ class JSONOAuthLibCore(OAuthLibCore):
     """
     Extends the default OAuthLibCore to parse ``application/json`` request bodies.
 
-    .. deprecated:: 3.5
+    .. deprecated:: 3.4.1
         The OAuth token, introspection, and revocation endpoints are
         defined to use ``application/x-www-form-urlencoded`` request bodies
         (RFC 6749, RFC 7662, RFC 7009). Reading ``application/json`` on these

--- a/tests/test_oauth2_backends.py
+++ b/tests/test_oauth2_backends.py
@@ -183,12 +183,21 @@ class TestJSONOAuthLibCoreBackend(TestCase):
             }
         )
         request = self.factory.post("/o/token/", payload, content_type="application/json")
-        oauthlib_core = JSONOAuthLibCore()
+        with pytest.warns(DeprecationWarning):
+            oauthlib_core = JSONOAuthLibCore()
 
         uri, http_method, body, headers = oauthlib_core._extract_params(request)
         self.assertIn("grant_type=password", body)
         self.assertIn("username=john", body)
         self.assertIn("password=123456", body)
+
+    def test_instantiation_emits_deprecation_warning(self):
+        # JSONOAuthLibCore is deprecated (removal tracked in #1773): reading JSON
+        # request bodies on the OAuth endpoints is non-standard (RFC 6749/7662/7009).
+        with pytest.warns(
+            DeprecationWarning, match="deprecated and will be removed in django-oauth-toolkit 4.0"
+        ):
+            JSONOAuthLibCore()
 
 
 class TestOAuthLibCore(TestCase):


### PR DESCRIPTION
Deprecates #1773

## Description of the Change

`JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"] = "oauth2_provider.oauth2_backends.JSONOAuthLibCore"`) makes the OAuth **token, introspection, and revocation** endpoints read `application/json` request bodies. Those endpoints are defined by spec to use `application/x-www-form-urlencoded` bodies:

- token — [RFC 6749 §3.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.2)
- introspection — [RFC 7662 §2.1](https://datatracker.ietf.org/doc/html/rfc7662#section-2.1)
- revocation — [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1)

(The authorization endpoint carries its parameters in the request URI query string, not a request body, so it's unaffected.)

So the JSON mode is non-standard: it makes the server non-interoperable with spec-compliant OAuth clients/libraries and provides no capability the default backend lacks (any client can send a form-encoded body). It's a long-standing compatibility shim and was effectively undocumented.

This marks it deprecated:
- `JSONOAuthLibCore.__init__` now emits a `DeprecationWarning` (matching the existing deprecation pattern in `oauth2_provider/bcp.py` / `settings.py`), including a migration action.
- Docstring (`.. deprecated:: 3.4.1`), a `.. note::` in the `OAUTH2_BACKEND_CLASS` docs section, and `CHANGELOG.md` note the deprecation and the 4.0 removal.

Behavior is otherwise unchanged; removal is tracked in #1773 (4.0 milestone). Surfaced originally via #613 (JSON introspection), closed wontfix for the same reason.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UL3VhFFLATq7uKuBYScEn