### PR TITLE
docs: Content Security Policy guidance for the authorization form (#1623)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the
   interrelated token models together.
+* #1623 Documentation ("Content Security Policy and the authorization form") on completing
+  the authorization-code flow under a strict `form-action` Content Security Policy, which
+  Chromium enforces against the post-authorization redirect to the client's `redirect_uri`.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -223,3 +223,50 @@ same namespace as before.
     ]
 
 This method also allows to remove some of the urls (such as managements) urls if you don't want them.
+
+.. _csp-authorization-form:
+
+Content Security Policy and the authorization form
+==================================================
+
+If your project sends a `Content Security Policy
+<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy>`_ that
+restricts ``form-action`` (for example ``form-action 'self'``, commonly configured through
+`django-csp <https://django-csp.readthedocs.io/>`_), the authorization-code flow can fail
+in Chromium-based browsers: clicking **Authorize** appears to do nothing and the browser
+never reaches the client's ``redirect_uri``.
+
+This happens because the authorization form posts to ``/o/authorize/`` and the server
+answers with a ``302`` redirect to the client's registered ``redirect_uri`` — a *different*
+origin. Chromium enforces ``form-action`` against the redirect target of a form submission,
+so the off-site redirect is blocked; Firefox and Safari historically check only the form's
+own action (``'self'``) and are unaffected. This is a browser/CSP-policy interaction rather
+than a defect in the toolkit — DOT issues a standard ``302`` — and it cannot be worked around
+by setting an ``action`` attribute on the ``<form>`` element, because the block is on the
+redirect *target*, not on the POST target.
+
+To allow the flow under a strict ``form-action`` policy, add the requesting application's
+registered redirect URIs to the ``form-action`` directive for the authorization response,
+by overriding :class:`~oauth2_provider.views.AuthorizationView` (see :ref:`override-views`)::
+
+    from oauth2_provider.models import get_application_model
+    from oauth2_provider.views import AuthorizationView
+
+
+    class CSPAuthorizationView(AuthorizationView):
+        def get(self, request, *args, **kwargs):
+            response = super().get(request, *args, **kwargs)
+            application = get_application_model().objects.get(
+                client_id=request.GET.get("client_id")
+            )
+            # django-csp: extend form-action with this client's redirect URIs so the
+            # post-authorization redirect is allowed. The exact response attribute
+            # (``_csp_replace`` / ``_csp_update``) and value format depend on your
+            # django-csp version; consult its documentation.
+            response._csp_replace = {
+                "form-action": ["'self'", *application.redirect_uris.split()]
+            }
+            return response
+
+Scope the added origins as narrowly as possible — to the requesting application's redirect
+URIs, as above — rather than relaxing ``form-action`` globally.

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -236,9 +236,9 @@ restricts ``form-action`` (for example ``form-action 'self'``, commonly configur
 in Chromium-based browsers: clicking **Authorize** appears to do nothing and the browser
 never reaches the client's ``redirect_uri``.
 
-This happens because the authorization form posts to ``/o/authorize/`` and the server
-answers with a ``302`` redirect to the client's registered ``redirect_uri`` — a *different*
-origin. Chromium enforces ``form-action`` against the redirect target of a form submission,
+This happens because the authorization form posts to the authorization endpoint
+(``/o/authorize/`` by default, wherever you mounted it) and the server answers with a
+``302`` redirect to the client's registered ``redirect_uri`` — a *different* origin. Chromium enforces ``form-action`` against the redirect target of a form submission,
 so the off-site redirect is blocked; Firefox and Safari historically check only the form's
 own action (``'self'``) and are unaffected. This is a browser/CSP-policy interaction rather
 than a defect in the toolkit — DOT issues a standard ``302`` — and it cannot be worked around
@@ -249,23 +249,25 @@ To allow the flow under a strict ``form-action`` policy, add the requesting appl
 registered redirect URIs to the ``form-action`` directive for the authorization response,
 by overriding :class:`~oauth2_provider.views.AuthorizationView` (see :ref:`override-views`)::
 
-    from oauth2_provider.models import get_application_model
     from oauth2_provider.views import AuthorizationView
 
 
     class CSPAuthorizationView(AuthorizationView):
         def get(self, request, *args, **kwargs):
             response = super().get(request, *args, **kwargs)
-            application = get_application_model().objects.get(
-                client_id=request.GET.get("client_id")
-            )
-            # django-csp: extend form-action with this client's redirect URIs so the
-            # post-authorization redirect is allowed. The exact response attribute
-            # (``_csp_replace`` / ``_csp_update``) and value format depend on your
-            # django-csp version; consult its documentation.
-            response._csp_replace = {
-                "form-action": ["'self'", *application.redirect_uris.split()]
-            }
+            # Only the rendered consent page carries the form and needs the relaxed
+            # directive; reuse the application the base view already put in the template
+            # context rather than re-querying, and skip redirect / error responses
+            # (skip_authorization, auto-approval, invalid client_id) that have no context.
+            application = getattr(response, "context_data", {}).get("application")
+            if application is not None:
+                # django-csp: extend form-action with this client's redirect URIs so the
+                # post-authorization redirect is allowed. The exact response attribute
+                # (``_csp_replace`` / ``_csp_update``) and value format depend on your
+                # django-csp version; consult its documentation.
+                response._csp_replace = {
+                    "form-action": ["'self'", *application.redirect_uris.split()]
+                }
             return response
 
 Scope the added origins as narrowly as possible — to the requesting application's redirect

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -249,7 +249,17 @@ To allow the flow under a strict ``form-action`` policy, add the requesting appl
 registered redirect URIs to the ``form-action`` directive for the authorization response,
 by overriding :class:`~oauth2_provider.views.AuthorizationView` (see :ref:`override-views`)::
 
+    from urllib.parse import urlsplit, urlunsplit
+
     from oauth2_provider.views import AuthorizationView
+
+
+    def csp_source(uri):
+        # A CSP source expression matches scheme/host/port/path only. DOT permits
+        # a query string (and fragment) in a redirect URI, but those are not valid
+        # in a CSP source and would make the directive non-matching, so drop them.
+        parts = urlsplit(uri)
+        return urlunsplit((parts.scheme, parts.netloc, parts.path, "", ""))
 
 
     class CSPAuthorizationView(AuthorizationView):
@@ -266,7 +276,10 @@ by overriding :class:`~oauth2_provider.views.AuthorizationView` (see :ref:`overr
                 # (``_csp_replace`` / ``_csp_update``) and value format depend on your
                 # django-csp version; consult its documentation.
                 response._csp_replace = {
-                    "form-action": ["'self'", *application.redirect_uris.split()]
+                    "form-action": [
+                        "'self'",
+                        *(csp_source(uri) for uri in application.redirect_uris.split()),
+                    ]
                 }
             return response
 


### PR DESCRIPTION
Fixes #1623

## Description of the Change

Adds a documentation section, *"Content Security Policy and the authorization form"*, to `docs/advanced_topics.rst`.

Verification of the report against the current tree found this is a browser/CSP-policy interaction, **not a defect in the toolkit**:

- The authorization form posts to `/o/authorize/` and the server answers with a standard `302` redirect to the client's registered `redirect_uri` — a different origin.
- Chromium enforces the `form-action` CSP directive against the *redirect target* of a form submission, so a policy like `form-action 'self'` (commonly set via `django-csp`) blocks the off-site redirect. Firefox/Safari historically check only the form's own action and are unaffected.
- It cannot be worked around by adding an `action` attribute to the `<form>`, because the block is on the redirect target, not the POST target. DOT cannot know a deployment's CSP policy and should not emit its own `form-action` header.

The new section explains the cause and shows the correct, narrowly-scoped mitigation: override `AuthorizationView` to add the requesting application's registered `redirect_uris` to the `form-action` directive for the authorization response (the reporter's workaround, generalized).

Documentation-only change; no code or behavior changes.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHWFBuMo9ZnAZUrC8MQuLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHWFBuMo9ZnAZUrC8MQuLn)_