### PR TITLE
docs: clarify TokenHasResourceScope colon scope syntax (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the authorization-code flow under a strict `form-action` Content Security Policy, which
   Chromium enforces against the post-authorization redirect to the client's `redirect_uri`.
 * #410 Documentation ("Resource scope syntax") clarifying that `TokenHasResourceScope`
-  checks the `:read`/`:write`-suffixed form of `required_scopes` (e.g. `music:read`,
-  `music:write`), so a bare `music` scope is rejected and the colon-separated scopes must be
+  checks each `required_scopes` entry suffixed with the `READ_SCOPE`/`WRITE_SCOPE` setting
+  value (defaults `read`/`write`, e.g. `music:read`, `music:write`), so a bare `music` scope
+  is rejected; with the default settings-based scopes backend the suffixed scopes must be
   declared in `SCOPES`.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #1623 Documentation ("Content Security Policy and the authorization form") on completing
   the authorization-code flow under a strict `form-action` Content Security Policy, which
   Chromium enforces against the post-authorization redirect to the client's `redirect_uri`.
+* #410 Documentation ("Resource scope syntax") clarifying that `TokenHasResourceScope`
+  checks the `:read`/`:write`-suffixed form of `required_scopes` (e.g. `music:read`,
+  `music:write`), so a bare `music` scope is rejected and the colon-separated scopes must be
+  declared in `SCOPES`.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a

--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -65,6 +65,37 @@ When the request's method is one of "non safe" methods, the access is allowed on
 
 The `required_scopes` attribute is mandatory (you just need inform the resource scope).
 
+.. _resource-scope-syntax:
+
+Resource scope syntax
+^^^^^^^^^^^^^^^^^^^^^^
+
+``TokenHasResourceScope`` does not check the plain ``required_scopes`` value. It appends
+``:read`` or ``:write`` to each entry depending on the request method and checks *that*
+scope instead. With ``required_scopes = ['music']`` a safe method (``GET``, ``HEAD``,
+``OPTIONS``) requires ``music:read`` and an unsafe method (``POST``, ``PUT``, ``PATCH``,
+``DELETE``) requires ``music:write``. A token whose scope is the bare ``music`` — without a
+``:read`` or ``:write`` suffix — is therefore **rejected**, because neither ``music:read``
+nor ``music:write`` is present.
+
+For the check to succeed you must both declare the colon-separated scopes in your settings
+and issue tokens for them. Declare each read/write scope explicitly in the ``SCOPES``
+setting so it can be requested and shown on the authorization form:
+
+.. code-block:: python
+
+    OAUTH2_PROVIDER = {
+        "SCOPES": {
+            "music:read": "Read your music.",
+            "music:write": "Modify your music.",
+            # ...
+        },
+    }
+
+A token then has to be authorized for ``music:read`` and/or ``music:write`` (for example
+``scope=music:read music:write`` to allow both safe and unsafe methods). Requesting only the
+bare ``music`` scope will not satisfy this permission class.
+
 
 IsAuthenticatedOrTokenHasScope
 ------------------------------

--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -70,24 +70,27 @@ The `required_scopes` attribute is mandatory (you just need inform the resource 
 Resource scope syntax
 ^^^^^^^^^^^^^^^^^^^^^^
 
-``TokenHasResourceScope`` does not check the plain ``required_scopes`` value. It appends
-``:read`` or ``:write`` to each entry depending on the request method and checks *that*
-scope instead. With ``required_scopes = ['music']`` a safe method (``GET``, ``HEAD``,
-``OPTIONS``) requires ``music:read`` and an unsafe method (``POST``, ``PUT``, ``PATCH``,
-``DELETE``) requires ``music:write``. A token whose scope is the bare ``music`` — without a
-``:read`` or ``:write`` suffix — is therefore **rejected**, because neither ``music:read``
-nor ``music:write`` is present.
+``TokenHasResourceScope`` does not check the plain ``required_scopes`` value. For each entry
+it appends a colon and the read/write scope name — the ``READ_SCOPE`` setting for safe
+methods (``GET``, ``HEAD``, ``OPTIONS``) and the ``WRITE_SCOPE`` setting for the others
+(``POST``, ``PUT``, ``PATCH``, ``DELETE``) — and checks *that* scope instead. ``READ_SCOPE``
+and ``WRITE_SCOPE`` default to ``read`` and ``write``, so with the defaults and
+``required_scopes = ['music']`` a safe method requires ``music:read`` and an unsafe method
+requires ``music:write``. A token whose scope is the bare ``music`` — without the read/write
+suffix — is therefore **rejected**, because neither ``music:read`` nor ``music:write`` is
+present. If you customize ``READ_SCOPE`` / ``WRITE_SCOPE``, substitute those names for
+``read`` / ``write`` throughout this section.
 
-For the check to succeed you must both declare the colon-separated scopes in your settings
-and issue tokens for them. Declare each read/write scope explicitly in the ``SCOPES``
-setting so it can be requested and shown on the authorization form:
+For the check to succeed you must both declare the suffixed scopes and issue tokens for them.
+When using the default settings-based scopes backend, declare each read/write scope explicitly
+in the ``SCOPES`` setting so it can be requested and shown on the authorization form:
 
 .. code-block:: python
 
     OAUTH2_PROVIDER = {
-        "SCOPES": {
-            "music:read": "Read your music.",
-            "music:write": "Modify your music.",
+        'SCOPES': {
+            'music:read': 'Read your music.',
+            'music:write': 'Modify your music.',
             # ...
         },
     }


### PR DESCRIPTION
Fixes #410

## Description of the Change

The `TokenHasResourceScope` documentation described the per-method behavior but never
stated the scope *syntax* it requires. `TokenHasResourceScope` does not check the plain
`required_scopes` value — it appends `:read` or `:write` (based on the request method) and
checks that suffixed scope instead. A token granted the bare `music` scope is therefore
rejected, which repeatedly surprised users (see issue #410).

This PR adds a **"Resource scope syntax"** subsection to
`docs/rest-framework/permissions.rst` that:

- explains the `:read`/`:write` suffixing and that a bare scope (e.g. `music`) will not
  satisfy the permission;
- shows the required `SCOPES` declaration (`music:read`, `music:write`);
- notes that tokens must be authorized for the colon-separated scopes
  (e.g. `scope=music:read music:write`).

Documentation-only change.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FCYxmQAHaFMFw6Ei9rpWg)_