### PR TITLE
cleartokens: warn when REFRESH_TOKEN_EXPIRE_SECONDS is unset (#522)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
   removal in 4.0.
 ### Changed
+* #522 The `cleartokens` management command now prints a warning to stderr when
+  `REFRESH_TOKEN_EXPIRE_SECONDS` is unset (or `0`), explaining that only revoked and
+  orphaned refresh tokens are removed and that expired access/ID tokens are retained until
+  their refresh token is gone. The management command and settings docs were clarified to
+  match.
 * #746 Revoking an access token (via the RFC 7009 `/revoke/` endpoint) now also revokes
   the refresh token bound to it, matching the admin "delete access token" view and
   RFC 7009 §2.1. Previously the refresh token survived and could immediately mint a new

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * #522 The `cleartokens` management command now prints a warning to stderr when
   `REFRESH_TOKEN_EXPIRE_SECONDS` is unset (or `0`), explaining that only revoked and
-  orphaned refresh tokens are removed and that expired access/ID tokens are retained until
-  their refresh token is gone. The management command and settings docs were clarified to
-  match.
+  orphaned refresh tokens are removed and that expired access/ID tokens still bound to a
+  refresh token are retained until that refresh token is gone. The management-command docs
+  were clarified to match.
 * #746 Revoking an access token (via the RFC 7009 `/revoke/` endpoint) now also revokes
   the refresh token bound to it, matching the admin "delete access token" view and
   RFC 7009 §2.1. Previously the refresh token survived and could immediately mint a new

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -44,6 +44,10 @@ until they expire per ``REFRESH_TOKEN_EXPIRE_SECONDS``.
 
 Note: Refresh tokens need to expire before AccessTokens can be removed from the
 database. Using ``cleartokens`` without ``REFRESH_TOKEN_EXPIRE_SECONDS`` has limited effect.
+When ``REFRESH_TOKEN_EXPIRE_SECONDS`` is unset (or ``0``), ``cleartokens`` prints a warning to
+stderr to make this easy to notice: only revoked and orphaned refresh tokens are removed, and
+expired access and ID tokens are retained as long as their refresh token lives. Set
+``REFRESH_TOKEN_EXPIRE_SECONDS`` to enable expiry-based cleanup.
 
 .. _clearcimdapplications:
 

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -46,8 +46,10 @@ Note: Refresh tokens need to expire before AccessTokens can be removed from the
 database. Using ``cleartokens`` without ``REFRESH_TOKEN_EXPIRE_SECONDS`` has limited effect.
 When ``REFRESH_TOKEN_EXPIRE_SECONDS`` is unset (or ``0``), ``cleartokens`` prints a warning to
 stderr to make this easy to notice: only revoked and orphaned refresh tokens are removed, and
-expired access and ID tokens are retained as long as their refresh token lives. Set
-``REFRESH_TOKEN_EXPIRE_SECONDS`` to enable expiry-based cleanup.
+expired access and ID tokens that are still bound to a refresh token are retained as long as that
+refresh token lives. (Expired access tokens with no refresh token, and their ID tokens, are still
+cleared regardless of ``REFRESH_TOKEN_EXPIRE_SECONDS``.) Set ``REFRESH_TOKEN_EXPIRE_SECONDS`` to
+enable expiry-based cleanup.
 
 .. _clearcimdapplications:
 

--- a/oauth2_provider/management/commands/cleartokens.py
+++ b/oauth2_provider/management/commands/cleartokens.py
@@ -12,8 +12,9 @@ class Command(BaseCommand):
                 self.style.WARNING(
                     "REFRESH_TOKEN_EXPIRE_SECONDS is not set (or is 0), so refresh tokens never "
                     "age-expire. cleartokens will only remove revoked and orphaned refresh tokens; "
-                    "expired access and ID tokens are kept as long as their refresh token lives. "
-                    "Set REFRESH_TOKEN_EXPIRE_SECONDS to enable expiry-based cleanup."
+                    "expired access and ID tokens that are still bound to a refresh token are kept "
+                    "as long as that refresh token lives. Set REFRESH_TOKEN_EXPIRE_SECONDS to enable "
+                    "expiry-based cleanup."
                 )
             )
         clear_expired()

