### PR TITLE
Don't let the grace period bypass refresh-token reuse protection (#1617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) an
   access token revocation may also revoke the respective refresh token; for a
   user-initiated revocation that is now the behavior.
+* #1617 With `REFRESH_TOKEN_REUSE_PROTECTION` enabled, `REFRESH_TOKEN_GRACE_PERIOD_SECONDS`
+  no longer extends the validity of a refresh token that is several generations old in
+  the rotation chain. The grace period now only shields the *immediately preceding*
+  refresh token (the token a client retries when it did not receive the rotated
+  response); replaying an older, already-rotated-past token within the grace window is
+  rejected and revokes the whole token family, instead of being honored (and, without a
+  requested scope, minting a fresh token pair).
 
 ## [3.4.0] - 2026-07-23
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -162,8 +162,12 @@ Refresh-token rotation and replay detection (§4.14)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Rotation is on by default (``ROTATE_REFRESH_TOKEN``). Set
 ``REFRESH_TOKEN_REUSE_PROTECTION`` to ``True`` to revoke the entire token family when
-a refresh token is replayed (§4.14.2). Note that reuse detection only treats a replay
-as an attack after ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS``. The
+a refresh token is replayed (§4.14.2). With reuse protection enabled,
+``REFRESH_TOKEN_GRACE_PERIOD_SECONDS`` only shields the *immediately preceding*
+refresh token — the one a client retries when it did not receive the rotated
+response. Replaying a token that has already been rotated past (one several
+generations old in the chain) is treated as an attack immediately, even inside the
+grace window, and revokes the whole family. The
 ``COMPLIANT_BCP_RFC9700_REFRESH_TOKEN`` validation gate flags
 ``REFRESH_TOKEN_REUSE_PROTECTION = False`` (``W007`` while the gate is ``False``,
 ``E002`` once it is ``True``).

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -242,6 +242,11 @@ The ``cleartokens`` management command removes revoked refresh tokens once the
 grace period has passed, unless ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled.
 Check :ref:`cleartokens` management command for further info.
 
+When ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled the grace period applies only to
+the *immediately preceding* refresh token (the token a client retries when it did not
+receive the rotated response). A token that has already been rotated past is rejected
+as a reuse even within the grace window — see ``REFRESH_TOKEN_REUSE_PROTECTION`` below.
+
 REFRESH_TOKEN_REUSE_PROTECTION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When this is set to ``True`` (default ``False``), and ``ROTATE_REFRESH_TOKEN`` is used, the server will check

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1220,14 +1220,27 @@ class OAuth2Validator(RequestValidator):
         if not rt:
             return False
 
