### PR TITLE
docs: tutorial on managing applications and tokens in the Django admin (#1045)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * #452 Documentation ("Custom scopes backend") explaining how to replace the default
   settings-driven scopes backend via `SCOPES_BACKEND_CLASS`, including a worked model-based
   example that stores scopes in the database.
+* #1045 Tutorial ("Managing applications and tokens in the Django admin") walking through the
+  admin site for applications and issued tokens, including client-secret hashing, credential
+  masking, and that tokens cannot be created by hand.
 ### Deprecated
 * #1773 `JSONOAuthLibCore` (`OAUTH2_PROVIDER["OAUTH2_BACKEND_CLASS"]` set to
   `oauth2_provider.oauth2_backends.JSONOAuthLibCore`) is deprecated and now emits a

--- a/docs/tutorial/tutorial.rst
+++ b/docs/tutorial/tutorial.rst
@@ -10,3 +10,4 @@ Tutorials
    tutorial_04
    tutorial_05
    tutorial_06
+   tutorial_admin

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -1,0 +1,94 @@
+Part 7 - Managing applications and tokens in the Django admin
+=============================================================
+
+Scenario
+--------
+In :doc:`Part 1 <tutorial_01>` you created your own :term:`Authorization Server` and registered
+an application through the front-end ``/o/applications/`` views. Django OAuth Toolkit also
+registers all of its models with the `Django admin site
+<https://docs.djangoproject.com/en/stable/ref/contrib/admin/>`_, which gives staff users a
+single place to review and manage applications, issued tokens, authorization codes and OIDC ID
+tokens. This part walks through that admin UI.
+
+Enabling the admin
+------------------
+The admin is set up exactly as in a normal Django project — nothing OAuth-specific is required.
+As shown in :doc:`Part 1 <tutorial_01>`, add ``django.contrib.admin`` to ``INSTALLED_APPS`` and
+route it in your ``urls.py``:
+
+.. code-block:: python
+
+    from django.contrib import admin
+
+    urlpatterns = [
+        path("admin/", admin.site.urls),
+        # ...
+    ]
+
+Log in at http://localhost:8000/admin/ with a staff account. Under the **DJANGO OAUTH TOOLKIT**
+section you will find five model admins:
+
+* **Applications** — the OAuth clients you have registered.
+* **Access tokens** — bearer tokens issued to those clients.
+* **Refresh tokens** — tokens used to obtain a new access token.
+* **Grants** — short-lived authorization codes exchanged for tokens.
+* **ID tokens** — OpenID Connect ID tokens (only relevant when you use OIDC).
+
+If you have :ref:`swapped any of these models <extend_app_model>`, your custom models appear
+here instead, under their own app.
+
+Managing applications
+---------------------
+Open **Applications** to see the registered clients. The changelist shows the primary key,
+name, owning user, client type, authorization grant type and registration source, and can be
+filtered by client type, grant type, ``skip_authorization`` and registration source, or searched
+by application name (and user email, when your user model has one).
+
+Click **Add application** (or an existing row) to open the application form. The most important
+fields are:
+
+* **User** — the user the application belongs to. It uses a raw-id widget, so enter or look up
+  the user's primary key.
+* **Redirect uris** — a space-separated list of allowed redirect URIs. A client using the
+  authorization-code or implicit grant must register at least one.
+* **Post logout redirect uris** — space-separated URIs allowed after an RP-initiated OIDC logout.
+* **Allowed origins** — space-separated origins for which CORS is enabled on the token endpoint.
+* **Client type** — ``confidential`` or ``public`` (:rfc:`2.1`).
+* **Authorization grant type** — the flow this application uses (authorization-code, implicit,
+  password, client-credentials or openid-hybrid).
+* **Name** — a friendly label shown to users on the authorization form.
+* **Skip authorization** — when enabled, users are never shown the authorization form for this
+  application, even on first use. Enable it only for applications you fully trust (see
+  :ref:`skip-auth-form`).
+* **Algorithm** — the OIDC token signing algorithm (``No OIDC support``, ``RS256`` or ``HS256``).
+
+.. note::
+   **Client secrets are hashed and shown only once.** By default the toolkit stores a hash of
+   ``client_secret`` (like a password), so the raw value cannot be recovered after you save. When
+   you create an application — or paste a new secret into an existing one — copy the secret
+   *before* clicking **Save**. If you lose it, generate a new one by saving a fresh random value
+   into both the admin and your client. ``registration_source`` and ``cimd_expires_at`` are
+   maintained by the toolkit (they mark applications created via Dynamic Client Registration or
+   :doc:`CIMD <../cimd>`) and are read-only.
+
+Reviewing and revoking tokens
+-----------------------------
+The **Access tokens**, **Refresh tokens**, **Grants** and **ID tokens** admins let you inspect
+what the server has issued and revoke it by deleting rows. A few behaviors are specific to these
+credential admins:
+
+* **You cannot create tokens by hand.** Tokens, refresh tokens, authorization codes and ID
+  tokens are issued by the OAuth/OIDC flows, so the **Add** button is disabled for all four.
+* **Secret values are masked.** Access/refresh token values and authorization codes are stored in
+  cleartext, so the admin never shows the usable value: the changelist displays only a short
+  masked suffix, the raw value is hidden on the change form, and you can search only by
+  non-secret identifiers (application client id / name, and user) — never by the token itself.
+  This keeps live, replayable credentials out of the admin UI and out of ``?q=`` search URLs
+  captured in server logs and browser history.
+* **Deleting an access token also revokes its refresh token.** Removing an access token from the
+  admin revokes the refresh token bound to it, so a deleted access token cannot be silently
+  refreshed back into existence.
+
+To revoke a user's access, delete their access token (and, if present, refresh token) from these
+changelists. For bulk, scheduled cleanup of *expired* tokens, use the :ref:`cleartokens`
+management command rather than deleting rows by hand.

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -5,7 +5,7 @@ Scenario
 --------
 In :doc:`Part 1 <tutorial_01>` you created your own :term:`Authorization Server` and registered
 an application through the front-end ``/o/applications/`` views. Django OAuth Toolkit also