--- a/oauth2_provider/management/commands/cleartokens.py
+++ b/oauth2_provider/management/commands/cleartokens.py
@@ -1,10 +1,19 @@
 from django.core.management.base import BaseCommand
 
-from ...models import clear_expired
+from ...models import clear_expired, refresh_token_expire_timedelta
 
 
-class Command(BaseCommand):  # pragma: no cover
+class Command(BaseCommand):
     help = "Can be run as a cronjob or directly to clean out expired tokens"
 
     def handle(self, *args, **options):
+        if refresh_token_expire_timedelta() is None:
+            self.stderr.write(
+                self.style.WARNING(
+                    "REFRESH_TOKEN_EXPIRE_SECONDS is not set (or is 0), so refresh tokens never "
+                    "age-expire. cleartokens will only remove revoked and orphaned refresh tokens; "
+                    "expired access and ID tokens are kept as long as their refresh token lives. "
+                    "Set REFRESH_TOKEN_EXPIRE_SECONDS to enable expiry-based cleanup."
+                )
+            )
         clear_expired()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -149,3 +149,20 @@ class CreateApplicationTest(TestCase):
             self.assertIn("does not exist", output_str)
         else:
             self.assertIn("is not a valid choice", output_str)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class ClearTokensTest(TestCase):
+    def test_warns_when_refresh_token_expiry_unset(self):
+        # With REFRESH_TOKEN_EXPIRE_SECONDS unset, refresh tokens never age-expire and
+        # cleartokens cannot reclaim expired access/ID tokens, so the command warns.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = None
+        stderr = StringIO()
+        call_command("cleartokens", stderr=stderr)
+        self.assertIn("REFRESH_TOKEN_EXPIRE_SECONDS is not set", stderr.getvalue())
+
+    def test_no_warning_when_refresh_token_expiry_set(self):
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
+        stderr = StringIO()
+        call_command("cleartokens", stderr=stderr)
+        self.assertEqual(stderr.getvalue(), "")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -161,6 +161,13 @@ class ClearTokensTest(TestCase):
         call_command("cleartokens", stderr=stderr)
         self.assertIn("REFRESH_TOKEN_EXPIRE_SECONDS is not set", stderr.getvalue())
 
+    def test_warns_when_refresh_token_expiry_zero(self):
+        # 0 is treated the same as unset (expiry disabled), so it also warns.
+        self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 0
+        stderr = StringIO()
+        call_command("cleartokens", stderr=stderr)
+        self.assertIn("REFRESH_TOKEN_EXPIRE_SECONDS is not set", stderr.getvalue())
+
     def test_no_warning_when_refresh_token_expiry_set(self):
         self.oauth2_settings.REFRESH_TOKEN_EXPIRE_SECONDS = 3600
         stderr = StringIO()


### PR DESCRIPTION
Fixes #522

## Description of the Change

Issue #522 reported that it is too easy to run `cleartokens` without realizing that, with
`REFRESH_TOKEN_EXPIRE_SECONDS` unset, expired tokens are not actually removed — the setting
is required for expiry-based cleanup, and nothing tells the operator otherwise.

The management-command and settings documentation already spell out the
`REFRESH_TOKEN_EXPIRE_SECONDS` requirement (recently expanded for #746). This PR adds the
remaining piece the issue asked for — a runtime signal:

- **`cleartokens` now prints a warning to stderr** when `REFRESH_TOKEN_EXPIRE_SECONDS` is
  unset (or `0`), explaining that only revoked and orphaned refresh tokens are removed and
  that expired access/ID tokens are retained until their refresh token is gone, and pointing
  the operator at the setting.
- The **management-command docs** are updated to describe this warning.
- **Regression tests** cover the warning appearing when the setting is unset and being
  absent when it is set.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FCYxmQAHaFMFw6Ei9rpWg)_