### PR TITLE
admin: revoke tokens via shared helper instead of raw delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
   removal in 4.0.
 ### Changed
+* The `AccessToken` and `RefreshToken` admins now invalidate tokens through a **"Revoke selected"**
+  action instead of raw delete (delete is disabled on those two admins). A raw delete of an access
+  token left its bound refresh token behind (`RefreshToken.access_token` is `SET_NULL`) — an orphan
+  that could still mint new access tokens — and a raw delete of a refresh token discarded the
+  revoked tombstone that `REFRESH_TOKEN_REUSE_PROTECTION` relies on. The revoke action invalidates
+  the whole token family consistently; expired rows are still pruned by `cleartokens`. `Grant` and
+  `IDToken` admins keep the default delete. The access-token revoke logic is now a single shared
+  `oauth2_provider.models.revoke_access_token()` helper used by the admin action, the `/revoke/`
+  endpoint, and `AuthorizedTokenDeleteView`.
 * #522 The `cleartokens` management command now prints a warning to stderr when
   `REFRESH_TOKEN_EXPIRE_SECONDS` is unset (or `0`), explaining that only revoked and
   orphaned refresh tokens are removed and that expired access/ID tokens still bound to a

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -13,6 +13,7 @@ from oauth2_provider.models import (
     get_id_token_model,
     get_refresh_token_admin_class,
     get_refresh_token_model,
+    revoke_access_token,
 )
 
 
@@ -85,11 +86,32 @@ class AccessTokenAdmin(admin.ModelAdmin):
     # Search by non-secret identifiers only; never by the token itself.
     search_fields = ("application__client_id", "application__name") + USER_SEARCH_FIELDS
     list_filter = ("application",)
+    actions = ("revoke_tokens",)
 
     def has_add_permission(self, request):
         # Access tokens are issued by the OAuth flows, not hand-created in the admin.
         # Disabling add also removes the add form's editable (cleartext) token field.
         return False
+
+    def has_delete_permission(self, request, obj=None):
+        # Invalidate access tokens with the "Revoke selected access tokens" action, not a raw
+        # delete. Deleting an access token row leaves its bound refresh token behind
+        # (``RefreshToken.access_token`` is ``SET_NULL``), and that orphan can still mint new
+        # access tokens; revoking invalidates the whole token family consistently. Expired rows
+        # are pruned by the :ref:`cleartokens` management command.
+        return False
+
+    @admin.action(description="Revoke selected access tokens")
+    def revoke_tokens(self, request, queryset):
+        # ``revoke_access_token`` is the shared revoke path (also used by the ``/revoke/`` endpoint
+        # and ``AuthorizedTokenDeleteView``): it revokes the bound refresh token when present --
+        # preserving the tombstone ``REFRESH_TOKEN_REUSE_PROTECTION`` relies on -- otherwise
+        # revokes the access token directly.
+        revoked = 0
+        for access_token in queryset:
+            revoke_access_token(access_token)
+            revoked += 1
+        self.message_user(request, "Revoked %d access token(s)." % revoked)
 
     def get_exclude(self, request, obj=None):
         # Hide the raw token on the change/view form (obj is set). Adding is disabled
@@ -164,10 +186,29 @@ class RefreshTokenAdmin(admin.ModelAdmin):
     # Search by non-secret identifiers only; never by the token itself.
     search_fields = ("application__client_id", "application__name") + USER_SEARCH_FIELDS
     list_filter = ("application",)
+    actions = ("revoke_tokens",)
 
     def has_add_permission(self, request):
         # Refresh tokens are issued by the OAuth flows, not hand-created in the admin.
         return False
+
+    def has_delete_permission(self, request, obj=None):
+        # Invalidate refresh tokens with the "Revoke selected refresh tokens" action, not a raw
+        # delete. ``RefreshToken.revoke()`` revokes the bound access token and keeps the refresh
+        # token as a revoked tombstone, which ``REFRESH_TOKEN_REUSE_PROTECTION`` needs to detect
+        # replay of a rotated token; a raw delete would discard that. Revoked/expired rows are
+        # pruned by the :ref:`cleartokens` management command.
+        return False
+
+    @admin.action(description="Revoke selected refresh tokens")
+    def revoke_tokens(self, request, queryset):
+        revoked = 0
+        for refresh_token in queryset:
+            # ``RefreshToken.revoke()`` revokes the bound access token and marks this token
+            # revoked; it is a no-op on an already-revoked token.
+            refresh_token.revoke()
+            revoked += 1
+        self.message_user(request, "Revoked %d refresh token(s)." % revoked)
 
     def get_exclude(self, request, obj=None):
         # Hide the raw token on the change/view form. Adding is disabled (see

