### PR TITLE
docs: security guidance for refresh-token and RP-logout token lifetimes (#1715)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the
   interrelated token models together.
-* #1715 Security guidance in the settings reference: recommend a finite
-  `REFRESH_TOKEN_EXPIRE_SECONDS` as defense-in-depth (rotation remains the primary
-  mitigation), and document why `OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS` defaults
-  to `True` (the `id_token_hint` is a previously issued token per OIDC RP-Initiated Logout)
-  and how to harden it.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a
@@ -39,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   access token, defeating the revocation and leaving the refresh token an active "orphan"
   (its `access_token` foreign key is `SET_NULL`). Whether a refresh token may survive
   access-token revocation will become a configurable policy in 4.0.
+* #1715 Security guidance in the settings reference: recommend a finite
+  `REFRESH_TOKEN_EXPIRE_SECONDS` as defense-in-depth (rotation remains the primary
+  mitigation), and document why `OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS` defaults
+  to `True` (the `id_token_hint` is a previously issued token per OIDC RP-Initiated Logout)
+  and how to harden it.
 ### Fixed
 * #746 `REFRESH_TOKEN_EXPIRE_SECONDS` is now enforced when a refresh token is presented,
   not only by the `cleartokens` (`clear_expired`) cleanup job. Previously a refresh token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the
   interrelated token models together.
+* #1715 Security guidance in the settings reference: recommend a finite
+  `REFRESH_TOKEN_EXPIRE_SECONDS` as defense-in-depth (rotation remains the primary
+  mitigation), and document why `OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS` defaults
+  to `True` (the `id_token_hint` is a previously issued token per OIDC RP-Initiated Logout)
+  and how to harden it.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -246,6 +246,13 @@ expiry is disabled -- consistent with ``cleartokens``.
    are already past their configured lifetime are rejected on their next use, which may
    force affected clients to re-authenticate.
 
+.. note::
+   **Security guidance.** Refresh-token rotation (``ROTATE_REFRESH_TOKEN``, on by default)
+   is the primary defense against a leaked refresh token; see :doc:`security`. As
+   additional defense-in-depth, consider setting a finite ``REFRESH_TOKEN_EXPIRE_SECONDS``
+   so a refresh token that leaks and is then left idle cannot be redeemed indefinitely.
+   The default ``None`` places no upper bound on an idle refresh token's lifetime.
+
 REFRESH_TOKEN_GRACE_PERIOD_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The number of seconds a refresh token can still be used after it has been
@@ -556,7 +563,16 @@ OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Default: ``True``
 
-Whether expired ID tokens are accepted for RP-Initiated Logout. The Tokens must still be signed by the OP and otherwise valid.
+Whether expired ID tokens are accepted for RP-Initiated Logout. The token must still be
+signed by the OP, carry a matching ``iss`` claim, and resolve to a stored ``IDToken``;
+only the ``exp`` and ``nbf`` claims are skipped.
+
+The default is ``True`` because `OpenID Connect RP-Initiated Logout 1.0
+<https://openid.net/specs/openid-connect-rpinitiated-1_0.html>`_ treats ``id_token_hint``
+as a *previously issued* ID token, used only as a hint about which session to end. Logout
+frequently happens long after the ID token's (typically short) ``exp``, so rejecting an
+expired hint would break the normal logout flow. Set this to ``False`` if you additionally
+want to require that the ``id_token_hint`` is still within its validity period.
 
 OIDC_RP_INITIATED_LOGOUT_DELETE_TOKENS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #1715

## Description of the Change

Adds security guidance to the settings reference (`docs/settings.rst`) for the two lifetime settings raised in the issue. Verification against the current tree found **neither is a spec violation** — both are working-as-designed and configurable — so the resolution is documentation rather than a behavior change:

- **`REFRESH_TOKEN_EXPIRE_SECONDS` (default `None`).** RFC 6749 does not mandate an absolute refresh-token lifetime, and refresh-token rotation (`ROTATE_REFRESH_TOKEN`, on by default) is already the primary mitigation per RFC 9700 §4.14.2. The new note recommends setting a finite value as defense-in-depth so a leaked-then-idle token cannot be redeemed indefinitely, and points to `docs/security.rst`.
- **`OIDC_RP_INITIATED_LOGOUT_ACCEPT_EXPIRED_TOKENS` (default `True`).** This is the spec-aligned default: OpenID Connect RP-Initiated Logout 1.0 treats `id_token_hint` as a *previously issued* token used only as a session hint, and logout routinely happens after the ID token's short `exp`. The expanded text clarifies that the signature, `iss`, and stored-`IDToken` checks are still enforced (only `exp`/`nbf` are skipped) and documents how to harden by setting `False`.

Documentation-only change; no code or behavior changes.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHWFBuMo9ZnAZUrC8MQuLn

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHWFBuMo9ZnAZUrC8MQuLn)_