-registers all of its models with the `Django admin site
+registers its user-facing models with the `Django admin site
 <https://docs.djangoproject.com/en/stable/ref/contrib/admin/>`_, which gives staff users a
 single place to review and manage applications, issued tokens, authorization codes and OIDC ID
 tokens. This part walks through that admin UI.
@@ -94,8 +94,9 @@ what the server has issued and revoke it. A few behaviors are specific to these 
   enabled, the raw token is not stored at all — only a checksum — so there is nothing to mask and
   the value column is simply empty.)
 * **Revoke access and refresh tokens; don't delete them.** The **Access tokens** and
-  **Refresh tokens** admins invalidate tokens through a **"Revoke selected …"** action rather than
-  a raw delete (delete is disabled on those two). Revoking is the *only* consistent way to
+  **Refresh tokens** admins invalidate tokens through the **"Revoke selected access tokens"** and
+  **"Revoke selected refresh tokens"** actions rather than a raw delete (delete is disabled on
+  those two). Revoking is the *only* consistent way to
   invalidate a token, because a raw delete would only detach the paired token
   (``RefreshToken.access_token`` is ``SET_NULL``), leaving an orphaned refresh token that can still
   mint new access tokens. The revoke action invalidates the whole token family: revoking an access
@@ -104,5 +105,5 @@ what the server has issued and revoke it. A few behaviors are specific to these 
   semantics for them).
 
 To revoke a user's access, select their access and/or refresh tokens in the relevant changelist
-and run the **Revoke selected …** action. For bulk, scheduled cleanup of *expired* tokens, use the
+and run that admin's revoke action. For bulk, scheduled cleanup of *expired* tokens, use the
 :ref:`cleartokens` management command instead.

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -51,7 +51,8 @@ fields are:
 * **User** — the user the application belongs to. It uses a raw-id widget, so enter or look up
   the user's primary key.
 * **Redirect uris** — a space-separated list of allowed redirect URIs. A client using the
-  authorization-code or implicit grant must register at least one.
+  authorization-code, implicit or openid-hybrid grant must register at least one (application
+  validation rejects an empty value for those grants).
 * **Post logout redirect uris** — space-separated URIs allowed after an RP-initiated OIDC logout.
 * **Allowed origins** — space-separated origins for which CORS is enabled on the token endpoint.
 * **Client type** — ``confidential`` or ``public`` (:rfc:`2.1`).

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -56,8 +56,8 @@ fields are:
 * **Post logout redirect uris** — space-separated URIs allowed after an RP-initiated OIDC logout.
 * **Allowed origins** — space-separated origins for which CORS is enabled on the token endpoint.
 * **Client type** — ``confidential`` or ``public`` (:rfc:`2.1`).
