### PR TITLE
Delete the associated ID token when revoking an access token (#1604)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its ID token orphaned, and those rows accumulated until they expired and `cleartokens`
   reclaimed them. `AccessToken.revoke()` now removes the ID token too, keeping the ID
   token count aligned with the access token count. (The RP-initiated logout flow, which
-  previously deleted the ID token itself, now relies on this.)
+  previously deleted the ID token itself, now relies on this.) **Behavior change:** because
+  a rotated-out ID token is deleted immediately rather than lingering until it expires, an
+  `id_token_hint` for RP-initiated logout must be the client's *current* ID token; a
+  superseded one is no longer accepted.
 * #1687 Reusing a refresh token within `REFRESH_TOKEN_GRACE_PERIOD_SECONDS` no longer
   raises `AttributeError: 'NoneType' object has no attribute 'token'` (HTTP 500) when the
   access token previously minted from that refresh token still exists but its own refresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
   removal in 4.0.
 ### Fixed
+* #1604 Revoking an access token now also deletes its associated OIDC ID token. The
+  one-to-one `AccessToken.id_token` cascade only ran in the ID-token→access-token
+  direction, so rotating an access token out on refresh (or otherwise revoking it) left
+  its ID token orphaned, and those rows accumulated until they expired and `cleartokens`
+  reclaimed them. `AccessToken.revoke()` now removes the ID token too, keeping the ID
+  token count aligned with the access token count. (The RP-initiated logout flow, which
+  previously deleted the ID token itself, now relies on this.)
 * #1687 Reusing a refresh token within `REFRESH_TOKEN_GRACE_PERIOD_SECONDS` no longer
   raises `AttributeError: 'NoneType' object has no attribute 'token'` (HTTP 500) when the
   access token previously minted from that refresh token still exists but its own refresh

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -607,7 +607,15 @@ class AbstractAccessToken(models.Model):
         Convenience method to uniform tokens" interface, for now
         simply remove this token from the database in order to revoke it.
         """
+        # Also remove the associated ID token. The OneToOne ``AccessToken.id_token``
+        # cascade only fires when the *ID token* is deleted (which deletes its access
+        # token), not the reverse, so deleting the access token on its own -- e.g. when
+        # rotating it out on refresh -- would orphan its ID token and let those rows
+        # accumulate until they expire and ``cleartokens`` reclaims them (#1604).
+        id_token = self.id_token
         self.delete()
+        if id_token is not None:
+            id_token.delete()
 
     @property
     def scopes(self):

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -623,7 +623,7 @@ class AbstractAccessToken(models.Model):
             id_token = None
         self.delete()
         if id_token is not None:
-            id_token.delete()
+            id_token.revoke()
 
     @property
     def scopes(self):

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -12,7 +12,7 @@ from urllib.parse import parse_qsl, urlparse
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.hashers import identify_hasher, make_password
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, ValidationError
 from django.db import models, router, transaction
 from django.urls import reverse
 from django.utils import timezone
@@ -612,7 +612,15 @@ class AbstractAccessToken(models.Model):
         # token), not the reverse, so deleting the access token on its own -- e.g. when
         # rotating it out on refresh -- would orphan its ID token and let those rows
         # accumulate until they expire and ``cleartokens`` reclaims them (#1604).
-        id_token = self.id_token
+        #
+        # A swapped access token model may drop ID token support entirely
+        # (``id_token = None``), so ``self.id_token`` -- not ``self.id_token_id`` -- is the
+        # field-agnostic accessor. Under cross-database routing the FK is not enforced, so
+        # the reference may dangle; treat a missing row as "nothing to clean up".
+        try:
+            id_token = self.id_token
+        except ObjectDoesNotExist:
+            id_token = None
         self.delete()
         if id_token is not None:
             id_token.delete()

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -446,9 +446,8 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
                 RefreshToken.objects.filter(access_token__in=access_tokens_to_delete)
             )
             for token in access_tokens_to_delete:
-                # Delete the token and its corresponding refresh and IDTokens.
-                if token.id_token:
-                    token.id_token.revoke()
+                # Delete the token and its corresponding IDToken. AccessToken.revoke()
+                # removes the associated IDToken as well (see #1604).
                 token.revoke()
             for refresh_token in refresh_tokens_to_delete:
                 refresh_token.revoke()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,7 +6,7 @@ from unittest import mock
 import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import check_password
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import ImproperlyConfigured, ObjectDoesNotExist, ValidationError
 from django.test.utils import override_settings
 from django.utils import timezone
 
@@ -385,6 +385,24 @@ class TestAccessTokenModel(BaseTestModels):
         expected_checksum = hashlib.sha256(token.encode()).hexdigest()
 
         self.assertEqual(access_token.token_checksum, expected_checksum)
+
+    def test_revoke_tolerates_missing_id_token(self):
+        # revoke() cleans up the associated ID token, but a dangling reference is
+        # possible under cross-database routing (where the FK is not enforced). Loading
+        # it then raises ObjectDoesNotExist, which must not break revocation (#1604).
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="tok-dangling-id-token",
+            expires=timezone.now() + timedelta(hours=1),
+        )
+        with mock.patch.object(
+            type(access_token),
+            "id_token",
+            new_callable=mock.PropertyMock,
+            side_effect=ObjectDoesNotExist,
+        ):
+            access_token.revoke()
+        self.assertFalse(AccessToken.objects.filter(pk=access_token.pk).exists())
 
 
 class TestRefreshTokenModel(BaseTestModels):

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -29,6 +29,7 @@ from oauth2_provider.views.oidc import RPInitiatedLogoutView, _load_id_token, _v
 
 from . import presets
 from .common_testing import OAuth2ProviderTestCase as TestCase
+from .conftest import CLEARTEXT_SECRET
 
 
 @pytest.mark.usefixtures("oauth2_settings")
@@ -1064,6 +1065,37 @@ def test_token_deletion_on_logout_disabled(oidc_tokens, logged_in_client, rp_set
     assert not any([token.is_expired() for token in IDToken.objects.all()])
     assert RefreshToken.objects.count() == 1
     assert not any([token.revoked is not None for token in RefreshToken.objects.all()])
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_id_token_not_orphaned_on_refresh(oidc_tokens, client):
+    """
+    Rotating an access token out on refresh must not leave its ID token orphaned.
+    A fresh ID token is issued on each refresh, so without cleanup the ID token count
+    grows unbounded while the access token count stays constant (#1604).
+    """
+    AccessToken = get_access_token_model()
+    IDToken = get_id_token_model()
+    RefreshToken = get_refresh_token_model()
+    assert AccessToken.objects.count() == 1
+    assert IDToken.objects.count() == 1
+
+    refresh_token = RefreshToken.objects.get().token
+    rsp = client.post(
+        reverse("oauth2_provider:token"),
+        data={
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": oidc_tokens.application.client_id,
+            "client_secret": CLEARTEXT_SECRET,
+            "scope": "openid",
+        },
+    )
+    assert rsp.status_code == 200
+    assert "id_token" in rsp.json()
+    # The rotated-out access token's ID token must be cleaned up, not left orphaned.
+    assert AccessToken.objects.count() == 1
+    assert IDToken.objects.count() == 1
 
 
 EXAMPLE_EMAIL = "example.email@example.com"


### PR DESCRIPTION
Fixes #1604

## Description of the Change

`AccessToken.id_token` is a `OneToOneField(IDToken, on_delete=CASCADE)`, but that cascade only fires in the **ID-token → access-token** direction. So deleting an access token on its own — e.g. rotating it out on refresh — left its ID token **orphaned**. Since a fresh ID token is issued on every OIDC refresh, the ID token count grew unbounded while the access token count stayed constant (they were only reclaimed later, once expired, by `cleartokens`).

`AccessToken.revoke()` now deletes the associated ID token as well, keeping ID-token lifetime aligned with its access token.

### Is this spec-compatible?

Yes. **OIDC Core 1.0 §12.2** makes returning an ID token on refresh *optional* and imposes **no requirement to retain superseded ID tokens** — an ID token is an authentication-time assertion consumed by the client, not something the AS must persist. The only DOT feature that reads a *stored* ID token is **RP-Initiated Logout** (`id_token_hint`, looked up by `jti`); the correct flow uses the client's *current* ID token (which this leaves intact), and logout tolerates an unrecognized hint. This fix just reclaims orphaned rows promptly instead of waiting for expiry + `cleartokens`.

### Scope

Implemented at `AccessToken.revoke()`, so it also cleans up on explicit revocation (`/o/revoke_token/`) and RP-initiated logout — not only refresh. The logout flow (`do_logout`) previously deleted the ID token itself before `token.revoke()`; that manual step is removed, since `revoke()` now handles it (leaving it would double-delete).

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

### Testing
Added `test_id_token_not_orphaned_on_refresh`, which refreshes an OIDC token and asserts the ID token count stays at 1 (fails on master with count 2, passes after). Full suite: **1014 passed** under `tests.settings`. Under `tests.settings_swapped` this change is strictly neutral-to-positive (8 pre-existing failures on master → 7 with this branch; the remaining ones are unrelated swapped-model reverse-accessor issues). `ruff check` / `ruff format --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5nbZ25qTxm7Q4mHxywwx8)_