### PR TITLE
docs: make TokenHasResourceScope intro consistent with READ_SCOPE/WRITE_SCOPE

### DIFF
--- a/docs/rest-framework/permissions.rst
+++ b/docs/rest-framework/permissions.rst
@@ -53,8 +53,8 @@ TokenHasResourceScope
 ----------------------
 The `TokenHasResourceScope` permission class allows access only when the current access token has been authorized for **all** the scopes listed in the `required_scopes` field of the view but according of request's method.
 
-When the current request's method is one of the "safe" methods, the access is allowed only if the access token has been authorized for the `scope:read` scope (for example `music:read`).
-When the request's method is one of "non safe" methods, the access is allowed only if the access token has been authorized for the `scope:write` scope (for example `music:write`).
+When the current request's method is one of the "safe" methods, the access is allowed only if the access token has been authorized for the ``READ_SCOPE``-suffixed scope (``music:read`` with the default ``READ_SCOPE`` of ``read``).
+When the request's method is one of "non safe" methods, the access is allowed only if the access token has been authorized for the ``WRITE_SCOPE``-suffixed scope (``music:write`` by default). See :ref:`resource-scope-syntax` below for the exact rules.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Description of the Change

Follow-up to #410 (merged in #1791). The "Resource scope syntax" subsection added there explains
that `TokenHasResourceScope` suffixes each scope with the configurable `READ_SCOPE` / `WRITE_SCOPE`
value (defaults `read`/`write`), but the **intro sentences** just above it still described the
required scopes as the literal `scope:read` / `scope:write` — which is only correct with the
defaults.

This PR rewords those two sentences to reference `READ_SCOPE` / `WRITE_SCOPE` (noting `read`/`write`
as the defaults) and cross-links the `resource-scope-syntax` section, so the whole
`TokenHasResourceScope` section is consistent and not misleading for readers who customize those
setting values. (This was a low-confidence suggestion from the Copilot review on #1791 that I'm
addressing here as a small follow-up now that #1791 has merged.)

Documentation-only change.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [ ] unit-test added
- [x] documentation updated
- [ ] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FCYxmQAHaFMFw6Ei9rpWg)_