### PR TITLE
Enforce client ownership check in token revocation endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   response); replaying an older, already-rotated-past token within the grace window is
   rejected and revokes the whole token family, instead of being honored (and, without a
   requested scope, minting a fresh token pair).
+* #727 The token revocation endpoint (`/o/revoke_token/`) now only revokes tokens that
+  were issued to the authenticated client. Previously it revoked any token matching the
+  submitted value regardless of which application issued it, so a client could revoke
+  another client's tokens. Per
+  [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) the server
+  verifies the token was issued to the client making the request; a token belonging to a
+  different client is now left untouched and the endpoint still returns `200` (RFC 7009
+  §2.2) without disclosing whether the token exists.
 
 ## [3.4.0] - 2026-07-23
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1156,12 +1156,11 @@ class OAuth2Validator(RequestValidator):
 
         # RefreshToken uniqueness is (token_checksum, revoked), so several rows may share a
         # checksum; revoke every match instead of get() to avoid MultipleObjectsReturned.
-        tokens = list(token_type.objects.filter(token_checksum=token_checksum, application_id=application_pk))
+        lookup = {"token_checksum": token_checksum, "application_id": application_pk}
+        tokens = list(token_type.objects.filter(**lookup))
         if not tokens:
             for other_type in [_t for _t in token_types.values() if _t != token_type]:
-                tokens.extend(
-                    other_type.objects.filter(token_checksum=token_checksum, application_id=application_pk)
-                )
+                tokens.extend(other_type.objects.filter(**lookup))
         for t in tokens:
             t.revoke()
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1146,8 +1146,16 @@ class OAuth2Validator(RequestValidator):
         if not tokens:
             for other_type in [_t for _t in token_types.values() if _t != token_type]:
                 tokens.extend(other_type.objects.filter(token_checksum=token_checksum))
+        # RFC 7009 section 2.1: the authorization server "verifies whether the token was
+        # issued to the client making the revocation request." A client must not be able
+        # to revoke another client's tokens. Tokens that were not issued to the
+        # authenticated client are left untouched and treated like an unknown token, so
+        # the endpoint still returns 200 (RFC 7009 section 2.2) without disclosing whether
+        # the token exists.
+        client = request.client
         for t in tokens:
-            t.revoke()
+            if client is not None and t.application_id == client.pk:
+                t.revoke()
 
     def build_http_request(self, request: OauthlibRequest) -> HttpRequest:
         """

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1140,22 +1140,30 @@ class OAuth2Validator(RequestValidator):
 
         token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
         token_type = token_types.get(token_type_hint, AccessToken)
-        # RefreshToken uniqueness is (token_checksum, revoked), so several rows may share a
-        # checksum; revoke every match instead of get() to avoid MultipleObjectsReturned.
-        tokens = list(token_type.objects.filter(token_checksum=token_checksum))
-        if not tokens:
-            for other_type in [_t for _t in token_types.values() if _t != token_type]:
-                tokens.extend(other_type.objects.filter(token_checksum=token_checksum))
+
         # RFC 7009 section 2.1: the authorization server "verifies whether the token was
         # issued to the client making the revocation request." A client must not be able
-        # to revoke another client's tokens. Tokens that were not issued to the
-        # authenticated client are left untouched and treated like an unknown token, so
-        # the endpoint still returns 200 (RFC 7009 section 2.2) without disclosing whether
-        # the token exists.
-        client = request.client
+        # to revoke another client's tokens, so the lookup is scoped to the authenticated
+        # client (request.client). Filtering by application in the queryset means a
+        # same-checksum token belonging to a different client is treated like an unknown
+        # token -- the search still falls back to the other token type, and the endpoint
+        # returns 200 (RFC 7009 section 2.2) without disclosing whether the token exists.
+        # Bail out when the request is not tied to a stored application so a NULL
+        # application filter can never match unrelated tokens.
+        application_pk = getattr(request.client, "pk", None)
+        if application_pk is None:
+            return
+
+        # RefreshToken uniqueness is (token_checksum, revoked), so several rows may share a
+        # checksum; revoke every match instead of get() to avoid MultipleObjectsReturned.
+        tokens = list(token_type.objects.filter(token_checksum=token_checksum, application_id=application_pk))
+        if not tokens:
+            for other_type in [_t for _t in token_types.values() if _t != token_type]:
+                tokens.extend(
+                    other_type.objects.filter(token_checksum=token_checksum, application_id=application_pk)
+                )
         for t in tokens:
-            if client is not None and t.application_id == client.pk:
-                t.revoke()
+            t.revoke()
 
     def build_http_request(self, request: OauthlibRequest) -> HttpRequest:
         """

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -457,7 +457,9 @@ class TestOAuth2Validator(TransactionTestCase):
     def test_revoke_token_without_authenticated_client_is_noop(self):
         # RFC 7009 §2.1 client-ownership check: with no authenticated client on the
         # request there is nobody the token could have been "issued to," so revoke_token