--- a/oauth2_provider/admin.py
+++ b/oauth2_provider/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.contrib.auth import get_user_model
+from django.utils.translation import ngettext
 
 from oauth2_provider.forms import ApplicationForm
 from oauth2_provider.models import (
@@ -111,7 +112,10 @@ class AccessTokenAdmin(admin.ModelAdmin):
         for access_token in queryset:
             revoke_access_token(access_token)
             revoked += 1
-        self.message_user(request, "Revoked %d access token(s)." % revoked)
+        self.message_user(
+            request,
+            ngettext("Revoked %d access token.", "Revoked %d access tokens.", revoked) % revoked,
+        )
 
     def get_exclude(self, request, obj=None):
         # Hide the raw token on the change/view form (obj is set). Adding is disabled
@@ -208,7 +212,10 @@ class RefreshTokenAdmin(admin.ModelAdmin):
             # revoked; it is a no-op on an already-revoked token.
             refresh_token.revoke()
             revoked += 1
-        self.message_user(request, "Revoked %d refresh token(s)." % revoked)
+        self.message_user(
+            request,
+            ngettext("Revoked %d refresh token.", "Revoked %d refresh tokens.", revoked) % revoked,
+        )
 
     def get_exclude(self, request, obj=None):
         # Hide the raw token on the change/view form. Adding is disabled (see

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -989,6 +989,32 @@ def refresh_token_expire_timedelta():
     return value
 
 
+def revoke_access_token(access_token):
+    """
+    Revoke an access token and, if present, its bound refresh token.
+
+    Deleting the access token on its own leaves the refresh token usable (the
+    ``RefreshToken.access_token`` FK is ``SET_NULL``), so it can still be exchanged for a fresh
+    access token, defeating the revocation. Per :rfc:`7009#section-2.1` revoking an access token
+    MAY also revoke the bound refresh token; revoking the refresh token also deletes the bound
+    access token, so it covers both. When there is no refresh token, revoke the access token
+    directly (which deletes it).
+
+    The bound refresh token is looked up with a forward query on the refresh token model rather
+    than the reverse ``access_token.refresh_token`` accessor, whose name depends on the
+    ``related_name`` a swapped refresh token model may override.
+
+    This is the single revoke path shared by the ``/revoke/`` endpoint, the
+    ``AuthorizedTokenDeleteView``, and the admin "Revoke selected access tokens" action. Whether a
+    refresh token may *survive* access-token revocation is a policy deferred to 4.x (see #1786).
+    """
+    refresh_token = get_refresh_token_model().objects.filter(access_token=access_token).first()
+    if refresh_token is not None:
+        refresh_token.revoke()
+    else:
+        access_token.revoke()
+
+
 def clear_expired():
     def batch_delete(queryset, query):
         CLEAR_EXPIRED_TOKENS_BATCH_SIZE = oauth2_settings.CLEAR_EXPIRED_TOKENS_BATCH_SIZE

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -989,7 +989,7 @@ def refresh_token_expire_timedelta():
     return value
 
 
-def revoke_access_token(access_token):
+def revoke_access_token(access_token: AbstractAccessToken) -> None:
     """
     Revoke an access token and, if present, its bound refresh token.
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -42,6 +42,7 @@ from .models import (
     get_id_token_model,
     get_refresh_token_model,
     refresh_token_expire_timedelta,
+    revoke_access_token,
 )
 from .scopes import get_scopes_backend
 from .settings import oauth2_settings
@@ -1188,17 +1189,13 @@ class OAuth2Validator(RequestValidator):
         for t in tokens:
             if isinstance(t, AccessToken):
                 # RFC 7009 section 2.1: revoking an access token MAY also revoke the bound
-                # refresh token. We do -- otherwise deleting the access token alone leaves
-                # the refresh token an active orphan (``RefreshToken.access_token`` is
-                # SET_NULL) that can immediately re-mint an access token, defeating the
-                # revocation. Revoking the refresh token deletes its access token too, so it
-                # covers both. Mirrors the admin DeleteAccessTokenView. Whether a refresh
-                # token may survive access-token revocation is a policy deferred to 4.x.
-                bound_refresh_token = RefreshToken.objects.filter(access_token=t).first()
-                if bound_refresh_token is not None:
-                    bound_refresh_token.revoke()
-                    continue
-            t.revoke()
+                # refresh token. We do -- otherwise deleting the access token alone leaves the
+                # refresh token an active orphan (``RefreshToken.access_token`` is SET_NULL) that
+                # can immediately re-mint an access token, defeating the revocation. ``revoke_access_token``
+                # is the shared path used here, by ``AuthorizedTokenDeleteView``, and by the admin.
+                revoke_access_token(t)
+            else:
+                t.revoke()
 
     def build_http_request(self, request: OauthlibRequest) -> HttpRequest:
         """

--- a/oauth2_provider/views/token.py
+++ b/oauth2_provider/views/token.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
 from django.views.generic import DeleteView, ListView
 
-from ..models import get_access_token_model, get_refresh_token_model
+from ..models import get_access_token_model, revoke_access_token
 
 
 class AuthorizedTokensListView(LoginRequiredMixin, ListView):
@@ -43,20 +43,8 @@ class AuthorizedTokenDeleteView(LoginRequiredMixin, DeleteView):
         exchanged for a fresh access token, defeating the revocation. Per
         :rfc:`7009#section-2.1` revoking an access token may also revoke the
         respective refresh token; for a user-initiated "revoke access" action that
-        is the only unsurprising behavior. Revoking the refresh token also deletes
-        the bound access token, so it covers both.
-
-        The bound refresh token is looked up with a forward query on the refresh
-        token model rather than the reverse ``access_token.refresh_token`` accessor,
-        whose name depends on the ``related_name`` a swapped refresh token model may
-        override.
+        is the only unsurprising behavior. ``revoke_access_token`` is the shared
+        revoke path used here, by the ``/revoke/`` endpoint, and by the admin.
         """
-        access_token = self.object
-        refresh_token = get_refresh_token_model().objects.filter(access_token=access_token).first()
-
-        if refresh_token is not None:
-            refresh_token.revoke()
-        else:
-            access_token.revoke()
-
+        revoke_access_token(self.object)
         return HttpResponseRedirect(self.get_success_url())

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -6,8 +6,13 @@ which would leak them into the ``?q=`` query string and therefore into access
 logs / browser history).
 """
 
+import pytest
+from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth import get_user_model
+from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory
+from django.utils import timezone
 
 from oauth2_provider.admin import (
     AccessTokenAdmin,
@@ -18,6 +23,7 @@ from oauth2_provider.admin import (
 )
 from oauth2_provider.models import (
     get_access_token_model,
+    get_application_model,
     get_grant_model,
     get_id_token_model,
     get_refresh_token_model,
@@ -134,3 +140,103 @@ def test_id_token_admin_searchable_by_app_and_user():
     # IDTokenAdmin holds no cleartext replayable secret, but its search should stay
     # consistent with the other credential admins (and non-empty on custom user models).
     _assert_searchable_by_app_and_user(IDTokenAdmin)
+
+
+def test_credential_admins_delete_policy():
+    """Access/refresh tokens are invalidated via the revoke action, not raw delete (a raw delete
+    would orphan the paired token / discard the reuse-protection tombstone). Grants and ID tokens
+    keep Django's default delete."""
+    request = RequestFactory().get("/")
+    for admin_class, model in (
+        (AccessTokenAdmin, get_access_token_model()),
+        (RefreshTokenAdmin, get_refresh_token_model()),
+    ):
+        model_admin = admin_class(model, AdminSite())
+        assert model_admin.has_delete_permission(request) is False
+        assert "revoke_tokens" in model_admin.actions
+    # Grants and ID tokens don't override delete -- they keep Django's default policy.
+    assert GrantAdmin.has_delete_permission is admin.ModelAdmin.has_delete_permission
+    assert IDTokenAdmin.has_delete_permission is admin.ModelAdmin.has_delete_permission
+
+
+def _request_with_messages():
+    # message_user() needs the messages framework attached to the request.
+    request = RequestFactory().post("/")
+    request.session = {}
+    setattr(request, "_messages", FallbackStorage(request))
+    return request
+
+
+def _make_application(user):
+    Application = get_application_model()
+    return Application.objects.create(
+        name="revoke-test-app",
+        client_type=Application.CLIENT_CONFIDENTIAL,
+        authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        user=user,
+    )
+
+
+@pytest.mark.django_db
+def test_access_token_admin_revoke_action_revokes_token_family():
+    UserModel = get_user_model()
+    AccessToken = get_access_token_model()
+    RefreshToken = get_refresh_token_model()
+
+    user = UserModel.objects.create(username="revoke-at")
+    app = _make_application(user)
+    access_token = AccessToken.objects.create(
+        user=user, token="at-to-revoke", application=app, expires=timezone.now(), scope="read"
+    )
+    refresh_token = RefreshToken.objects.create(
+        user=user, token="rt-bound", application=app, access_token=access_token
+    )
+
+    model_admin = AccessTokenAdmin(AccessToken, AdminSite())
+    model_admin.revoke_tokens(_request_with_messages(), AccessToken.objects.filter(pk=access_token.pk))
+
+    # The access token is gone and the bound refresh token is revoked (kept as a tombstone).
+    assert not AccessToken.objects.filter(pk=access_token.pk).exists()
+    refresh_token.refresh_from_db()
+    assert refresh_token.revoked is not None
+
+
+@pytest.mark.django_db
+def test_access_token_admin_revoke_action_without_refresh_token_deletes():
+    UserModel = get_user_model()
+    AccessToken = get_access_token_model()
+
+    user = UserModel.objects.create(username="revoke-at-solo")
+    app = _make_application(user)
+    access_token = AccessToken.objects.create(
+        user=user, token="at-solo", application=app, expires=timezone.now(), scope="read"
+    )
+
+    model_admin = AccessTokenAdmin(AccessToken, AdminSite())
+    model_admin.revoke_tokens(_request_with_messages(), AccessToken.objects.filter(pk=access_token.pk))
+
+    assert not AccessToken.objects.filter(pk=access_token.pk).exists()
+
+
+@pytest.mark.django_db
+def test_refresh_token_admin_revoke_action_revokes_token_family():
+    UserModel = get_user_model()
+    AccessToken = get_access_token_model()
+    RefreshToken = get_refresh_token_model()
+
+    user = UserModel.objects.create(username="revoke-rt")
+    app = _make_application(user)
+    access_token = AccessToken.objects.create(
+        user=user, token="at-bound", application=app, expires=timezone.now(), scope="read"
+    )
+    refresh_token = RefreshToken.objects.create(
+        user=user, token="rt-to-revoke", application=app, access_token=access_token
+    )
+
+    model_admin = RefreshTokenAdmin(RefreshToken, AdminSite())
+    model_admin.revoke_tokens(_request_with_messages(), RefreshToken.objects.filter(pk=refresh_token.pk))
+
+    # Revoking the refresh token revokes the bound access token (deletes it) and tombstones itself.
+    assert not AccessToken.objects.filter(pk=access_token.pk).exists()
+    refresh_token.refresh_from_db()
+    assert refresh_token.revoked is not None

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -11,6 +11,7 @@ from django.contrib import admin
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.test import RequestFactory
 from django.utils import timezone
 
@@ -162,7 +163,9 @@ def test_credential_admins_delete_policy():
 def _request_with_messages():
     # message_user() needs the messages framework attached to the request.
     request = RequestFactory().post("/")
-    request.session = {}
+    # A real session (via SessionMiddleware) so message_user() works even if the messages
+    # framework falls back from cookie to session storage.
+    SessionMiddleware(lambda r: None).process_request(request)
     setattr(request, "_messages", FallbackStorage(request))
     return request
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -176,6 +176,7 @@ def _make_application(user):
         name="revoke-test-app",
         client_type=Application.CLIENT_CONFIDENTIAL,
         authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        redirect_uris="https://example.com/callback",
         user=user,
     )
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -31,6 +31,21 @@ from oauth2_provider.models import (
 )
 
 
+class _PermissiveUser:
+    """A minimal stand-in for an authenticated superuser, so admin permission checks pass
+    without a database user."""
+
+    is_active = True
+    is_staff = True
+    is_superuser = True
+
+    def has_perm(self, perm, obj=None):
+        return True
+
+    def has_module_perms(self, app_label):
+        return True
+
+
 def _admin_form_fields(admin_class, model, obj):
     """
     Return the fields the admin form would render. Pass ``obj=None`` for the add
@@ -148,6 +163,9 @@ def test_credential_admins_delete_policy():
     would orphan the paired token / discard the reuse-protection tombstone). Grants and ID tokens
     keep Django's default delete."""
     request = RequestFactory().get("/")
+    # get_actions() can consult request.user for permission-gated actions; a RequestFactory
+    # request has none, so attach a permissive stub (no DB needed) to keep the assertion robust.
+    request.user = _PermissiveUser()
     for admin_class, model in (
         (AccessTokenAdmin, get_access_token_model()),
         (RefreshTokenAdmin, get_refresh_token_model()),

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -177,7 +177,7 @@ def _make_application(user):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_access_token_admin_revoke_action_revokes_token_family():
     UserModel = get_user_model()
     AccessToken = get_access_token_model()
@@ -201,7 +201,7 @@ def test_access_token_admin_revoke_action_revokes_token_family():
     assert refresh_token.revoked is not None
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_access_token_admin_revoke_action_without_refresh_token_deletes():
     UserModel = get_user_model()
     AccessToken = get_access_token_model()
@@ -218,7 +218,7 @@ def test_access_token_admin_revoke_action_without_refresh_token_deletes():
     assert not AccessToken.objects.filter(pk=access_token.pk).exists()
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases="__all__")
 def test_refresh_token_admin_revoke_action_revokes_token_family():
     UserModel = get_user_model()
     AccessToken = get_access_token_model()

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -154,7 +154,7 @@ def test_credential_admins_delete_policy():
     ):
         model_admin = admin_class(model, AdminSite())
         assert model_admin.has_delete_permission(request) is False
-        assert "revoke_tokens" in model_admin.actions
+        assert "revoke_tokens" in model_admin.get_actions(request)
     # Grants and ID tokens don't override delete -- they keep Django's default policy.
     assert GrantAdmin.has_delete_permission is admin.ModelAdmin.has_delete_permission
     assert IDTokenAdmin.has_delete_permission is admin.ModelAdmin.has_delete_permission
@@ -187,7 +187,7 @@ def test_access_token_admin_revoke_action_revokes_token_family():
     AccessToken = get_access_token_model()
     RefreshToken = get_refresh_token_model()
 
-    user = UserModel.objects.create(username="revoke-at")
+    user = UserModel.objects.create_user(username="revoke-at")
     app = _make_application(user)
     access_token = AccessToken.objects.create(
         user=user, token="at-to-revoke", application=app, expires=timezone.now(), scope="read"
@@ -210,7 +210,7 @@ def test_access_token_admin_revoke_action_without_refresh_token_deletes():
     UserModel = get_user_model()
     AccessToken = get_access_token_model()
 
-    user = UserModel.objects.create(username="revoke-at-solo")
+    user = UserModel.objects.create_user(username="revoke-at-solo")
     app = _make_application(user)
     access_token = AccessToken.objects.create(
         user=user, token="at-solo", application=app, expires=timezone.now(), scope="read"
@@ -228,7 +228,7 @@ def test_refresh_token_admin_revoke_action_revokes_token_family():
     AccessToken = get_access_token_model()
     RefreshToken = get_refresh_token_model()
 
-    user = UserModel.objects.create(username="revoke-rt")
+    user = UserModel.objects.create_user(username="revoke-rt")
     app = _make_application(user)
     access_token = AccessToken.objects.create(
         user=user, token="at-bound", application=app, expires=timezone.now(), scope="read"


### PR DESCRIPTION
## Description of the Change

Follow-up to the review discussion on #1794 (admin tutorial). The `AccessToken` / `RefreshToken`
Django admins exposed Django's default **raw delete**, which bypasses the toolkit's revoke
semantics:

- Deleting an access token row leaves its bound refresh token behind (`RefreshToken.access_token`
  is `SET_NULL`) — an active **orphan** that can still be exchanged for a fresh access token,
  defeating the "revocation".
- Deleting a refresh token row discards the **revoked tombstone** that
  `REFRESH_TOKEN_REUSE_PROTECTION` relies on to detect replay of a rotated token.

This mirrors the footgun #746/#1787 already fixed for the `/revoke/` endpoint and
`AuthorizedTokenDeleteView`, which both revoke *"the access token and, if present, its bound
refresh token."*

### What this does

1. **Extract the shared revoke path.** The "revoke the access token, and its bound refresh token
   if present" logic (duplicated in `AuthorizedTokenDeleteView` and the `/revoke/` endpoint) is
   pulled into a single `oauth2_provider.models.revoke_access_token()` helper, and all three call
   sites now use it. The forward refresh-token lookup (not the reverse `access_token.refresh_token`
   accessor, whose name a swapped model may override) is preserved. This keeps the behavior — and
   the eventual 4.x "may a refresh token survive revocation" policy (#1786) — in one place.
2. **Admin uses revoke, not delete.** `AccessTokenAdmin` and `RefreshTokenAdmin` gain a
   **"Revoke selected"** action and disable `has_delete_permission`, so tokens are invalidated
   consistently. Expired rows are still pruned by `cleartokens`. `GrantAdmin` and `IDTokenAdmin`
   keep the default delete (no cascade semantics there).

### Notes

- Behavior of `/revoke/` and `AuthorizedTokenDeleteView` is unchanged — pure extraction (full
  suite green: the revocation, validator, model, token-view and admin tests pass).
- The #1794 tutorial ("Reviewing and revoking tokens") documents the *current* raw-delete behavior;
  if this lands, I'll update that section to describe the revoke action. Happy to fold that in or
  keep it a follow-up.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018FCYxmQAHaFMFw6Ei9rpWg)_