### PR TITLE
Expire refresh tokens by their own age in clear_expired (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the
   interrelated token models together.
+* #746 A system check (`oauth2_provider.W012`) that warns when
+  `REFRESH_TOKEN_EXPIRE_SECONDS` is set shorter than `ACCESS_TOKEN_EXPIRE_SECONDS`. Since
+  refresh tokens are now reclaimed by their own age, such a configuration can delete a
+  refresh token before its access token expires, leaving clients unable to refresh.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
   removal in 4.0.
 ### Fixed
+* #746 `cleartokens` / `clear_expired()` now expires refresh tokens by their own age
+  (`created`) rather than by their access token's expiry. The previous
+  `access_token__expires__lt` condition keyed cleanup on the wrong lifetime and could
+  never match a refresh token whose access token had already been removed (rotated out,
+  or deleted by an earlier sweep), leaving such refresh tokens in the database
+  indefinitely. They are now reclaimed `REFRESH_TOKEN_EXPIRE_SECONDS` after issuance
+  regardless of their access token's state.
 * #1687 Reusing a refresh token within `REFRESH_TOKEN_GRACE_PERIOD_SECONDS` no longer
   raises `AttributeError: 'NoneType' object has no attribute 'token'` (HTTP 500) when the
   access token previously minted from that refresh token still exists but its own refresh

--- a/oauth2_provider/checks.py
+++ b/oauth2_provider/checks.py
@@ -204,7 +204,10 @@ def validate_refresh_token_expire_seconds(app_configs, **kwargs):
     """
     refresh_expire = _expire_seconds(oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS)
     access_expire = _expire_seconds(oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
-    if refresh_expire is None or access_expire is None:
+    # clear_expired() only age-expires refresh tokens when REFRESH_TOKEN_EXPIRE_SECONDS is
+    # truthy (it gates on ``if REFRESH_TOKEN_EXPIRE_SECONDS``); None / 0 / timedelta(0)
+    # disable that cleanup, so there is nothing to warn about.
+    if not refresh_expire or access_expire is None:
         return []
     if refresh_expire < access_expire:
         return [
@@ -212,9 +215,10 @@ def validate_refresh_token_expire_seconds(app_configs, **kwargs):
                 "OAUTH2_PROVIDER['REFRESH_TOKEN_EXPIRE_SECONDS'] "
                 f"({oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS!r}) is shorter than "
                 "OAUTH2_PROVIDER['ACCESS_TOKEN_EXPIRE_SECONDS'] "
-                f"({oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS!r}). A refresh token is "
-                "reclaimed that many seconds after it is issued, so it can be deleted "
-                "before its access token expires, leaving clients unable to refresh.",
+                f"({oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS!r}). cleartokens reclaims a "
+                "refresh token that many seconds after it is issued, so once it runs a "
+                "refresh token can be deleted before its access token expires, leaving "
+                "clients unable to refresh.",
                 hint=(
                     "Set OAUTH2_PROVIDER['REFRESH_TOKEN_EXPIRE_SECONDS'] to at least "
                     "ACCESS_TOKEN_EXPIRE_SECONDS (a refresh token should outlive the access "

--- a/oauth2_provider/checks.py
+++ b/oauth2_provider/checks.py
@@ -1,8 +1,21 @@
+from datetime import timedelta
+
 from django.apps import apps
 from django.core import checks
 from django.db import router
 
 from .settings import oauth2_settings
+
+
+def _expire_seconds(value):
+    """Coerce a ``*_EXPIRE_SECONDS`` setting (int/float seconds or ``timedelta``) to
+    seconds, or ``None`` if it is not a usable numeric value (bad types are surfaced by
+    ``clear_expired``/token issuance, not here)."""
+    if isinstance(value, timedelta):
+        return value.total_seconds()
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return value
 
 
 # RFC 9700 (OAuth 2.0 Security Best Current Practice) behavior gates. Each tuple is
@@ -176,6 +189,41 @@ def validate_bcp_configuration(app_configs, **kwargs):
         )
 
     return messages
+
+
+@checks.register(checks.Tags.security)
+def validate_refresh_token_expire_seconds(app_configs, **kwargs):
+    """
+    A refresh token must outlive the access token it is meant to refresh.
+
+    ``cleartokens`` reclaims a refresh token ``REFRESH_TOKEN_EXPIRE_SECONDS`` after it is
+    issued (#746). If that is shorter than ``ACCESS_TOKEN_EXPIRE_SECONDS`` the refresh
+    token can be deleted before its access token even expires, leaving the client with an
+    access token it cannot refresh. ``REFRESH_TOKEN_EXPIRE_SECONDS`` defaults to ``None``
+    (refresh tokens are not age-expired), for which this check is a no-op.
+    """
+    refresh_expire = _expire_seconds(oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS)
+    access_expire = _expire_seconds(oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS)
+    if refresh_expire is None or access_expire is None:
+        return []
+    if refresh_expire < access_expire:
+        return [
+            checks.Warning(
+                "OAUTH2_PROVIDER['REFRESH_TOKEN_EXPIRE_SECONDS'] "
+                f"({oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS!r}) is shorter than "
+                "OAUTH2_PROVIDER['ACCESS_TOKEN_EXPIRE_SECONDS'] "
+                f"({oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS!r}). A refresh token is "
+                "reclaimed that many seconds after it is issued, so it can be deleted "
+                "before its access token expires, leaving clients unable to refresh.",
+                hint=(
+                    "Set OAUTH2_PROVIDER['REFRESH_TOKEN_EXPIRE_SECONDS'] to at least "
+                    "ACCESS_TOKEN_EXPIRE_SECONDS (a refresh token should outlive the access "
+                    "tokens it issues)."
+                ),
+                id="oauth2_provider.W012",
+            )
+        ]
+    return []
 
 
 @checks.register(checks.Tags.database)

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1032,7 +1032,12 @@ def clear_expired():
         logger.info("refresh_revoked_at is %s. No revoked refresh tokens deleted.", refresh_revoked_at)
 
     if refresh_expire_at:
-        expired_query = models.Q(access_token__expires__lt=refresh_expire_at)
+        # Expire refresh tokens by their own age (``created``), not by their access
+        # token's expiry. The old ``access_token__expires__lt`` join keyed cleanup on the
+        # wrong lifetime and, worse, could never match once the access token had been
+        # deleted (rotated out, or removed by an earlier sweep) -- leaving the refresh
+        # token in the database forever. See issue #746.
+        expired_query = models.Q(created__lt=refresh_expire_at)
         expired = refresh_token_model.objects.filter(expired_query)
 
         expired_deleted_no = batch_delete(expired, expired_query)

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -85,6 +85,18 @@ class RefreshTokenExpireSecondsCheckTestCase(TestCase):
         self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
         self.assertNotIn("oauth2_provider.W012", self._ids())
 
+    def test_zero_refresh_expire_passes(self):
+        # clear_expired() gates its refresh-token cleanup on ``if REFRESH_TOKEN_EXPIRE_SECONDS``,
+        # so 0 / timedelta(0) disable age expiry entirely -- there is nothing to warn about.
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 0
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_zero_timedelta_refresh_expire_passes(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = timedelta(0)
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
     def test_refresh_longer_than_access_passes(self):
         self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
         self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 86400

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -1,10 +1,15 @@
+from datetime import timedelta
+
 import pytest
 from django.core import checks
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import override_settings
 
-from oauth2_provider.checks import validate_swapped_model_consistency
+from oauth2_provider.checks import (
+    validate_refresh_token_expire_seconds,
+    validate_swapped_model_consistency,
+)
 
 from .common_testing import OAuth2ProviderTestCase as TestCase
 
@@ -60,3 +65,49 @@ class SwappedModelConsistencyCheckTestCase(TestCase):
         self.oauth2_settings.ACCESS_TOKEN_MODEL = "app_a.AccessToken"
         self.oauth2_settings.REFRESH_TOKEN_MODEL = "app_b.RefreshToken"
         self.assertIn("oauth2_provider.W011", self._ids())
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class RefreshTokenExpireSecondsCheckTestCase(TestCase):
+    def _ids(self):
+        return {m.id for m in validate_refresh_token_expire_seconds(None)}
+
+    def test_check_is_registered(self):
+        from django.core.checks.registry import registry as checks_registry
+
+        self.assertIn(
+            validate_refresh_token_expire_seconds,
+            checks_registry.get_checks(include_deployment_checks=True),
+        )
+
+    def test_default_none_passes(self):
+        # REFRESH_TOKEN_EXPIRE_SECONDS defaults to None (no age expiry) -> no-op.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_refresh_longer_than_access_passes(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 86400
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_refresh_equal_to_access_passes(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_refresh_shorter_than_access_warns(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 60
+        messages = validate_refresh_token_expire_seconds(None)
+        self.assertEqual([m.id for m in messages], ["oauth2_provider.W012"])
+        self.assertIsInstance(messages[0], checks.Warning)
+
+    def test_timedelta_refresh_shorter_than_access_warns(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = 3600
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = timedelta(minutes=1)
+        self.assertIn("oauth2_provider.W012", self._ids())
+
+    def test_non_numeric_does_not_crash(self):
+        # A bad type is surfaced by clear_expired()/issuance, not this check.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = "not-a-number"
+        self.assertNotIn("oauth2_provider.W012", self._ids())

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -558,6 +558,12 @@ class TestClearExpired(BaseTestModels):
         initial_gt_count = Grant.objects.count()
         assert initial_gt_count == self.num_tokens * 2, f"{self.num_tokens * 2} grants should exist."
 
+        # Refresh tokens now expire by their own age (``created``), not by their access
+        # token's expiry (#746). Backdate the refresh tokens attached to expired access
+        # tokens past REFRESH_TOKEN_EXPIRE_SECONDS so they are the ones reclaimed; the
+        # rest were just created and must survive.
+        RefreshToken.objects.filter(access_token__expires__lte=self.now).update(created=self.earlier)
+
         clear_expired()
 
         # after clear_expired():
@@ -585,6 +591,42 @@ class TestClearExpired(BaseTestModels):
         )
         remaining_gt_count = Grant.objects.count()
         assert remaining_gt_count == initial_gt_count // 2, "half the remaining grants should still exist."
+
+    def test_clear_expired_deletes_old_refresh_token_without_access_token(self):
+        """
+        A refresh token older than REFRESH_TOKEN_EXPIRE_SECONDS must be reclaimed even
+        when its access token is gone (rotated out or removed by an earlier sweep). The
+        previous ``access_token__expires__lt`` condition could never match a refresh token
+        whose ``access_token`` is NULL, so such tokens were left in the DB forever (#746).
+        """
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = self.delta_secs // 2
+
+        app = Application.objects.get(name="test_app")
+        orphaned = RefreshToken.objects.create(
+            token="orphaned old refresh token",
+            application=app,
+            access_token=None,
+            user=self.user,
+        )
+        # created is auto_now_add, so backdate it past the expiry window.
+        RefreshToken.objects.filter(pk=orphaned.pk).update(created=self.earlier)
+
+        # A recently issued refresh token with no access token must survive.
+        recent = RefreshToken.objects.create(
+            token="recent refresh token without access token",
+            application=app,
+            access_token=None,
+            user=self.user,
+        )
+
+        clear_expired()
+
+        assert not RefreshToken.objects.filter(pk=orphaned.pk).exists(), (
+            "an expired refresh token must be reclaimed even without an access token"
+        )
+        assert RefreshToken.objects.filter(pk=recent.pk).exists(), (
+            "a refresh token within its expiry window must be kept"
+        )
 
 
 @pytest.mark.usefixtures("oauth2_settings")
@@ -875,12 +917,14 @@ def test_clear_expired_id_tokens(oauth2_settings, oidc_tokens, rf):
 
     assert IDToken.objects.filter(jti=id_token.jti).exists()
 
-    # Mark refresh token as expired
+    # Mark the refresh token as expired. Refresh tokens now expire by their own age
+    # (``created``), not by their access token's expiry (#746), so backdate it past the
+    # expiry window rather than expiring the access token.
     delta = timedelta(seconds=oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS + 60)
-    access_token.expires = timezone.now() - delta
-    access_token.save()
+    RefreshToken.objects.filter(access_token=access_token).update(created=timezone.now() - delta)
 
-    # With the refresh token expired, the ID token should be deleted
+    # With the refresh token expired, it -- and then the now-orphaned, expired access and
+    # ID tokens -- should be deleted.
     clear_expired()
 
     assert not IDToken.objects.filter(jti=id_token.jti).exists()


### PR DESCRIPTION
Fixes #746 (in part — see scope note below)

## Description of the Change

`clear_expired()` reclaimed "expired" refresh tokens with:

```python
expired_query = models.Q(access_token__expires__lt=refresh_expire_at)
```

That's wrong two ways, both called out in #746:

1. **Wrong lifetime.** It keys refresh-token cleanup on the *access token's* expiry, not the refresh token's own lifetime. A refresh token's validity window is `REFRESH_TOKEN_EXPIRE_SECONDS` from **its** issuance, independent of any access token.
2. **Orphaned forever.** The condition is a join on `access_token__expires`. Once the access token is gone — rotated out on refresh, or removed by an earlier `clear_expired` sweep — the refresh token's `access_token` is `NULL`, the join can never match, and the refresh token is **left in the database indefinitely**. (The reporter also noted the sweep can delete the access token first, permanently stranding the refresh token.)

`RefreshToken` already has a `created` timestamp, so the fix keys the deletion on the token's own age:

```python
expired_query = models.Q(created__lt=refresh_expire_at)
```

Refresh tokens are now reclaimed `REFRESH_TOKEN_EXPIRE_SECONDS` after issuance regardless of whether their access token still exists. The revoked-refresh-token deletion (and reuse-protection retention) is unchanged.

## Scope

#746 raises three things; this PR fixes the third (the `clear_expired` conditions — the foundation flagged in #1783). The other two are carried as separate follow-ups because they're more entangled:
- `validate_refresh_token` ignoring `REFRESH_TOKEN_EXPIRE_SECONDS` at validation time (interacts with the default-`None` question in #1715);
- the grace period being applied to *voluntary* revocation as well as rotation (a revocation-semantics change touching `revoke()`).

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

### Testing
Added `test_clear_expired_deletes_old_refresh_token_without_access_token` — a refresh token older than `REFRESH_TOKEN_EXPIRE_SECONDS` with `access_token=None`; it fails on `master` (the token survives forever) and passes here. Updated `test_clear_expired_tokens_with_tokens` and `test_clear_expired_id_tokens` to drive expiry by refresh-token age (`created`) rather than by expiring the access token, since that's what now correctly triggers the cleanup cascade. Full suite: **1014 passed** under `tests.settings`. (The `tests.settings_swapped` clear-token tests fail on `master` already — `clear_expired`'s existing `refresh_token__isnull` reverse-accessor doesn't resolve under the swapped test models — and that suite isn't part of the CI matrix, which runs swapped *migrations* only.) `ruff check` / `ruff format --check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5nbZ25qTxm7Q4mHxywwx8)_