-        # must not revoke anything (and must not match tokens with a NULL application).
+        # must not revoke anything. In particular the early return must fire before the
+        # queryset is built, so an application-less (NULL application) token is not matched
+        # by an ``application_id=None`` filter.
         token = "unauthenticated-revoke-token"
         access_token = AccessToken.objects.create(
             token=token,
@@ -465,12 +467,21 @@ class TestOAuth2Validator(TransactionTestCase):
             expires=timezone.now() + datetime.timedelta(seconds=60),
             application=self.application,
         )
+        applicationless_token = AccessToken.objects.create(
+            token="applicationless-token",
+            user=self.user,
+            expires=timezone.now() + datetime.timedelta(seconds=60),
+            application=None,
+        )
 
         request = mock.MagicMock(wraps=Request)
         request.client = None
-        self.validator.revoke_token(token, "access_token", request)
+        # Revoke by the value of the NULL-application token: a naive ``application_id=None``
+        # filter would match it; the early return must prevent that.
+        self.validator.revoke_token("applicationless-token", "access_token", request)
 
         self.assertTrue(AccessToken.objects.filter(pk=access_token.pk).exists())
+        self.assertTrue(AccessToken.objects.filter(pk=applicationless_token.pk).exists())
 
     def test_save_bearer_token__without_user__raises_fatal_client(self):
         token = {}

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -404,7 +404,11 @@ class TestOAuth2Validator(TransactionTestCase):
             application=self.application,
         )
 
-        self.validator.revoke_token(long_token, "refresh_token", mock.MagicMock(wraps=Request))
+        # revoke_token runs after client authentication, so request.client is the
+        # authenticated (owning) application; see RFC 7009 §2.1 client-ownership check.
+        request = mock.MagicMock(wraps=Request)
+        request.client = self.application
+        self.validator.revoke_token(long_token, "refresh_token", request)
 
         refresh_token.refresh_from_db()
         self.assertIsNotNone(refresh_token.revoked)
@@ -443,7 +447,9 @@ class TestOAuth2Validator(TransactionTestCase):
             application=self.application,
         )
 
-        self.validator.revoke_token(token, "refresh_token", mock.MagicMock(wraps=Request))
+        request = mock.MagicMock(wraps=Request)
+        request.client = self.application
+        self.validator.revoke_token(token, "refresh_token", request)
 
         active_token.refresh_from_db()
         self.assertIsNotNone(active_token.revoked)

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -454,6 +454,24 @@ class TestOAuth2Validator(TransactionTestCase):
         active_token.refresh_from_db()
         self.assertIsNotNone(active_token.revoked)
 
+    def test_revoke_token_without_authenticated_client_is_noop(self):
+        # RFC 7009 §2.1 client-ownership check: with no authenticated client on the
+        # request there is nobody the token could have been "issued to," so revoke_token
+        # must not revoke anything (and must not match tokens with a NULL application).
+        token = "unauthenticated-revoke-token"
+        access_token = AccessToken.objects.create(
+            token=token,
+            user=self.user,
+            expires=timezone.now() + datetime.timedelta(seconds=60),
+            application=self.application,
+        )
+
+        request = mock.MagicMock(wraps=Request)
+        request.client = None
+        self.validator.revoke_token(token, "access_token", request)
+
+        self.assertTrue(AccessToken.objects.filter(pk=access_token.pk).exists())
+
     def test_save_bearer_token__without_user__raises_fatal_client(self):
         token = {}
 

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -314,6 +314,62 @@ class TestRevocationView(BaseTest):
         self.assertIsNone(refresh_token.revoked)
         self.assertTrue(AccessToken.objects.filter(pk=victim_access_token.pk).exists())
 
