### PR TITLE
Update documentation and metadata for OAuth 2.0 authorization server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,9 @@ from your existing Django project, instead of standing up and operating a separa
 As of 3.4.0, Django OAuth Toolkit supports the authorization server role required by the
 Model Context Protocol (MCP) authorization specification: PKCE is required by default, and the
 authorization server metadata (RFC 8414) and protected resource metadata (RFC 9728) discovery
-endpoints are published out of the box. Dynamic Client Registration (RFC 7591/7592) and Client
-ID Metadata Documents can be enabled by setting. See the
+endpoints are included in the default URLconf. Dynamic Client Registration (RFC 7591/7592) and
+Client ID Metadata Documents can be enabled with the ``DCR_ENABLED`` and ``CIMD_ENABLED`` settings.
+See the
 `3.4.0 release discussion <https://github.com/django-oauth/django-oauth-toolkit/discussions/1775>`_
 for the supported specifications and current gaps.
 

--- a/README.rst
+++ b/README.rst
@@ -22,12 +22,20 @@ Django OAuth Toolkit
    :target: https://pypi.org/project/django-oauth-toolkit/
    :alt: Supported Django versions
 
-If you are facing one or more of the following:
- * Your Django app exposes a web API you want to protect with OAuth2 authentication,
- * You need to implement an OAuth2 authorization server to provide tokens management for your infrastructure,
+Django OAuth Toolkit is an OAuth 2.0 authorization server for teams already running Django.
+It provides, out of the box, the endpoints, models, and logic to issue and manage OAuth2 tokens
+from your existing Django project, instead of standing up and operating a separate service.
 
-Django OAuth Toolkit can help you providing out of the box all the endpoints, data and logic needed to add OAuth2
-capabilities to your Django projects. Django OAuth Toolkit makes extensive use of the excellent
+As of 3.4.0, Django OAuth Toolkit supports the authorization server role required by the
+Model Context Protocol (MCP) authorization specification: PKCE is required by default, and the
+authorization server metadata (RFC 8414) and protected resource metadata (RFC 9728) discovery
+endpoints are published out of the box. Dynamic Client Registration (RFC 7591/7592) and Client
+ID Metadata Documents can be enabled by setting. See the
+`3.4.0 release discussion <https://github.com/django-oauth/django-oauth-toolkit/discussions/1775>`_
+for the supported specifications and current gaps.
+
+Django OAuth Toolkit can also act as a resource server to protect a Django or Django REST
+Framework API with OAuth2. It makes extensive use of the excellent
 `OAuthLib <https://github.com/idan/oauthlib>`_, so that everything is
 `rfc-compliant <https://rfc-editor.org/rfc/rfc6749.html>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Add ``oauth2_provider`` to your ``INSTALLED_APPS``
     )
 
 
-If you need an OAuth2 provider you'll want to add the following to your ``urls.py``.
+If you need an OAuth 2.0 authorization server you'll want to add the following to your ``urls.py``.
 
 .. code-block:: python
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -328,7 +328,7 @@ Remember we used ``http://127.0.0.1:8000/noexist/callback`` as ``redirect_uri`` 
 
     http://127.0.0.1:8000/noexist/callback?code=uVqLxiHDKIirldDZQfSnDsmYW1Abj2
 
-This is the OAuth2 provider trying to give you a ``code``. in this case ``uVqLxiHDKIirldDZQfSnDsmYW1Abj2``.
+This is the OAuth 2.0 authorization server trying to give you a ``code``. in this case ``uVqLxiHDKIirldDZQfSnDsmYW1Abj2``.
 
 Export it as an environment variable:
 
@@ -353,7 +353,7 @@ To be more easy to visualize::
         -d "redirect_uri=http://127.0.0.1:8000/noexist/callback" \
         -d "grant_type=authorization_code"
 
-The OAuth2 provider will return the follow response:
+The OAuth 2.0 authorization server will return the follow response:
 
 .. code-block:: json
 
@@ -423,7 +423,7 @@ To be easier to visualize::
         "http://127.0.0.1:8000/o/token/" \
         -d "grant_type=client_credentials"
 
-The OAuth2 provider will return the following response:
+The OAuth 2.0 authorization server will return the following response:
 
 .. code-block:: json
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -328,7 +328,7 @@ Remember we used ``http://127.0.0.1:8000/noexist/callback`` as ``redirect_uri`` 
 
     http://127.0.0.1:8000/noexist/callback?code=uVqLxiHDKIirldDZQfSnDsmYW1Abj2
 
-This is the OAuth 2.0 authorization server trying to give you a ``code``. in this case ``uVqLxiHDKIirldDZQfSnDsmYW1Abj2``.
+This is the OAuth 2.0 authorization server trying to give you a ``code``, in this case ``uVqLxiHDKIirldDZQfSnDsmYW1Abj2``.
 
 Export it as an environment variable:
 
@@ -353,7 +353,7 @@ To be more easy to visualize::
         -d "redirect_uri=http://127.0.0.1:8000/noexist/callback" \
         -d "grant_type=authorization_code"
 
-The OAuth 2.0 authorization server will return the follow response:
+The OAuth 2.0 authorization server will return the following response:
 
 .. code-block:: json
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,12 +1,12 @@
 Getting started
 ===============
 
-Build a OAuth2 provider using Django, Django OAuth Toolkit, and OAuthLib.
+Build an OAuth 2.0 authorization server using Django, Django OAuth Toolkit, and OAuthLib.
 
 What we will build?
 -------------------
 
-The plan is to build an OAuth2 provider from ground up.
+The plan is to build an OAuth 2.0 authorization server from the ground up.
 
 On this getting started we will:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,12 +6,26 @@
 Welcome to Django OAuth Toolkit Documentation
 =============================================
 
-Django OAuth Toolkit can help you by providing, out of the box, all the endpoints, data, and logic needed to add OAuth2
-capabilities to your Django projects. Django OAuth Toolkit makes extensive use of the excellent
+Django OAuth Toolkit is an OAuth 2.0 authorization server for teams already running Django. It
+provides, out of the box, the endpoints, models, and logic to issue and manage OAuth2 tokens from
+your existing Django project. It can also act as a resource server to protect a Django or Django
+REST Framework API. Django OAuth Toolkit makes extensive use of the excellent
 `OAuthLib <https://github.com/idan/oauthlib>`_, so that everything is
 `rfc-compliant <https://rfc-editor.org/rfc/rfc6749.html>`_.
 
 See our :doc:`Changelog <changelog>` for information on updates.
