### PR TITLE
Enforce refresh-token expiry and eliminate orphaned refresh tokens (#746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   use `application/x-www-form-urlencoded` (RFC 6749, RFC 7662, RFC 7009); the JSON mode is
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
   removal in 4.0.
+### Changed
+* #746 Revoking an access token (via the RFC 7009 `/revoke/` endpoint) now also revokes
+  the refresh token bound to it, matching the admin "delete access token" view and
+  RFC 7009 §2.1. Previously the refresh token survived and could immediately mint a new
+  access token, defeating the revocation and leaving the refresh token an active "orphan"
+  (its `access_token` foreign key is `SET_NULL`). Whether a refresh token may survive
+  access-token revocation will become a configurable policy in 4.0.
 ### Fixed
+* #746 `REFRESH_TOKEN_EXPIRE_SECONDS` is now enforced when a refresh token is presented,
+  not only by the `cleartokens` (`clear_expired`) cleanup job. Previously a refresh token
+  past its configured lifetime kept working until a cleanup sweep happened to remove it —
+  or forever, if `cleartokens` was never scheduled. Expiry is idle-based: a refresh token
+  is rejected `REFRESH_TOKEN_EXPIRE_SECONDS` after its access token expires (the deadline
+  slides forward on every refresh), so actively-used tokens are unaffected. The default
+  (`REFRESH_TOKEN_EXPIRE_SECONDS = None`) still never expires refresh tokens. **Upgrade
+  note:** deployments that set `REFRESH_TOKEN_EXPIRE_SECONDS` may see idle refresh tokens
+  that are already past their lifetime rejected on upgrade, forcing those clients to
+  re-authenticate.
+* #746 `clear_expired()` now reclaims "orphaned" refresh tokens — non-revoked refresh
+  tokens whose access token was deleted out of band, leaving `access_token` `NULL`. The
+  previous `access_token__expires__lt` join could never match a `NULL` access token, so
+  such rows could remain in the database indefinitely.
 * #1687 Reusing a refresh token within `REFRESH_TOKEN_GRACE_PERIOD_SECONDS` no longer
   raises `AttributeError: 'NoneType' object has no attribute 'token'` (HTTP 500) when the
   access token previously minted from that refresh token still exists but its own refresh

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -10,15 +10,26 @@ cleartokens
 ~~~~~~~~~~~
 
 The ``cleartokens`` management command allows the user to remove refresh tokens that can no longer be
-used: those whose lifetime is greater than the amount specified by the ``REFRESH_TOKEN_EXPIRE_SECONDS``
-setting, and those that have been revoked for longer than the ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS``
-setting. It is important that this command is run regularly (eg: via cron) to avoid cluttering the
+used:
+
+* those that have been idle longer than ``REFRESH_TOKEN_EXPIRE_SECONDS`` -- i.e. whose paired access
+  token expired more than ``REFRESH_TOKEN_EXPIRE_SECONDS`` ago (see ``REFRESH_TOKEN_EXPIRE_SECONDS``
+  for the idle-expiry semantics);
+* those that have been revoked for longer than the ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS`` setting; and
+* orphaned refresh tokens -- non-revoked refresh tokens whose access token was deleted out of band,
+  leaving nothing to refresh against. These are removed unconditionally, regardless of
+  ``REFRESH_TOKEN_EXPIRE_SECONDS``.
+
+It is important that this command is run regularly (eg: via cron) to avoid cluttering the
 database with expired refresh tokens.
 
 If ``cleartokens`` runs daily the maximum delay before a refresh token is
 removed is its retention period (``REFRESH_TOKEN_EXPIRE_SECONDS`` for expired
 tokens, ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS`` for revoked ones) + 1 day. This
 is normally not a problem since refresh tokens are long lived.
+
+Note that ``REFRESH_TOKEN_EXPIRE_SECONDS`` is also enforced when a refresh token is presented, so a
+refresh token past its lifetime is rejected even if ``cleartokens`` has not yet removed it.
 
 To prevent the CPU and RAM high peaks during deletion process use ``CLEAR_EXPIRED_TOKENS_BATCH_SIZE`` and
 ``CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL`` settings to adjust the process speed.

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -219,13 +219,32 @@ to get a ``Server`` instance. Defaults to
 
 REFRESH_TOKEN_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The number of seconds before a refresh token gets removed from the database by
-the ``cleartokens`` management command. Check :ref:`cleartokens` management command for further info.
-Can be an ``Int`` or ``datetime.timedelta``.
+How long a refresh token remains valid. Can be an ``Int`` or ``datetime.timedelta``.
+Defaults to ``None``, which means refresh tokens never expire (they last until
+revoked or rotated).
 
-NOTE: This value is completely ignored when validating refresh tokens.
-If you don't change the validator code and don't run cleartokens all refresh
-tokens will last until revoked or the end of time. You should change this.
+Expiry is **idle-based**: a refresh token is rejected ``REFRESH_TOKEN_EXPIRE_SECONDS``
+after its paired access token expires. Because the access token's expiry advances
+every time the refresh token is used, an actively-used refresh token keeps sliding
+forward and never expires on its own; only a refresh token that has been dormant for
+longer than ``REFRESH_TOKEN_EXPIRE_SECONDS`` past its last access token's expiry is
+rejected.
+
+When set, this is enforced in two places:
+
+* at validation time -- a refresh token past its lifetime is rejected when presented,
+  regardless of whether ``cleartokens`` has run; and
+* by the ``cleartokens`` management command, which deletes expired refresh tokens from
+  the database (see the :ref:`cleartokens` management command).
+
+A value of ``0`` (or ``datetime.timedelta(0)``) is treated the same as ``None`` --
+expiry is disabled -- consistent with ``cleartokens``.
+
+.. note::
+   Deployments that already set ``REFRESH_TOKEN_EXPIRE_SECONDS`` should be aware that,
+   as of the release that introduced validation-time enforcement, refresh tokens that
+   are already past their configured lifetime are rejected on their next use, which may
+   force affected clients to re-authenticate.
 
 REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -971,19 +971,22 @@ def refresh_token_expire_timedelta():
     """Return ``REFRESH_TOKEN_EXPIRE_SECONDS`` as a ``timedelta``, or ``None`` when refresh
     tokens do not age-expire (the setting is unset, ``0``, or ``timedelta(0)``).
 
-    Raises ``ImproperlyConfigured`` for a non-numeric value so that both the validation-time
+    Raises ``ImproperlyConfigured`` for a non-numeric, out-of-range, or negative value
+    (like ``REFRESH_TOKEN_GRACE_PERIOD_SECONDS``) so that both the validation-time
     enforcement and ``clear_expired`` fail the same way on a misconfiguration instead of
-    raising an opaque ``TypeError``.
+    raising an opaque ``TypeError``/``OverflowError``.
     """
     value = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
     if not value:
         return None
-    if isinstance(value, timedelta):
-        return value
-    try:
-        return timedelta(seconds=value)
-    except TypeError:
-        raise ImproperlyConfigured("REFRESH_TOKEN_EXPIRE_SECONDS must be either a timedelta or seconds")
+    if not isinstance(value, timedelta):
+        try:
+            value = timedelta(seconds=value)
+        except (TypeError, OverflowError):
+            raise ImproperlyConfigured("REFRESH_TOKEN_EXPIRE_SECONDS must be either a timedelta or seconds")
+    if value < timedelta(0):
+        raise ImproperlyConfigured("REFRESH_TOKEN_EXPIRE_SECONDS must not be negative")
+    return value
 
 
 def clear_expired():

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -967,6 +967,25 @@ def get_refresh_token_admin_class():
     return refresh_token_admin_class
 
 
+def refresh_token_expire_timedelta():
+    """Return ``REFRESH_TOKEN_EXPIRE_SECONDS`` as a ``timedelta``, or ``None`` when refresh
+    tokens do not age-expire (the setting is unset, ``0``, or ``timedelta(0)``).
+
+    Raises ``ImproperlyConfigured`` for a non-numeric value so that both the validation-time
+    enforcement and ``clear_expired`` fail the same way on a misconfiguration instead of
+    raising an opaque ``TypeError``.
+    """
+    value = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+    if not value:
+        return None
+    if isinstance(value, timedelta):
+        return value
+    try:
+        return timedelta(seconds=value)
+    except TypeError:
+        raise ImproperlyConfigured("REFRESH_TOKEN_EXPIRE_SECONDS must be either a timedelta or seconds")
+
+
 def clear_expired():
     def batch_delete(queryset, query):
         CLEAR_EXPIRED_TOKENS_BATCH_SIZE = oauth2_settings.CLEAR_EXPIRED_TOKENS_BATCH_SIZE
@@ -994,7 +1013,6 @@ def clear_expired():
     id_token_model = get_id_token_model()
     grant_model = get_grant_model()
     REFRESH_TOKEN_GRACE_PERIOD_SECONDS = oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS
-    REFRESH_TOKEN_EXPIRE_SECONDS = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
 
     if REFRESH_TOKEN_GRACE_PERIOD_SECONDS:
         try:
@@ -1007,14 +1025,9 @@ def clear_expired():
             raise ImproperlyConfigured(e)
         refresh_revoked_at = now - REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 
-    if REFRESH_TOKEN_EXPIRE_SECONDS:
-        if not isinstance(REFRESH_TOKEN_EXPIRE_SECONDS, timedelta):
-            try:
-                REFRESH_TOKEN_EXPIRE_SECONDS = timedelta(seconds=REFRESH_TOKEN_EXPIRE_SECONDS)
-            except TypeError:
-                e = "REFRESH_TOKEN_EXPIRE_SECONDS must be either a timedelta or seconds"
-                raise ImproperlyConfigured(e)
-        refresh_expire_at = now - REFRESH_TOKEN_EXPIRE_SECONDS
+    refresh_token_expire_delta = refresh_token_expire_timedelta()
+    if refresh_token_expire_delta:
+        refresh_expire_at = now - refresh_token_expire_delta
 
     if oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION:
         # Revoked refresh tokens are what allows reuse of a rotated token to

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1068,7 +1068,9 @@ def clear_expired():
         # paired access token expires. ``access_token.expires`` advances on every refresh,
         # so an actively-used token slides forward and only dormant ones are reaped. Orphans
         # (NULL access token) are handled above; this join deliberately ignores them.
-        expired_query = models.Q(revoked__isnull=True, access_token__expires__lt=refresh_expire_at)
+        # ``__lte`` so a token whose access token expired exactly at the cutoff is reclaimed,
+        # matching AccessToken.is_expired() (``now >= expires``) and validation-time expiry.
+        expired_query = models.Q(revoked__isnull=True, access_token__expires__lte=refresh_expire_at)
         expired = refresh_token_model.objects.filter(expired_query)
 
         expired_deleted_no = batch_delete(expired, expired_query)

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1031,8 +1031,28 @@ def clear_expired():
     else:
         logger.info("refresh_revoked_at is %s. No revoked refresh tokens deleted.", refresh_revoked_at)
 
+    # Orphaned refresh tokens: non-revoked, but their access token is gone
+    # (``RefreshToken.access_token`` is SET_NULL, so deleting an access token out of band
+    # leaves the refresh token behind with a NULL FK). The toolkit no longer produces
+    # these -- both the RFC 7009 ``/revoke/`` endpoint and the admin view revoke the bound
+    # refresh token when an access token is revoked -- so any that remain came from an
+    # out-of-band deletion and are stale. Delete them regardless of
+    # REFRESH_TOKEN_EXPIRE_SECONDS: there is no access token to anchor an expiry on, and a
+    # surviving orphan could re-mint access tokens, defeating whatever removed the access
+    # token in the first place. This is also the case that could previously live in the DB
+    # forever, because the age join below can never match a NULL access token (#746).
+    orphan_query = models.Q(revoked__isnull=True, access_token__isnull=True)
+    orphans = refresh_token_model.objects.filter(orphan_query)
+
+    orphans_deleted_no = batch_delete(orphans, orphan_query)
+    logger.info("%s Orphaned refresh tokens deleted", orphans_deleted_no)
+
     if refresh_expire_at:
-        expired_query = models.Q(access_token__expires__lt=refresh_expire_at)
+        # Idle expiry: a refresh token is reclaimed REFRESH_TOKEN_EXPIRE_SECONDS after its
+        # paired access token expires. ``access_token.expires`` advances on every refresh,
+        # so an actively-used token slides forward and only dormant ones are reaped. Orphans
+        # (NULL access token) are handled above; this join deliberately ignores them.
+        expired_query = models.Q(revoked__isnull=True, access_token__expires__lt=refresh_expire_at)
         expired = refresh_token_model.objects.filter(expired_query)
 
         expired_deleted_no = batch_delete(expired, expired_query)

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -41,6 +41,7 @@ from .models import (
     get_grant_model,
     get_id_token_model,
     get_refresh_token_model,
+    refresh_token_expire_timedelta,
 )
 from .scopes import get_scopes_backend
 from .settings import oauth2_settings
@@ -1302,14 +1303,14 @@ class OAuth2Validator(RequestValidator):
         # non-revoked token with no access token is an orphan from an out-of-band access
         # token deletion -- there is nothing left to refresh against, so reject it.
         if rt.revoked is None:
-            expire_seconds = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
             if rt.access_token is None:
                 return False
-            if expire_seconds:
-                if not isinstance(expire_seconds, timedelta):
-                    expire_seconds = timedelta(seconds=expire_seconds)
-                if rt.access_token.expires + expire_seconds < timezone.now():
-                    return False
+            # refresh_token_expire_timedelta() returns None when age expiry is disabled and
+            # raises ImproperlyConfigured on a bad type, exactly as clear_expired does, so a
+            # misconfiguration fails the same way here instead of raising an opaque TypeError.
+            expire_delta = refresh_token_expire_timedelta()
+            if expire_delta and rt.access_token.expires + expire_delta < timezone.now():
+                return False
 
         request.user = rt.user
         # Use the raw token presented in the request, not rt.token: under hashed-at-rest

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1185,6 +1185,18 @@ class OAuth2Validator(RequestValidator):
             for other_type in [_t for _t in token_types.values() if _t != token_type]:
                 tokens.extend(other_type.objects.filter(**lookup))
         for t in tokens:
+            if isinstance(t, AccessToken):
+                # RFC 7009 section 2.1: revoking an access token MAY also revoke the bound
+                # refresh token. We do -- otherwise deleting the access token alone leaves
+                # the refresh token an active orphan (``RefreshToken.access_token`` is
+                # SET_NULL) that can immediately re-mint an access token, defeating the
+                # revocation. Revoking the refresh token deletes its access token too, so it
+                # covers both. Mirrors the admin DeleteAccessTokenView. Whether a refresh
+                # token may survive access-token revocation is a policy deferred to 4.x.
+                bound_refresh_token = RefreshToken.objects.filter(access_token=t).first()
+                if bound_refresh_token is not None:
+                    bound_refresh_token.revoke()
+                    continue
             t.revoke()
 
     def build_http_request(self, request: OauthlibRequest) -> HttpRequest:
@@ -1279,6 +1291,25 @@ class OAuth2Validator(RequestValidator):
                     for related_rt in rt_token_family.all():
                         related_rt.revoke()
                 return False
+
+        # Enforce REFRESH_TOKEN_EXPIRE_SECONDS at validation time. Historically the setting
+        # only governed clear_expired() cleanup, so a refresh token past its configured
+        # lifetime was still accepted until a sweep happened to remove it -- or forever, if
+        # cleartokens never ran (#746). A live, actively-used refresh token is always paired
+        # with an access token (rotation mints the pair together; non-rotating reuse keeps
+        # it and bumps its ``expires``), so the expiry slides with the access token: the
+        # token is dead REFRESH_TOKEN_EXPIRE_SECONDS after its access token expires. A
+        # non-revoked token with no access token is an orphan from an out-of-band access
+        # token deletion -- there is nothing left to refresh against, so reject it.
+        if rt.revoked is None:
+            expire_seconds = oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS
+            if rt.access_token is None:
+                return False
+            if expire_seconds:
+                if not isinstance(expire_seconds, timedelta):
+                    expire_seconds = timedelta(seconds=expire_seconds)
+                if rt.access_token.expires + expire_seconds < timezone.now():
+                    return False
 
         request.user = rt.user
         # Use the raw token presented in the request, not rt.token: under hashed-at-rest

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1309,7 +1309,9 @@ class OAuth2Validator(RequestValidator):
             # raises ImproperlyConfigured on a bad type, exactly as clear_expired does, so a
             # misconfiguration fails the same way here instead of raising an opaque TypeError.
             expire_delta = refresh_token_expire_timedelta()
-            if expire_delta and rt.access_token.expires + expire_delta < timezone.now():
+            # ``<=`` so the deadline itself counts as expired, matching AccessToken.is_expired()
+            # (``now >= expires``).
+            if expire_delta and rt.access_token.expires + expire_delta <= timezone.now():
                 return False
 
         request.user = rt.user

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,6 +19,7 @@ from oauth2_provider.models import (
     get_id_token_model,
     get_refresh_token_model,
     redirect_to_uri_allowed,
+    refresh_token_expire_timedelta,
 )
 
 from . import presets
@@ -623,6 +624,38 @@ class TestClearExpired(BaseTestModels):
         assert RefreshToken.objects.filter(pk=paired.pk).exists(), (
             "a refresh token paired with a current access token must survive"
         )
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class TestRefreshTokenExpireTimedelta(TestCase):
+    def test_none_and_zero_disable_expiry(self):
+        for value in (None, 0, timedelta(0)):
+            self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = value
+            assert refresh_token_expire_timedelta() is None, f"{value!r} should disable expiry"
+
+    def test_int_seconds_coerced_to_timedelta(self):
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
+        assert refresh_token_expire_timedelta() == timedelta(seconds=3600)
+
+    def test_timedelta_passed_through(self):
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = timedelta(days=1)
+        assert refresh_token_expire_timedelta() == timedelta(days=1)
+
+    def test_non_numeric_raises(self):
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = "not-a-number"
+        with pytest.raises(ImproperlyConfigured, match="must be either a timedelta or seconds"):
+            refresh_token_expire_timedelta()
+
+    def test_negative_raises(self):
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = -3600
+        with pytest.raises(ImproperlyConfigured, match="must not be negative"):
+            refresh_token_expire_timedelta()
+
+    def test_out_of_range_raises(self):
+        # timedelta() overflows for absurdly large values; normalize to ImproperlyConfigured.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 10**20
+        with pytest.raises(ImproperlyConfigured, match="must be either a timedelta or seconds"):
+            refresh_token_expire_timedelta()
 
 
 @pytest.mark.usefixtures("oauth2_settings")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -586,6 +586,44 @@ class TestClearExpired(BaseTestModels):
         remaining_gt_count = Grant.objects.count()
         assert remaining_gt_count == initial_gt_count // 2, "half the remaining grants should still exist."
 
+    def test_clear_expired_deletes_orphaned_refresh_tokens(self):
+        """
+        A non-revoked refresh token whose access token is gone (``access_token`` is
+        SET_NULL, so an out-of-band access-token deletion strands it) is an orphan. The
+        toolkit no longer produces these -- the ``/revoke/`` endpoint and admin view both
+        revoke the bound refresh token -- so any that remain are stale and are reclaimed
+        regardless of age or REFRESH_TOKEN_EXPIRE_SECONDS. This is the case that could
+        previously survive in the DB forever, since the age join can never match a NULL
+        access token (#746).
+        """
+        # No age policy at all: orphans are still deleted.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
+        app = Application.objects.get(name="test_app")
+
+        old_orphan = RefreshToken.objects.create(
+            token="old orphan", application=app, access_token=None, user=self.user
+        )
+        RefreshToken.objects.filter(pk=old_orphan.pk).update(created=self.earlier)
+        new_orphan = RefreshToken.objects.create(
+            token="new orphan", application=app, access_token=None, user=self.user
+        )
+
+        # A refresh token paired with a current access token must survive.
+        paired_at = AccessToken.objects.create(token="paired current AT", expires=self.later)
+        paired = RefreshToken.objects.create(
+            token="paired refresh token", application=app, access_token=paired_at, user=self.user
+        )
+
+        clear_expired()
+
+        assert not RefreshToken.objects.filter(pk=old_orphan.pk).exists()
+        assert not RefreshToken.objects.filter(pk=new_orphan.pk).exists(), (
+            "orphaned refresh tokens are reclaimed regardless of age"
+        )
+        assert RefreshToken.objects.filter(pk=paired.pk).exists(), (
+            "a refresh token paired with a current access token must survive"
+        )
+
 
 @pytest.mark.usefixtures("oauth2_settings")
 class TestCustomPrimaryKeyTokens(BaseTestModels):
@@ -693,10 +731,18 @@ class TestClearRevoked(BaseTestModels):
             ).save()
 
         for i in range(2, cls.num_tokens, 3):