-        if rt.revoked is not None and rt.revoked <= timezone.now() - timedelta(
-            seconds=oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS
-        ):
-            if oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION and rt.token_family:
-                rt_token_family = RefreshToken.objects.filter(token_family=rt.token_family)
-                for related_rt in rt_token_family.all():
-                    related_rt.revoke()
-            return False
+        if rt.revoked is not None:
+            grace_expired = rt.revoked <= timezone.now() - timedelta(
+                seconds=oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS
+            )
+            # With reuse protection the grace period must only shield the
+            # *immediately preceding* refresh token -- a client that retried
+            # because it did not receive the rotated token. That token still owns
+            # the access token it minted; once the chain rotates again that access
+            # token is revoked (deleted), so its absence marks a stale token being
+            # replayed several generations down the chain. Honoring such a token
+            # within the grace window would defeat reuse protection (#1617).
+            stale_replay = (
+                oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION
+                and not AccessToken.objects.filter(source_refresh_token=rt).exists()
+            )
+            if grace_expired or stale_replay:
+                if oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION and rt.token_family:
+                    rt_token_family = RefreshToken.objects.filter(token_family=rt.token_family)
+                    for related_rt in rt_token_family.all():
+                        related_rt.revoke()
+                return False
 
         request.user = rt.user
         # Use the raw token presented in the request, not rt.token: under hashed-at-rest

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -1349,6 +1349,73 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_reuse_protection_stale_token_within_grace_period_is_rejected(self):
+        """
+        With reuse protection, the grace period only covers the immediately preceding
+        refresh token (a client retrying because it did not receive the rotated token).
+        A token that is several generations old must be rejected -- and must trigger
+        family revocation -- even while its ``revoked`` timestamp is still inside the
+        grace window. See issue #1617.
+        """
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 1000
+        self.oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION = True
+        self.client.login(username="test_user", password="123456")
+        authorization_code = self.get_auth()
+
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={
+                "grant_type": "authorization_code",
+                "code": authorization_code,
+                "redirect_uri": "http://example.org",
+            },
+            **auth_headers,
+        )
+        content = json.loads(response.content.decode("utf-8"))
+        refresh_token_1 = content["refresh_token"]
+        scope = content["scope"]
+
+        # R1 -> R2 (fresh, distinct token)
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token_1, "scope": scope},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        refresh_token_2 = json.loads(response.content.decode("utf-8"))["refresh_token"]
+        self.assertNotEqual(refresh_token_2, refresh_token_1)
+
+        # R2 -> R3 (fresh, distinct token): the chain has now advanced past R1
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token_2, "scope": scope},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+        refresh_token_3 = json.loads(response.content.decode("utf-8"))["refresh_token"]
+        self.assertNotEqual(refresh_token_3, refresh_token_2)
+
+        # Reusing R1 -- now two generations old -- within the grace window must fail,
+        # not mint a new token pair. The scope is intentionally omitted here: with the
+        # scope present the request happened to fail for an unrelated reason (the stale
+        # token's original scopes resolve to empty); without it, the pre-fix code minted
+        # brand-new tokens.
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token_1},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
+        # And the replay must revoke the whole family, so R3 is now unusable too.
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token_3, "scope": scope},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_refresh_repeating_requests_non_rotating_tokens(self):
         """
         Try refreshing an access token with the same refresh token more than once when not rotating tokens.


### PR DESCRIPTION
Fixes #1617

## Description of the Change

With `REFRESH_TOKEN_REUSE_PROTECTION` enabled, `validate_refresh_token` honored **any** revoked refresh token whose `revoked` timestamp was still inside `REFRESH_TOKEN_GRACE_PERIOD_SECONDS` — including tokens several generations old in the rotation chain. Replaying such a stale token within the grace window was accepted, defeating reuse protection.

### What actually happens on current `master`

Reproducing the issue's chain (R1 → R2 → R3, then reuse R1 within the grace window) shows the residual gap:

- Reusing stale **R1 without a `scope` param → HTTP 200 with a brand-new access + refresh pair** (the issue's reported behavior).
- With a `scope` param the request *happens* to 400, but only incidentally: `get_original_scopes` finds the stale token's minted access token has been deleted and returns `[]`, so oauthlib rejects on `invalid_scope` — not reuse protection. Either way the **token family is never revoked**, so the legitimately-rotated current token (R3) stays valid.

### The fix

The grace period is meant to shield only the **immediately preceding** refresh token — a client that retried because it did not receive the rotated response. That token still owns the access token it minted (`AccessToken.source_refresh_token`); once the chain rotates again that access token is revoked/deleted, so its absence is a reliable marker of a stale replay.

`validate_refresh_token` now, when reuse protection is on, treats a revoked token whose minted access token no longer exists as a stale replay: it rejects the request **and revokes the whole token family**, matching the [OAuth 2.0 Security BCP](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics#name-refresh-token-protection) recommendation. The legitimate immediately-preceding retry (its access token still present) continues to succeed within the grace window exactly as before.

Scope note: the new rejection is gated on `REFRESH_TOKEN_REUSE_PROTECTION`, matching the issue. Deployments without reuse protection keep the existing lenient grace behavior unchanged.

Docs (`docs/security.rst`, `docs/settings.rst`) are updated so the grace-period + reuse-protection interaction is described accurately.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

### Testing
Added `test_reuse_protection_stale_token_within_grace_period_is_rejected` (fails before, passes after) — it drives R1→R2→R3, then asserts a within-grace R1 replay is rejected **and** that the family revocation makes R3 unusable too. The existing grace / reuse-protection tests (`test_refresh_repeating_requests_grace_period_with_reuse_protection`, `test_refresh_repeating_requests`, `test_refresh_with_grace_period`, …) still pass. Full suite: 1007 passed under `tests.settings`; `tests/test_authorization_code.py` also green under `tests.settings_swapped`. `ruff check` / `ruff format --check` clean.