-* **Authorization grant type** — the flow this application uses (authorization-code, implicit,
-  password, client-credentials or openid-hybrid).
+* **Authorization grant type** — the flow this application uses (authorization-code, device
+  code, implicit, password, client-credentials or openid-hybrid).
 * **Name** — a friendly label shown to users on the authorization form.
 * **Skip authorization** — when enabled, users are never shown the authorization form for this
   application, even on first use. Enable it only for applications you fully trust (see

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -80,30 +80,16 @@ fields are:
 
 Reviewing and revoking tokens
 -----------------------------
-The **Access tokens**, **Refresh tokens**, **Grants** and **ID tokens** admins let you inspect
-what the server has issued and revoke it. A few behaviors are specific to these credential admins:
+The **Access tokens**, **Refresh tokens**, **Grants** and **ID tokens** admins let you review what
+the server has issued to each application and user. Tokens are always created by the OAuth/OIDC
+flows, so you can browse and revoke them here, but not add them by hand. For your users' safety,
+the admin also masks the secret token values — the changelist shows only a short masked suffix and
+you search by application or user, never by the token itself.
 
-* **You cannot create tokens by hand.** Tokens, refresh tokens, authorization codes and ID
-  tokens are issued by the OAuth/OIDC flows, so the **Add** button is disabled for all four.
-* **Secret values are masked.** By default, access/refresh token values and authorization codes are
-  stored in cleartext, so the admin never shows the usable value: the changelist displays only a
-  short masked suffix, the raw value is hidden on the change form, and you can search only by
-  non-secret identifiers (application client id / name, and user) — never by the token itself.
-  This keeps live, replayable credentials out of the admin UI and out of ``?q=`` search URLs
-  captured in server logs and browser history. (When ``COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`` is
-  enabled, the raw token is not stored at all — only a checksum — so there is nothing to mask and
-  the value column is simply empty.)
-* **Revoke access and refresh tokens; don't delete them.** The **Access tokens** and
-  **Refresh tokens** admins invalidate tokens through the **"Revoke selected access tokens"** and
-  **"Revoke selected refresh tokens"** actions rather than a raw delete (delete is disabled on
-  those two). Revoking is the *only* consistent way to
-  invalidate a token, because a raw delete would only detach the paired token
-  (``RefreshToken.access_token`` is ``SET_NULL``), leaving an orphaned refresh token that can still
-  mint new access tokens. The revoke action invalidates the whole token family: revoking an access
-  token also revokes its bound refresh token, and revoking a refresh token revokes its access
-  token. **Grants** and **ID tokens** keep the normal delete (there is no separate revoke
-  semantics for them).
+To cut off an application or user's access, open **Access tokens** or **Refresh tokens**, select
+the rows you want to invalidate, and run the **Revoke selected access tokens** / **Revoke selected
+refresh tokens** action from the actions dropdown. Revoking an access token also revokes the
+refresh token issued with it (and vice versa), so the client cannot simply refresh its way back in.
 
-To revoke a user's access, select their access and/or refresh tokens in the relevant changelist
-and run that admin's revoke action. For bulk, scheduled cleanup of *expired* tokens, use the
-:ref:`cleartokens` management command instead.
+For routine cleanup of *expired* tokens across all applications, use the :ref:`cleartokens`
+management command rather than revoking rows by hand.

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -19,14 +19,15 @@ route it in your ``urls.py``:
 .. code-block:: python
 
     from django.contrib import admin
+    from django.urls import path
 
     urlpatterns = [
         path("admin/", admin.site.urls),
         # ...
     ]
 
-Log in at http://localhost:8000/admin/ with a staff account. Under the **DJANGO OAUTH TOOLKIT**
-section you will find five model admins:
+Log in at http://localhost:8000/admin/ with a staff account. Under the **Django OAuth Toolkit**
+section (the app's ``verbose_name``) you will find five model admins:
 
 * **Applications** — the OAuth clients you have registered.
 * **Access tokens** — bearer tokens issued to those clients.
@@ -60,16 +61,21 @@ fields are:
 * **Skip authorization** — when enabled, users are never shown the authorization form for this
   application, even on first use. Enable it only for applications you fully trust (see
   :ref:`skip-auth-form`).
-* **Algorithm** — the OIDC token signing algorithm (``No OIDC support``, ``RS256`` or ``HS256``).
+* **Algorithm** — the OIDC token signing algorithm. The choices are labelled *No OIDC support*
+  (the default, empty value), *RSA with SHA-2 256* (``RS256``) and *HMAC with SHA-2 256*
+  (``HS256``).
+* **Hash client secret** — whether this application's ``client_secret`` is hashed on save (see the
+  note below).
 
 .. note::
-   **Client secrets are hashed and shown only once.** By default the toolkit stores a hash of
-   ``client_secret`` (like a password), so the raw value cannot be recovered after you save. When
-   you create an application — or paste a new secret into an existing one — copy the secret
-   *before* clicking **Save**. If you lose it, generate a new one by saving a fresh random value
-   into both the admin and your client. ``registration_source`` and ``cimd_expires_at`` are
-   maintained by the toolkit (they mark applications created via Dynamic Client Registration or
-   :doc:`CIMD <../cimd>`) and are read-only.
+   **Copy a hashed client secret before you save it.** When **Hash client secret** is enabled —
+   the default — the toolkit stores only a hash of ``client_secret`` (like a password), so the raw
+   value cannot be recovered after you save. When you create such an application, or paste a new
+   secret into one, copy the secret *before* clicking **Save**; if you lose it, generate a new one
+   by saving a fresh random value into both the admin and your client. If **Hash client secret** is
+   disabled, the secret is stored (and remains viewable) in cleartext instead. ``registration_source``
+   and ``cimd_expires_at`` are maintained by the toolkit (they mark applications created via Dynamic
+   Client Registration or :doc:`CIMD <../cimd>`) and are read-only.
 
 Reviewing and revoking tokens
 -----------------------------
@@ -85,10 +91,12 @@ credential admins:
   non-secret identifiers (application client id / name, and user) — never by the token itself.
   This keeps live, replayable credentials out of the admin UI and out of ``?q=`` search URLs
   captured in server logs and browser history.
-* **Deleting an access token also revokes its refresh token.** Removing an access token from the
-  admin revokes the refresh token bound to it, so a deleted access token cannot be silently
-  refreshed back into existence.
+* **Deleting one token does not cascade to the other.** ``RefreshToken.access_token`` is
+  ``SET_NULL``, so deleting an access token in the admin only detaches its refresh token (leaving
+  it active), and deleting a refresh token likewise leaves its access token in place. Neither
+  delete revokes the paired token.
 
-To revoke a user's access, delete their access token (and, if present, refresh token) from these
-changelists. For bulk, scheduled cleanup of *expired* tokens, use the :ref:`cleartokens`
-management command rather than deleting rows by hand.
+To fully revoke a user's access, delete **both** their access token and its refresh token from
+these changelists — otherwise a surviving refresh token can mint a new access token. For bulk,
+scheduled cleanup of *expired* tokens, use the :ref:`cleartokens` management command rather than
+deleting rows by hand.

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -81,8 +81,7 @@ fields are:
 Reviewing and revoking tokens
 -----------------------------
 The **Access tokens**, **Refresh tokens**, **Grants** and **ID tokens** admins let you inspect
-what the server has issued and revoke it by deleting rows. A few behaviors are specific to these
-credential admins:
+what the server has issued and revoke it. A few behaviors are specific to these credential admins:
 
 * **You cannot create tokens by hand.** Tokens, refresh tokens, authorization codes and ID
   tokens are issued by the OAuth/OIDC flows, so the **Add** button is disabled for all four.
@@ -92,12 +91,16 @@ credential admins:
   non-secret identifiers (application client id / name, and user) — never by the token itself.
   This keeps live, replayable credentials out of the admin UI and out of ``?q=`` search URLs
   captured in server logs and browser history.
-* **Deleting one token does not cascade to the other.** ``RefreshToken.access_token`` is
-  ``SET_NULL``, so deleting an access token in the admin only detaches its refresh token (leaving
-  it active), and deleting a refresh token likewise leaves its access token in place. Neither
-  delete revokes the paired token.
+* **Revoke access and refresh tokens; don't delete them.** The **Access tokens** and
+  **Refresh tokens** admins invalidate tokens through a **"Revoke selected …"** action rather than
+  a raw delete (delete is disabled on those two). Revoking is the *only* consistent way to
+  invalidate a token, because a raw delete would only detach the paired token
+  (``RefreshToken.access_token`` is ``SET_NULL``), leaving an orphaned refresh token that can still
+  mint new access tokens. The revoke action invalidates the whole token family: revoking an access
+  token also revokes its bound refresh token, and revoking a refresh token revokes its access
+  token. **Grants** and **ID tokens** keep the normal delete (there is no separate revoke
+  semantics for them).
 
-To fully revoke a user's access, delete **both** their access token and its refresh token from
-these changelists — otherwise a surviving refresh token can mint a new access token. For bulk,
-scheduled cleanup of *expired* tokens, use the :ref:`cleartokens` management command rather than
-deleting rows by hand.
+To revoke a user's access, select their access and/or refresh tokens in the relevant changelist
+and run the **Revoke selected …** action. For bulk, scheduled cleanup of *expired* tokens, use the
+:ref:`cleartokens` management command instead.

--- a/docs/tutorial/tutorial_admin.rst
+++ b/docs/tutorial/tutorial_admin.rst
@@ -85,12 +85,14 @@ what the server has issued and revoke it. A few behaviors are specific to these 
 
 * **You cannot create tokens by hand.** Tokens, refresh tokens, authorization codes and ID
   tokens are issued by the OAuth/OIDC flows, so the **Add** button is disabled for all four.
-* **Secret values are masked.** Access/refresh token values and authorization codes are stored in
-  cleartext, so the admin never shows the usable value: the changelist displays only a short
-  masked suffix, the raw value is hidden on the change form, and you can search only by
+* **Secret values are masked.** By default, access/refresh token values and authorization codes are
+  stored in cleartext, so the admin never shows the usable value: the changelist displays only a
+  short masked suffix, the raw value is hidden on the change form, and you can search only by
   non-secret identifiers (application client id / name, and user) — never by the token itself.
   This keeps live, replayable credentials out of the admin UI and out of ``?q=`` search URLs
-  captured in server logs and browser history.
+  captured in server logs and browser history. (When ``COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`` is
+  enabled, the raw token is not stored at all — only a checksum — so there is nothing to mask and
+  the value column is simply empty.)
 * **Revoke access and refresh tokens; don't delete them.** The **Access tokens** and
   **Refresh tokens** admins invalidate tokens through a **"Revoke selected …"** action rather than
   a raw delete (delete is disabled on those two). Revoking is the *only* consistent way to


### PR DESCRIPTION
Fixes #1045

## Description of the Change

Issue #1045 asked for a tutorial walk-through of the admin UI. Django OAuth Toolkit registers
all five of its models with the Django admin, but the tutorial only used the front-end
`/o/applications/` views and never explained the admin itself.

This PR adds a new tutorial page, **"Part 7 - Managing applications and tokens in the Django
admin"** (`docs/tutorial/tutorial_admin.rst`, linked from the tutorial toctree), covering:

- enabling the admin and where the five model admins appear;
- the **Applications** changelist and form — the important fields, and the note that
  `client_secret` is hashed and shown only once (copy it before saving), with
  `registration_source` / `cimd_expires_at` read-only;
- the **Access tokens / Refresh tokens / Grants / ID tokens** admins — that tokens cannot be
  created by hand, that secret values are masked and only non-secret identifiers are
  searchable, and that access/refresh tokens are invalidated with the **"Revoke selected …"**
  action (raw delete is disabled on those two) so the whole token family is revoked together;
- a pointer to `cleartokens` for bulk expiry cleanup.

The revoke-action guidance matches the admin behavior added in #1798 (`revoke_access_token`
helper + admin revoke action), which landed ahead of this PR.

The walk-through is written in prose (no screenshots) so it stays accurate as the admin
evolves. Documentation-only change.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FCYxmQAHaFMFw6Ei9rpWg)_