+
+MCP authorization
+-----------------
+
+As of 3.4.0, Django OAuth Toolkit supports the authorization server role required by the Model
+Context Protocol (MCP) authorization specification. PKCE is required by default, and the
+:doc:`authorization server metadata <oauth2_server_metadata>` (RFC 8414) and
+:doc:`protected resource metadata <protected_resource_metadata>` (RFC 9728) discovery endpoints are
+published out of the box. :doc:`Dynamic Client Registration </views/dynamic_client_registration>`
+(RFC 7591/7592) and :doc:`Client ID Metadata Documents <cimd>` can be enabled by setting. See the
+`3.4.0 release discussion <https://github.com/django-oauth/django-oauth-toolkit/discussions/1775>`_
+for the supported specifications and current gaps.
 
 Support
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,8 +22,9 @@ As of 3.4.0, Django OAuth Toolkit supports the authorization server role require
 Context Protocol (MCP) authorization specification. PKCE is required by default, and the
 :doc:`authorization server metadata <oauth2_server_metadata>` (RFC 8414) and
 :doc:`protected resource metadata <protected_resource_metadata>` (RFC 9728) discovery endpoints are
-published out of the box. :doc:`Dynamic Client Registration </views/dynamic_client_registration>`
-(RFC 7591/7592) and :doc:`Client ID Metadata Documents <cimd>` can be enabled by setting. See the
+included in the default URLconf. :doc:`Dynamic Client Registration </views/dynamic_client_registration>`
+(RFC 7591/7592) and :doc:`Client ID Metadata Documents <cimd>` can be enabled with the ``DCR_ENABLED``
+and ``CIMD_ENABLED`` settings. See the
 `3.4.0 release discussion <https://github.com/django-oauth/django-oauth-toolkit/discussions/1775>`_
 for the supported specifications and current gaps.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ As of 3.4.0, Django OAuth Toolkit supports the authorization server role require
 Context Protocol (MCP) authorization specification. PKCE is required by default, and the
 :doc:`authorization server metadata <oauth2_server_metadata>` (RFC 8414) and
 :doc:`protected resource metadata <protected_resource_metadata>` (RFC 9728) discovery endpoints are
-included in the default URLconf. :doc:`Dynamic Client Registration </views/dynamic_client_registration>`
+included in the default URLconf. :doc:`Dynamic Client Registration <views/dynamic_client_registration>`
 (RFC 7591/7592) and :doc:`Client ID Metadata Documents <cimd>` can be enabled with the ``DCR_ENABLED``
 and ``CIMD_ENABLED`` settings. See the
 `3.4.0 release discussion <https://github.com/django-oauth/django-oauth-toolkit/discussions/1775>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,8 +11,8 @@ authors = [
   {name = "Massimiliano Pippi"},
   {email = "synasius@gmail.com"},
 ]
-description = "OAuth2 Provider for Django"
-keywords = ["django", "oauth", "oauth2", "oauthlib"]
+description = "OAuth 2.0 authorization server for Django"
+keywords = ["django", "oauth", "oauth2", "oauthlib", "authorization-server", "oidc", "mcp", "pkce"]
 license = {file = "LICENSE"}
 readme = "README.rst"
 classifiers = [


### PR DESCRIPTION
## Description of the Change

This PR updates the project documentation and metadata to better reflect Django OAuth Toolkit's primary role as an OAuth 2.0 authorization server, while also clarifying its secondary role as a resource server for protecting APIs.

Key changes:
- Updated README.rst and docs/index.rst with clearer positioning as an "OAuth 2.0 authorization server for teams already running Django"
- Added documentation about MCP (Model Context Protocol) authorization support introduced in version 3.4.0, including PKCE enforcement and RFC 8414/9728 discovery endpoints
- Updated project description in pyproject.toml from "OAuth2 Provider for Django" to "OAuth 2.0 authorization server for Django"
- Enhanced keywords in pyproject.toml to include "authorization-server", "oidc", and "mcp"
- Updated getting_started.rst to use consistent terminology ("OAuth 2.0 authorization server" instead of "OAuth2 provider")

These changes improve discoverability and help users understand the toolkit's capabilities, particularly for MCP-related use cases.

## Checklist

- [x] PR only contains one change (documentation and metadata updates)
- [ ] unit-test added (N/A - documentation only)
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (documentation-only change)
- [ ] author name in `AUTHORS` (N/A)
- [ ] tests/app/idp updated to demonstrate new features (N/A)
- [ ] tests/app/rp updated to demonstrate new features (N/A)

https://claude.ai/code/session_01LoP6NVtBX332ewnj6Gqx6T