+    def test_hinted_lookup_falls_back_across_token_types_respecting_ownership(self):
+        """
+        A ``token_type_hint`` that matches only another client's token in the hinted
+        table must still fall back to the other token type to find the caller's own
+        token (issue #727 / RFC 7009 §2.1). Because the ownership filter is part of the
+        lookup, a same-value token owned by a different client does not block the
+        fallback.
+        """
+        other_application = Application.objects.create(
+            name="Other Application",
+            redirect_uris="http://localhost",
+            user=self.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_secret=CLEARTEXT_SECRET,
+        )
+        shared_value = "shared-token-value"
+        # Another client's access token in the *hinted* table, sharing the value...
+        other_access_token = AccessToken.objects.create(
+            user=self.test_user,
+            token=shared_value,
+            application=other_application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+        # ...and the caller's own refresh token (same value) in the other table.
+        own_access_token = AccessToken.objects.create(
+            user=self.test_user,
+            token="own-access-token",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+        own_refresh_token = RefreshToken.objects.create(
+            user=self.test_user,
+            token=shared_value,
+            application=self.application,
+            access_token=own_access_token,
+        )
+
+        data = {
+            "client_id": self.application.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "token": shared_value,
+            "token_type_hint": "access_token",
+        }
+        url = reverse("oauth2_provider:revoke-token")
+        response = self.client.post(url, data=data)
+        self.assertEqual(response.status_code, 200)
+
+        # The caller's own refresh token (in the non-hinted table) is revoked...
+        own_refresh_token.refresh_from_db()
+        self.assertIsNotNone(own_refresh_token.revoked)
+        # ...while the other client's same-valued access token is untouched.
+        self.assertTrue(AccessToken.objects.filter(pk=other_access_token.pk).exists())
+
     def test_revoke_token_with_wrong_hint(self):
         """
         From the revocation rfc, `Section 4.1.2`_ :

--- a/tests/test_token_revocation.py
+++ b/tests/test_token_revocation.py
@@ -238,6 +238,82 @@ class TestRevocationView(BaseTest):
         refresh_token = RefreshToken.objects.filter(pk=rtok.pk).first()
         self.assertIsNotNone(refresh_token.revoked)
 
+    def test_cannot_revoke_another_clients_token(self):
+        """
+        RFC 7009 §2.1: a client may only revoke tokens that were issued to it.
+        Authenticating as one application must not revoke a token belonging to a
+        different application. See issue #727.
+        """
+        other_application = Application.objects.create(
+            name="Other Application",
+            redirect_uris="http://localhost",
+            user=self.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_secret=CLEARTEXT_SECRET,
+        )
+        victim_token = AccessToken.objects.create(
+            user=self.test_user,
+            token="1234567890",
+            application=other_application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+
+        # Authenticate as self.application but present the other application's token.
+        data = {
+            "client_id": self.application.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "token": victim_token.token,
+        }
+        url = reverse("oauth2_provider:revoke-token")
+        response = self.client.post(url, data=data)
+
+        # RFC 7009 §2.2: the endpoint still returns 200 (it does not disclose whether the
+        # token exists), but the other client's token must remain untouched.
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(AccessToken.objects.filter(pk=victim_token.pk).exists())
+
+    def test_cannot_revoke_another_clients_refresh_token(self):
+        """
+        The client-ownership check also applies to refresh tokens (issue #727).
+        """
+        other_application = Application.objects.create(
+            name="Other Application",
+            redirect_uris="http://localhost",
+            user=self.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_secret=CLEARTEXT_SECRET,
+        )
+        victim_access_token = AccessToken.objects.create(
+            user=self.test_user,
+            token="1234567890",
+            application=other_application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            scope="read write",
+        )
+        victim_refresh_token = RefreshToken.objects.create(
+            user=self.test_user,
+            token="999999999",
+            application=other_application,
+            access_token=victim_access_token,
+        )
+
+        data = {
+            "client_id": self.application.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "token": victim_refresh_token.token,
+            "token_type_hint": "refresh_token",
+        }
+        url = reverse("oauth2_provider:revoke-token")
+        response = self.client.post(url, data=data)
+
+        self.assertEqual(response.status_code, 200)
+        refresh_token = RefreshToken.objects.filter(pk=victim_refresh_token.pk).first()
+        self.assertIsNone(refresh_token.revoked)
+        self.assertTrue(AccessToken.objects.filter(pk=victim_access_token.pk).exists())
+
     def test_revoke_token_with_wrong_hint(self):
         """
         From the revocation rfc, `Section 4.1.2`_ :


### PR DESCRIPTION
Fixes #727

## Description of the Change

This PR implements RFC 7009 §2.1 compliance for the token revocation endpoint by ensuring that clients can only revoke tokens that were issued to them. Previously, any authenticated client could revoke any token in the system by submitting its value, regardless of which application originally issued it.

### Changes Made

1. **oauth2_provider/oauth2_validators.py**: Modified the `revoke_token()` method to verify that the token being revoked belongs to the authenticated client before revoking it. Tokens belonging to other clients are left untouched, and the endpoint still returns HTTP 200 (per RFC 7009 §2.2) without disclosing whether the token exists.

2. **tests/test_token_revocation.py**: Added two comprehensive test cases:
   - `test_cannot_revoke_another_clients_token()`: Verifies that a client cannot revoke another client's access token
   - `test_cannot_revoke_another_clients_refresh_token()`: Verifies that a client cannot revoke another client's refresh token

3. **tests/test_oauth2_validators.py**: Updated existing tests to properly set `request.client` to the owning application, ensuring the client ownership check works as intended.

4. **CHANGELOG.md**: Documented the security fix with reference to RFC 7009 and issue #727.

## Checklist

- [x] PR only contains one change (client ownership enforcement in token revocation)
- [x] unit-test added (two new test cases covering access and refresh tokens)
- [x] documentation updated (CHANGELOG.md)
- [ ] `AUTHORS` update (not applicable for this fix)
- [ ] tests/app/idp updated (not applicable - no new features)
- [ ] tests/app/rp updated (not applicable - no new features)

https://claude.ai/code/session_01U5nbZ25qTxm7Q4mHxywwx8