+            # A current (non-revoked) refresh token is always paired with an access token
+            # in normal operation; without one it would be an orphan that clear_expired now
+            # reclaims. Give it a non-expired access token so it survives on its own merits.
+            current_access_token = AccessToken.objects.create(
+                token=f"current refresh token's access token {i}",
+                expires=cls.now + timedelta(seconds=cls.grace_secs),
+            )
             RefreshToken(
                 token=f"current refresh token {i}",
                 application=app,
                 user=cls.user,
+                access_token=current_access_token,
             ).save()
 
         cls.initial_rt_count = RefreshToken.objects.count()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -587,6 +587,28 @@ class TestClearExpired(BaseTestModels):
         remaining_gt_count = Grant.objects.count()
         assert remaining_gt_count == initial_gt_count // 2, "half the remaining grants should still exist."
 
+    def test_clear_expired_reclaims_refresh_token_at_expiry_boundary(self):
+        # A refresh token whose access token expired exactly at the cutoff
+        # (access_token.expires == now - REFRESH_TOKEN_EXPIRE_SECONDS) is reclaimed, matching
+        # AccessToken.is_expired() (``now >= expires``) and validation-time expiry.
+        self.oauth2_settings.CLEAR_EXPIRED_TOKENS_BATCH_INTERVAL = 0.0
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = self.delta_secs // 2
+        app = Application.objects.get(name="test_app")
+        frozen_now = timezone.now()
+        boundary_at = AccessToken.objects.create(
+            token="boundary AT", expires=frozen_now - timedelta(seconds=self.delta_secs // 2)
+        )
+        boundary_rt = RefreshToken.objects.create(
+            token="boundary RT", application=app, access_token=boundary_at, user=self.user
+        )
+
+        with mock.patch("oauth2_provider.models.timezone.now", return_value=frozen_now):
+            clear_expired()
+
+        assert not RefreshToken.objects.filter(pk=boundary_rt.pk).exists(), (
+            "a refresh token at exactly the expiry cutoff must be reclaimed"
+        )
+
     def test_clear_expired_deletes_orphaned_refresh_tokens(self):
         """
         A non-revoked refresh token whose access token is gone (``access_token`` is

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -58,6 +58,7 @@ def always_invalid_token():
         AccessToken.is_valid = original_is_valid
 
 
+@pytest.mark.usefixtures("oauth2_settings")
 class TestOAuth2Validator(TransactionTestCase):
     def setUp(self):
         self.user = UserModel.objects.create_user("user", "test@example.com", "123456")
@@ -423,15 +424,97 @@ class TestOAuth2Validator(TransactionTestCase):
             application=self.application,
             revoked=timezone.now() - datetime.timedelta(days=1),
         )
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="dup-active-access-token",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+        )
         RefreshToken.objects.create(
             user=self.user,
             token=token,
             application=self.application,
+            access_token=access_token,
         )
         request = mock.MagicMock(wraps=Request)
 
         self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
         self.assertIsNone(request.refresh_token_instance.revoked)
+
+    def test_validate_refresh_token_rejects_orphan_without_access_token(self):
+        # A non-revoked refresh token whose access token was deleted out of band is an
+        # orphan (access_token is SET_NULL). There is nothing left to refresh against, so
+        # validation rejects it rather than letting it re-mint an access token (#746).
+        token = "orphaned-refresh-token"
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            access_token=None,
+        )
+        request = mock.MagicMock(wraps=Request)
+        self.assertFalse(self.validator.validate_refresh_token(token, self.application, request))
+
+    def test_validate_refresh_token_rejects_token_past_expire_seconds(self):
+        # REFRESH_TOKEN_EXPIRE_SECONDS is enforced at validation time, not just by
+        # clear_expired cleanup (#746). Idle semantics: the deadline is the access token's
+        # expiry plus REFRESH_TOKEN_EXPIRE_SECONDS.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
+        token = "expired-refresh-token"
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="long-expired-access-token",
+            application=self.application,
+            expires=timezone.now() - datetime.timedelta(hours=2),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            access_token=access_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+        self.assertFalse(self.validator.validate_refresh_token(token, self.application, request))
+
+    def test_validate_refresh_token_accepts_token_within_expire_seconds(self):
+        # The access token expired only recently, so the refresh token is still within its
+        # REFRESH_TOKEN_EXPIRE_SECONDS idle window and must be accepted.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
+        token = "fresh-refresh-token"
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="recently-expired-access-token",
+            application=self.application,
+            expires=timezone.now() - datetime.timedelta(minutes=1),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            access_token=access_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+        self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
+
+    def test_validate_refresh_token_default_none_never_expires(self):
+        # With REFRESH_TOKEN_EXPIRE_SECONDS unset (the default), age is not enforced even
+        # for a long-expired access token, as long as the refresh token is still paired.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
+        token = "never-expires-refresh-token"
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="ancient-access-token",
+            application=self.application,
+            expires=timezone.now() - datetime.timedelta(days=365),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            access_token=access_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+        self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
 
     def test_revoke_token_with_duplicate_refresh_token_checksums(self):
         token = "duplicate-refresh-token"
@@ -453,6 +536,36 @@ class TestOAuth2Validator(TransactionTestCase):
 
         active_token.refresh_from_db()
         self.assertIsNotNone(active_token.revoked)
+
+    def test_revoke_access_token_also_revokes_bound_refresh_token(self):
+        # RFC 7009 §2.1: revoking an access token also revokes its bound refresh token, so
+        # the refresh token cannot re-mint an access token (and is not left an active
+        # orphan). See #746.
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="revoke-me-access-token",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+        )
+        refresh_token = RefreshToken.objects.create(
+            user=self.user,
+            token="bound-refresh-token",
+            application=self.application,
+            access_token=access_token,
+        )
+
+        request = mock.MagicMock(wraps=Request)
+        request.client = self.application
+        self.validator.revoke_token(access_token.token, "access_token", request)
+
+        self.assertFalse(
+            AccessToken.objects.filter(pk=access_token.pk).exists(),
+            "the access token itself must be revoked",
+        )
+        refresh_token.refresh_from_db()
+        self.assertIsNotNone(
+            refresh_token.revoked, "the bound refresh token must be revoked, not left an orphan"
+        )
 
     def test_revoke_token_without_authenticated_client_is_noop(self):
         # RFC 7009 §2.1 client-ownership check: with no authenticated client on the

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -497,6 +497,28 @@ class TestOAuth2Validator(TransactionTestCase):
         request = mock.MagicMock(wraps=Request)
         self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
 
+    def test_validate_refresh_token_rejects_token_at_expiry_boundary(self):
+        # At exactly access_token.expires + REFRESH_TOKEN_EXPIRE_SECONDS the token is
+        # expired, matching AccessToken.is_expired() (``now >= expires``).
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
+        frozen_now = timezone.now()
+        token = "boundary-refresh-token"
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="boundary-access-token",
+            application=self.application,
+            expires=frozen_now - datetime.timedelta(seconds=3600),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            access_token=access_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+        with mock.patch("oauth2_provider.oauth2_validators.timezone.now", return_value=frozen_now):
+            self.assertFalse(self.validator.validate_refresh_token(token, self.application, request))
+
     def test_validate_refresh_token_default_none_never_expires(self):
         # With REFRESH_TOKEN_EXPIRE_SECONDS unset (the default), age is not enforced even
         # for a long-expired access token, as long as the refresh token is still paired.

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -7,6 +7,7 @@ import pytest
 import requests
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
+from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpRequest
 from django.utils import timezone
 from jwcrypto import jwt
@@ -536,6 +537,28 @@ class TestOAuth2Validator(TransactionTestCase):
 
         active_token.refresh_from_db()
         self.assertIsNotNone(active_token.revoked)
+
+    def test_validate_refresh_token_invalid_expire_seconds_raises(self):
+        # A non-numeric REFRESH_TOKEN_EXPIRE_SECONDS is a misconfiguration. Validation
+        # surfaces it as ImproperlyConfigured -- the same way clear_expired() does -- rather
+        # than raising an opaque TypeError from timedelta().
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = "not-a-number"
+        token = "misconfigured-expire-refresh-token"
+        access_token = AccessToken.objects.create(
+            user=self.user,
+            token="misconfigured-expire-access-token",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+        )
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            access_token=access_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+        with self.assertRaises(ImproperlyConfigured):
+            self.validator.validate_refresh_token(token, self.application, request)
 
     def test_revoke_access_token_also_revokes_bound_refresh_token(self):
         # RFC 7009 §2.1: revoking an access token also revokes its bound refresh token, so


### PR DESCRIPTION
Fixes #746 (the refresh-token expiry / cleanup parts; see scope note).

Supersedes #1784, which fixed only the `clear_expired` symptom. Root-causing #746 showed the reported bug is at **validation** (`validate_refresh_token` never enforced `REFRESH_TOKEN_EXPIRE_SECONDS`), not cleanup — cleanup can't close the hole because between/without sweeps an "expired" token is still accepted. This PR fixes the actual bug and, in doing so, makes the cleanup much simpler.

## The problem (root cause)

`REFRESH_TOKEN_EXPIRE_SECONDS` was treated as a cleanup-only setting: `validate_refresh_token` checked existence, client, and revoked/grace — never age. So a refresh token past its configured lifetime kept working until `cleartokens` happened to remove it, or **forever** if `cleartokens` was never scheduled. This is the security issue reported in #746 (also tracked downstream in ansible/awx#6630).

## The fix (three coordinated changes)

1. **Validation enforcement** (`validate_refresh_token`). `REFRESH_TOKEN_EXPIRE_SECONDS` is now enforced when a refresh token is presented. Expiry is **idle-based**: a refresh token is rejected `REFRESH_TOKEN_EXPIRE_SECONDS` after its access token expires. A live refresh token is always paired with an access token whose `expires` advances on every refresh, so actively-used tokens slide forward and are unaffected; only dormant ones expire. The default (`None`) still never expires.

2. **`/revoke/` endpoint revokes the bound refresh token** (RFC 7009 §2.1 MAY, matching the admin `DeleteAccessTokenView`). Revoking an access token alone left the refresh token an active **orphan** (`RefreshToken.access_token` is `SET_NULL`) that could immediately re-mint an access token — defeating the revocation. This stops the toolkit from producing orphans at the source.

3. **`clear_expired()` reclaims orphans by presence.** Any remaining non-revoked, access-token-less refresh token (from out-of-band access-token deletion) is deleted unconditionally — this is the row that could previously live in the DB forever, because the age join can never match a `NULL` access token. The age join is retained for paired tokens as the idle-expiry cleanup.

Because orphans are now prevented at the source and swept if they appear, validation always has an access token to anchor idle expiry on — which is what collapses the idle-vs-absolute ambiguity and removes any need for `created`-based logic.

## Why not the `created`-based approach from #1784

That keyed cleanup on the refresh token's own age (absolute expiry). It fixed the orphan-cleanup symptom but (a) didn't touch the validation hole, and (b) silently changed non-rotating refresh-token expiry from idle to absolute. The idle-on-access-token approach here is symmetric with how a live token actually ages, needs no new field, and keeps validation and cleanup on one clock.

## Scope

- **Fixes here:** validation enforcement + orphan elimination + cleanup (the expiry/cleanup cluster of #746).
- **Deferred:** the grace period being applied to *voluntary* revocation as well as rotation (problem 2 in #746 — a `revoke()` semantics change) remains a separate follow-up. Whether a refresh token may *survive* access-token revocation is filed as a 4.x policy setting in #1786.

## Upgrade note

Deployments that set `REFRESH_TOKEN_EXPIRE_SECONDS` may see idle refresh tokens that are already past their lifetime rejected on upgrade, forcing those clients to re-authenticate. This is the setting finally doing what it says; intended to land in a minor release with this note.

## Testing

- `validate_refresh_token`: rejects a token past its idle window, rejects an orphan (no access token), accepts a token still within the window, and (default `None`) never expires while paired.
- `/revoke/`: revoking an access token also revokes its bound refresh token.
- `clear_expired`: orphaned refresh tokens are reclaimed regardless of age; paired current tokens survive. Updated `TestClearRevoked` and the duplicate-checksum validator fixture to pair their "current" refresh tokens with an access token (an unpaired non-revoked token is now, correctly, an orphan).
- Full suite: **1019 passed, 1 skipped** under `tests.settings`. `ruff check` / `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5nbZ25qTxm7Q4mHxywwx8)_