### PR TITLE
fix(dcr): honour hashed token storage for registration access tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verifies the token was issued to the client making the request; a token belonging to a
   different client is now left untouched and the endpoint still returns `200` (RFC 7009
   §2.2) without disclosing whether the token exists.
+* #1799 RFC 7592 registration access tokens now honour `COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`. The
+  dynamic client registration views assigned the token straight onto the model instead of routing it
+  through the validator, so a deployment that had opted into hashed-at-rest storage still had this one
+  token persisted in cleartext. The registration response and the management endpoint continue to
+  return the token to its owner; only what is written to the database changes.
 
 ## [3.4.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verifies the token was issued to the client making the request; a token belonging to a
   different client is now left untouched and the endpoint still returns `200` (RFC 7009
   §2.2) without disclosing whether the token exists.
+* #1799 RFC 7592 registration access tokens now honour `COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`. The
+  dynamic client registration views assigned the token straight onto the model instead of routing it
+  through the validator, so a deployment that had opted into hashed-at-rest storage still had this one
+  token persisted in cleartext. The registration response and the management endpoint continue to
+  return the token to its owner; only what is written to the database changes.
 
 ## [3.4.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,9 +193,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   §2.2) without disclosing whether the token exists.
 * #1799 RFC 7592 registration access tokens now honour `COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`. The
   dynamic client registration views assigned the token straight onto the model instead of routing it
-  through the validator, so a deployment that had opted into hashed-at-rest storage still had this one
-  token persisted in cleartext. The registration response and the management endpoint continue to
-  return the token to its owner; only what is written to the database changes.
+  through the storage path that honours the setting, so a deployment that had opted into hashed-at-rest
+  storage still had this one token persisted in cleartext. The registration response and the management
+  endpoint continue to return the token to its owner; only what is written to the database changes.
 
 ## [3.4.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,9 +200,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   §2.2) without disclosing whether the token exists.
 * #1799 RFC 7592 registration access tokens now honour `COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`. The
   dynamic client registration views assigned the token straight onto the model instead of routing it
-  through the validator, so a deployment that had opted into hashed-at-rest storage still had this one
-  token persisted in cleartext. The registration response and the management endpoint continue to
-  return the token to its owner; only what is written to the database changes.
+  through the storage path that honours the setting, so a deployment that had opted into hashed-at-rest
+  storage still had this one token persisted in cleartext. The registration response and the management
+  endpoint continue to return the token to its owner; only what is written to the database changes.
 
 ## [3.4.0] - 2026-07-23
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -188,6 +188,11 @@ By default DOT stores access and refresh tokens in cleartext (alongside a SHA-25
 token hash, so a database read no longer discloses usable tokens. Existing cleartext
 tokens are left in place and age out as they expire or rotate.
 
+This covers the RFC 7592 registration access token as well. Since the server keeps no
+readable copy, that token is returned in full only by the registration response that
+mints it; the management endpoint's ``GET`` echoes back whichever token the request
+presented.
+
 .. warning::
    Hashed token storage is incompatible with the refresh-token grace period, which
    must return a previously issued (cleartext) token from the database. When

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -189,9 +189,10 @@ token hash, so a database read no longer discloses usable tokens. Existing clear
 tokens are left in place and age out as they expire or rotate.
 
 This covers the RFC 7592 registration access token as well. Since the server keeps no
-readable copy, that token is returned in full only by the registration response that
-mints it; the management endpoint's ``GET`` echoes back whichever token the request
-presented.
+readable copy, a client only receives that token from a response that mints one: the
+registration response, and — when ``DCR_ROTATE_REGISTRATION_TOKEN_ON_UPDATE`` is
+enabled — the management ``PUT`` that rotates it. A management ``GET``, or a ``PUT``
+without rotation, echoes back whichever token the request presented.
 
 .. warning::
    Hashed token storage is incompatible with the refresh-token grace period, which

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -97,6 +97,31 @@ class TokenChecksumField(models.CharField):
         return super().pre_save(model_instance, add)
 
 
+def set_token_value(token_instance: "AbstractAccessToken | AbstractRefreshToken", raw_token: str) -> None:
+    """
+    Assign the raw token to a token instance, redacting the value stored at rest
+    when COMPLIANT_BCP_RFC9700_TOKEN_STORAGE is enabled (RFC 9700).
+
+    The lookup checksum (``token_checksum``) is always derived from the raw token;
+    when redacting, the raw value is stashed on ``_raw_token`` (used only to compute
+    the checksum, see :class:`TokenChecksumField`) and the ``token`` column is left
+    blank so the reusable token is never persisted.
+
+    Plaintext storage is an ambient config posture exercised on every token
+    issuance, so (unlike the request-time gates) it is surfaced by the ``--deploy``
+    system check ``W006`` rather than a per-token warning here. See
+    :mod:`oauth2_provider.bcp`.
+    """
+    if oauth2_settings.COMPLIANT_BCP_RFC9700_TOKEN_STORAGE:
+        token_instance._raw_token = raw_token
+        token_instance.token = ""
+    else:
+        token_instance.token = raw_token
+        # Clear any stale redaction marker so a later save recomputes the checksum
+        # from this plaintext token rather than a previously stashed raw value.
+        token_instance._raw_token = None
+
+
 class AbstractApplication(models.Model):
     """
     An Application instance represents a Client on the Authorization server.

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -35,7 +35,9 @@ from . import cimd
 from .bcp import bcp_compliant
 from .exceptions import FatalClientError
 from .models import (
+    AbstractAccessToken,
     AbstractApplication,
+    AbstractRefreshToken,
     get_access_token_model,
     get_application_model,
     get_grant_model,
@@ -43,6 +45,7 @@ from .models import (
     get_refresh_token_model,
     refresh_token_expire_timedelta,
     revoke_access_token,
+    set_token_value,
 )
 from .scopes import get_scopes_backend
 from .settings import oauth2_settings
@@ -1058,29 +1061,15 @@ class OAuth2Validator(RequestValidator):
         else:
             self._create_access_token(expires, request, token)
 
-    def _set_token_value(self, token_instance, raw_token):
+    def _set_token_value(
+        self, token_instance: AbstractAccessToken | AbstractRefreshToken, raw_token: str
+    ) -> None:
         """
-        Assign the raw token to a token instance, redacting the value stored at rest
-        when COMPLIANT_BCP_RFC9700_TOKEN_STORAGE is enabled (RFC 9700).
+        Assign the raw token to a token instance, honouring RFC 9700 token storage.
 
-        The lookup checksum (``token_checksum``) is always derived from the raw token;
-        when redacting, the raw value is stashed on ``_raw_token`` (used only to compute
-        the checksum) and the ``token`` column is left blank so the reusable token is
-        never persisted.
-
-        Plaintext storage is an ambient config posture exercised on every token
-        issuance, so (unlike the request-time gates) it is surfaced by the ``--deploy``
-        system check ``W006`` rather than a per-token warning here. See
-        :mod:`oauth2_provider.bcp`.
+        See :func:`oauth2_provider.models.set_token_value`.
         """
-        if oauth2_settings.COMPLIANT_BCP_RFC9700_TOKEN_STORAGE:
-            token_instance._raw_token = raw_token
-            token_instance.token = ""
-        else:
-            token_instance.token = raw_token
-            # Clear any stale redaction marker so a later save recomputes the checksum
-            # from this plaintext token rather than a previously stashed raw value.
-            token_instance._raw_token = None
+        set_token_value(token_instance, raw_token)
 
     def _create_access_token(self, expires, request, token, source_refresh_token=None):
         id_token = token.get("id_token", None)

--- a/oauth2_provider/views/dynamic_client_registration.py
+++ b/oauth2_provider/views/dynamic_client_registration.py
@@ -7,6 +7,7 @@ RFC 7592 — GET/PUT/DELETE /register/{client_id}/
 
 import hashlib
 import json
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from typing import Any
@@ -346,6 +347,21 @@ class DynamicClientRegistrationView(View):
         return JsonResponse(response_data, status=201)
 
 
+@dataclass(frozen=True)
+class _AuthenticatedRegistration:
+    """A management request that presented a valid registration access token.
+
+    ``presented_token`` is the raw token from the ``Authorization`` header. It is
+    carried alongside the row because under ``COMPLIANT_BCP_RFC9700_TOKEN_STORAGE``
+    the ``token`` column is blank, so the request itself is the only remaining
+    source of the value the RFC 7592 read response has to echo back.
+    """
+
+    application: AbstractApplication
+    registration_token: AbstractAccessToken
+    presented_token: str
+
+
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
 class DynamicClientRegistrationManagementView(View):
@@ -360,25 +376,20 @@ class DynamicClientRegistrationManagementView(View):
             return JsonResponse({"error": "not_found"}, status=404)
         return super().dispatch(request, *args, **kwargs)
 
-    def _get_application_from_registration_token(
+    def _authenticate_registration_request(
         self, request: HttpRequest, client_id: str
-    ) -> tuple[AbstractApplication, AbstractAccessToken, str] | tuple[None, HttpResponse, None]:
+    ) -> _AuthenticatedRegistration | HttpResponse:
         """
         Validate Bearer token, check scope, check client_id match.
 
-        Returns (application, registration_token, presented_token) or
-        (None, error_response, None).
+        Returns the authenticated registration, or the error response to send.
         """
         presented_token = parse_bearer_token(request.META.get("HTTP_AUTHORIZATION", ""))
         if presented_token is None:
-            return (
-                None,
-                _error_response(
-                    "invalid_token",
-                    "Registration access token required",
-                    status=401,
-                ),
-                None,
+            return _error_response(
+                "invalid_token",
+                "Registration access token required",
+                status=401,
             )
 
         token_checksum = hashlib.sha256(presented_token.encode("utf-8")).hexdigest()
@@ -386,25 +397,17 @@ class DynamicClientRegistrationManagementView(View):
         try:
             token = AccessToken.objects.get(token_checksum=token_checksum)
         except AccessToken.DoesNotExist:
-            return (
-                None,
-                _error_response(
-                    "invalid_token",
-                    "Invalid registration access token",
-                    status=401,
-                ),
-                None,
+            return _error_response(
+                "invalid_token",
+                "Invalid registration access token",
+                status=401,
             )
 
         if not token.is_valid([oauth2_settings.DCR_REGISTRATION_SCOPE]):
-            return (
-                None,
-                _error_response(
-                    "invalid_token",
-                    "Registration access token is expired or invalid",
-                    status=401,
-                ),
-                None,
+            return _error_response(
+                "invalid_token",
+                "Registration access token is expired or invalid",
+                status=401,
             )
 
         application = token.application
@@ -413,7 +416,7 @@ class DynamicClientRegistrationManagementView(View):
             # belongs on a 401 challenge, and the token simply isn't valid for
             # this registration URI. This also avoids confirming whether the
             # requested client_id exists.
-            return None, _error_response("invalid_token", "Token does not match client_id", status=401), None
+            return _error_response("invalid_token", "Token does not match client_id", status=401)
 
         # RFC 7592 management only applies to dynamically registered clients.
         # This stops a regular access token that happens to carry
@@ -424,38 +427,28 @@ class DynamicClientRegistrationManagementView(View):
         # a "not application.registration_source" test would let every
         # application through the management endpoint.
         if application.registration_source != application.RegistrationSource.DCR:
-            return (
-                None,
-                _error_response(
-                    "invalid_token",
-                    "Token was not issued by the registration endpoint",
-                    status=401,
-                ),
-                None,
+            return _error_response(
+                "invalid_token",
+                "Token was not issued by the registration endpoint",
+                status=401,
             )
 
-        return application, token, presented_token
+        return _AuthenticatedRegistration(application, token, presented_token)
 
     def get(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
-        application, result, presented_token = self._get_application_from_registration_token(
-            request, client_id
-        )
-        if application is None:
-            return result  # error response
+        auth = self._authenticate_registration_request(request, client_id)
+        if isinstance(auth, HttpResponse):
+            return auth
 
-        assert presented_token is not None  # paired with the application by the helper
-        return JsonResponse(_application_to_response(application, presented_token, request))
+        return JsonResponse(_application_to_response(auth.application, auth.presented_token, request))
 
     def put(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
-        application, result, presented_token = self._get_application_from_registration_token(
-            request, client_id
-        )
-        if application is None:
-            return result
+        auth = self._authenticate_registration_request(request, client_id)
+        if isinstance(auth, HttpResponse):
+            return auth
 
-        assert presented_token is not None  # paired with the application by the helper
-        registration_token = result
-        response_token = presented_token
+        application = auth.application
+        response_token = auth.presented_token
 
         data, err = _parse_metadata(request.body)
         if err:
@@ -479,14 +472,14 @@ class DynamicClientRegistrationManagementView(View):
             if oauth2_settings.DCR_ROTATE_REGISTRATION_TOKEN_ON_UPDATE:
                 user = application.user
                 response_token = _issue_registration_token(application, user)
-                registration_token.delete()
+                auth.registration_token.delete()
 
         return JsonResponse(_application_to_response(application, response_token, request))
 
     def delete(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
-        application, result, _ = self._get_application_from_registration_token(request, client_id)
-        if application is None:
-            return result
+        auth = self._authenticate_registration_request(request, client_id)
+        if isinstance(auth, HttpResponse):
+            return auth
 
-        application.delete()
+        auth.application.delete()
         return HttpResponse(status=204)

--- a/oauth2_provider/views/dynamic_client_registration.py
+++ b/oauth2_provider/views/dynamic_client_registration.py
@@ -22,7 +22,13 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from ..compat import login_not_required
-from ..models import AbstractAccessToken, AbstractApplication, get_access_token_model, get_application_model
+from ..models import (
+    AbstractAccessToken,
+    AbstractApplication,
+    get_access_token_model,
+    get_application_model,
+    set_token_value,
+)
 from ..settings import oauth2_settings
 from ..utils import parse_bearer_token
 
@@ -232,9 +238,8 @@ def _issue_registration_token(application: AbstractApplication, user: AbstractBa
         scope=oauth2_settings.DCR_REGISTRATION_SCOPE,
     )
     # Assigning ``token`` directly would store a reusable credential in cleartext even
-    # when the deployment asked for hashed-at-rest storage; the validator is what
-    # applies the redaction consistently for every other token this library issues.
-    oauth2_settings.OAUTH2_VALIDATOR_CLASS()._set_token_value(token, raw_token)
+    # when the deployment asked for hashed-at-rest storage.
+    set_token_value(token, raw_token)
     token.save()
     return raw_token
 
@@ -438,6 +443,7 @@ class DynamicClientRegistrationManagementView(View):
         if application is None:
             return result  # error response
 
+        assert presented_token is not None  # paired with the application by the helper
         return JsonResponse(_application_to_response(application, presented_token, request))
 
     def put(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
@@ -447,6 +453,7 @@ class DynamicClientRegistrationManagementView(View):
         if application is None:
             return result
 
+        assert presented_token is not None  # paired with the application by the helper
         registration_token = result
         response_token = presented_token
 

--- a/oauth2_provider/views/dynamic_client_registration.py
+++ b/oauth2_provider/views/dynamic_client_registration.py
@@ -202,7 +202,12 @@ def _build_application_kwargs(data):
 
 def _issue_registration_token(application, user):
     """
-    Create and return a new registration AccessToken for *application*.
+    Create a new registration AccessToken for *application*.
+
+    Returns ``(token, raw_token)``. The raw value is returned alongside the instance
+    because it is the caller's only chance to read it: under
+    ``COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`` the ``token`` column is left blank and only
+    the lookup checksum is persisted, so reading it back off the row yields "".
 
     Token scope is ``oauth2_settings.DCR_REGISTRATION_SCOPE``.
     Expiry: far-future (year 9999) when ``DCR_REGISTRATION_TOKEN_EXPIRE_SECONDS`` is None,
@@ -218,18 +223,28 @@ def _issue_registration_token(application, user):
     else:
         expires = timezone.now() + timedelta(seconds=expire_seconds)
 
-    token = AccessToken.objects.create(
+    raw_token = generate_client_secret()
+    token = AccessToken(
         application=application,
         user=user,
-        token=generate_client_secret(),
         expires=expires,
         scope=oauth2_settings.DCR_REGISTRATION_SCOPE,
     )
-    return token
+    # Assigning ``token`` directly would store a reusable credential in cleartext even
+    # when the deployment asked for hashed-at-rest storage; the validator is what
+    # applies the redaction consistently for every other token this library issues.
+    oauth2_settings.OAUTH2_VALIDATOR_CLASS()._set_token_value(token, raw_token)
+    token.save()
+    return token, raw_token
 
 
-def _application_to_response(application, registration_token, request):
-    """Build the RFC 7591 response dict for *application*."""
+def _application_to_response(application, registration_access_token, request):
+    """Build the RFC 7591 response dict for *application*.
+
+    *registration_access_token* is the raw token value rather than the model instance:
+    under hashed-at-rest storage the stored column is blank, so the value can only come
+    from whoever just issued it or from the request that presented it.
+    """
     data = {
         "client_id": application.client_id,
         "redirect_uris": application.redirect_uris.split() if application.redirect_uris else [],
@@ -237,7 +252,7 @@ def _application_to_response(application, registration_token, request):
         "token_endpoint_auth_method": (
             "none" if application.client_type == "public" else "client_secret_basic"
         ),
-        "registration_access_token": registration_token.token,
+        "registration_access_token": registration_access_token,
         "registration_client_uri": request.build_absolute_uri(
             reverse("oauth2_provider:dcr-register-management", kwargs={"client_id": application.client_id})
         ),
@@ -314,9 +329,9 @@ class DynamicClientRegistrationView(View):
 
         with transaction.atomic():
             application.save()
-            registration_token = _issue_registration_token(application, user)
+            _, raw_registration_token = _issue_registration_token(application, user)
 
-        response_data = _application_to_response(application, registration_token, request)
+        response_data = _application_to_response(application, raw_registration_token, request)
         if raw_secret:
             response_data["client_secret"] = raw_secret
 
@@ -341,14 +356,19 @@ class DynamicClientRegistrationManagementView(View):
         """
         Validate Bearer token, check scope, check client_id match.
 
-        Returns (application, registration_token) or (None, error_response).
+        Returns (application, registration_token, raw_token) or
+        (None, error_response, None).
         """
         raw_token = parse_bearer_token(request.META.get("HTTP_AUTHORIZATION", ""))
         if raw_token is None:
-            return None, _error_response(
-                "invalid_token",
-                "Registration access token required",
-                status=401,
+            return (
+                None,
+                _error_response(
+                    "invalid_token",
+                    "Registration access token required",
+                    status=401,
+                ),
+                None,
             )
 
         token_checksum = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
@@ -356,17 +376,25 @@ class DynamicClientRegistrationManagementView(View):
         try:
             token = AccessToken.objects.get(token_checksum=token_checksum)
         except AccessToken.DoesNotExist:
-            return None, _error_response(
-                "invalid_token",
-                "Invalid registration access token",
-                status=401,
+            return (
+                None,
+                _error_response(
+                    "invalid_token",
+                    "Invalid registration access token",
+                    status=401,
+                ),
+                None,
             )
 
         if not token.is_valid([oauth2_settings.DCR_REGISTRATION_SCOPE]):
-            return None, _error_response(
-                "invalid_token",
-                "Registration access token is expired or invalid",
-                status=401,
+            return (
+                None,
+                _error_response(
+                    "invalid_token",
+                    "Registration access token is expired or invalid",
+                    status=401,
+                ),
+                None,
             )
 
         application = token.application
@@ -375,7 +403,7 @@ class DynamicClientRegistrationManagementView(View):
             # belongs on a 401 challenge, and the token simply isn't valid for
             # this registration URI. This also avoids confirming whether the
             # requested client_id exists.
-            return None, _error_response("invalid_token", "Token does not match client_id", status=401)
+            return None, _error_response("invalid_token", "Token does not match client_id", status=401), None
 
         # RFC 7592 management only applies to dynamically registered clients.
         # This stops a regular access token that happens to carry
@@ -386,24 +414,27 @@ class DynamicClientRegistrationManagementView(View):
         # a "not application.registration_source" test would let every
         # application through the management endpoint.
         if application.registration_source != application.RegistrationSource.DCR:
-            return None, _error_response(
-                "invalid_token",
-                "Token was not issued by the registration endpoint",
-                status=401,
+            return (
+                None,
+                _error_response(
+                    "invalid_token",
+                    "Token was not issued by the registration endpoint",
+                    status=401,
+                ),
+                None,
             )
 
-        return application, token
+        return application, token, raw_token
 
     def get(self, request, client_id, *args, **kwargs):
-        application, result = self._get_application_from_registration_token(request, client_id)
+        application, result, raw_token = self._get_application_from_registration_token(request, client_id)
         if application is None:
             return result  # error response
 
-        registration_token = result
-        return JsonResponse(_application_to_response(application, registration_token, request))
+        return JsonResponse(_application_to_response(application, raw_token, request))
 
     def put(self, request, client_id, *args, **kwargs):
-        application, result = self._get_application_from_registration_token(request, client_id)
+        application, result, raw_token = self._get_application_from_registration_token(request, client_id)
         if application is None:
             return result
 
@@ -430,14 +461,13 @@ class DynamicClientRegistrationManagementView(View):
 
             if oauth2_settings.DCR_ROTATE_REGISTRATION_TOKEN_ON_UPDATE:
                 user = application.user
-                new_token = _issue_registration_token(application, user)
+                _, raw_token = _issue_registration_token(application, user)
                 registration_token.delete()
-                registration_token = new_token
 
-        return JsonResponse(_application_to_response(application, registration_token, request))
+        return JsonResponse(_application_to_response(application, raw_token, request))
 
     def delete(self, request, client_id, *args, **kwargs):
-        application, result = self._get_application_from_registration_token(request, client_id)
+        application, result, _ = self._get_application_from_registration_token(request, client_id)
         if application is None:
             return result
 

--- a/oauth2_provider/views/dynamic_client_registration.py
+++ b/oauth2_provider/views/dynamic_client_registration.py
@@ -9,10 +9,12 @@ import hashlib
 import json
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
+from typing import Any
 
+from django.contrib.auth.base_user import AbstractBaseUser
 from django.core.exceptions import ValidationError
 from django.db import transaction
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.decorators import method_decorator
@@ -20,7 +22,7 @@ from django.views import View
 from django.views.decorators.csrf import csrf_exempt
 
 from ..compat import login_not_required
-from ..models import get_access_token_model, get_application_model
+from ..models import AbstractAccessToken, AbstractApplication, get_access_token_model, get_application_model
 from ..settings import oauth2_settings
 from ..utils import parse_bearer_token
 
@@ -200,14 +202,13 @@ def _build_application_kwargs(data):
     return kwargs, None
 
 
-def _issue_registration_token(application, user):
+def _issue_registration_token(application: AbstractApplication, user: AbstractBaseUser | None) -> str:
     """
-    Create a new registration AccessToken for *application*.
+    Create a new registration AccessToken for *application* and return its raw value.
 
-    Returns ``(token, raw_token)``. The raw value is returned alongside the instance
-    because it is the caller's only chance to read it: under
-    ``COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`` the ``token`` column is left blank and only
-    the lookup checksum is persisted, so reading it back off the row yields "".
+    Only the raw value is returned, because reading it back off the row is not an
+    option: under ``COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`` the ``token`` column is left
+    blank and only the lookup checksum is persisted.
 
     Token scope is ``oauth2_settings.DCR_REGISTRATION_SCOPE``.
     Expiry: far-future (year 9999) when ``DCR_REGISTRATION_TOKEN_EXPIRE_SECONDS`` is None,
@@ -235,10 +236,12 @@ def _issue_registration_token(application, user):
     # applies the redaction consistently for every other token this library issues.
     oauth2_settings.OAUTH2_VALIDATOR_CLASS()._set_token_value(token, raw_token)
     token.save()
-    return token, raw_token
+    return raw_token
 
 
-def _application_to_response(application, registration_access_token, request):
+def _application_to_response(
+    application: AbstractApplication, registration_access_token: str, request: HttpRequest
+) -> dict[str, Any]:
     """Build the RFC 7591 response dict for *application*.
 
     *registration_access_token* is the raw token value rather than the model instance:
@@ -329,7 +332,7 @@ class DynamicClientRegistrationView(View):
 
         with transaction.atomic():
             application.save()
-            _, raw_registration_token = _issue_registration_token(application, user)
+            raw_registration_token = _issue_registration_token(application, user)
 
         response_data = _application_to_response(application, raw_registration_token, request)
         if raw_secret:
@@ -352,15 +355,17 @@ class DynamicClientRegistrationManagementView(View):
             return JsonResponse({"error": "not_found"}, status=404)
         return super().dispatch(request, *args, **kwargs)
 
-    def _get_application_from_registration_token(self, request, client_id):
+    def _get_application_from_registration_token(
+        self, request: HttpRequest, client_id: str
+    ) -> tuple[AbstractApplication, AbstractAccessToken, str] | tuple[None, HttpResponse, None]:
         """
         Validate Bearer token, check scope, check client_id match.
 
-        Returns (application, registration_token, raw_token) or
+        Returns (application, registration_token, presented_token) or
         (None, error_response, None).
         """
-        raw_token = parse_bearer_token(request.META.get("HTTP_AUTHORIZATION", ""))
-        if raw_token is None:
+        presented_token = parse_bearer_token(request.META.get("HTTP_AUTHORIZATION", ""))
+        if presented_token is None:
             return (
                 None,
                 _error_response(
@@ -371,7 +376,7 @@ class DynamicClientRegistrationManagementView(View):
                 None,
             )
 
-        token_checksum = hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+        token_checksum = hashlib.sha256(presented_token.encode("utf-8")).hexdigest()
         AccessToken = get_access_token_model()
         try:
             token = AccessToken.objects.get(token_checksum=token_checksum)
@@ -424,21 +429,26 @@ class DynamicClientRegistrationManagementView(View):
                 None,
             )
 
-        return application, token, raw_token
+        return application, token, presented_token
 
-    def get(self, request, client_id, *args, **kwargs):
-        application, result, raw_token = self._get_application_from_registration_token(request, client_id)
+    def get(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
+        application, result, presented_token = self._get_application_from_registration_token(
+            request, client_id
+        )
         if application is None:
             return result  # error response
 
-        return JsonResponse(_application_to_response(application, raw_token, request))
+        return JsonResponse(_application_to_response(application, presented_token, request))
 
-    def put(self, request, client_id, *args, **kwargs):
-        application, result, raw_token = self._get_application_from_registration_token(request, client_id)
+    def put(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
+        application, result, presented_token = self._get_application_from_registration_token(
+            request, client_id
+        )
         if application is None:
             return result
 
         registration_token = result
+        response_token = presented_token
 
         data, err = _parse_metadata(request.body)
         if err:
@@ -461,12 +471,12 @@ class DynamicClientRegistrationManagementView(View):
 
             if oauth2_settings.DCR_ROTATE_REGISTRATION_TOKEN_ON_UPDATE:
                 user = application.user
-                _, raw_token = _issue_registration_token(application, user)
+                response_token = _issue_registration_token(application, user)
                 registration_token.delete()
 
-        return JsonResponse(_application_to_response(application, raw_token, request))
+        return JsonResponse(_application_to_response(application, response_token, request))
 
-    def delete(self, request, client_id, *args, **kwargs):
+    def delete(self, request: HttpRequest, client_id: str, *args, **kwargs) -> HttpResponse:
         application, result, _ = self._get_application_from_registration_token(request, client_id)
         if application is None:
             return result

--- a/tests/test_bcp_rfc9700.py
+++ b/tests/test_bcp_rfc9700.py
@@ -17,7 +17,7 @@ from django.test import RequestFactory
 from django.urls import reverse
 from django.utils import timezone
 
-from oauth2_provider.models import get_access_token_model, get_application_model
+from oauth2_provider.models import get_access_token_model, get_application_model, set_token_value
 from oauth2_provider.oauth2_backends import _add_iss_to_redirect
 from oauth2_provider.views import ProtectedResourceView
 
@@ -279,6 +279,32 @@ def test_implicit_response_type_rejected_for_non_implicit_client():
 
     validator = OAuth2Validator()
     assert validator.validate_response_type(None, "token", _Client(), None) is False
+
+
+def test_set_token_value_keeps_plaintext_by_default():
+    # Plaintext storage (the default): the column carries the usable token and no
+    # redaction marker is left behind for TokenChecksumField to pick up.
+    class _Tok:
+        pass
+
+    tok = _Tok()
+    set_token_value(tok, "plaintoken")
+    assert tok.token == "plaintoken"
+    assert tok._raw_token is None
+
+
+def test_set_token_value_redacts_under_hashed_storage(oauth2_settings):
+    # Hashed-at-rest storage: the column is blanked and the raw value is stashed for
+    # TokenChecksumField to hash at save time.
+    oauth2_settings.COMPLIANT_BCP_RFC9700_TOKEN_STORAGE = True
+
+    class _Tok:
+        pass
+
+    tok = _Tok()
+    set_token_value(tok, "hashedtoken")
+    assert tok.token == ""
+    assert tok._raw_token == "hashedtoken"
 
 
 def test_set_token_value_clears_stale_raw_token_in_plaintext_mode():

--- a/tests/test_dcr_views.py
+++ b/tests/test_dcr_views.py
@@ -998,16 +998,13 @@ class TestDCRRegistrationTokenStorage(TestCase):
         assert token.token == ""
         assert token.token_checksum == checksum
 
-    def test_registration_response_returns_a_usable_token(self):
-        """Redacting the column must not cost the client the token it was issued."""
+    def test_issued_token_authenticates_and_is_echoed_back(self):
+        """Redacting the column must not cost the client the token it was issued, and
+        RFC 7592 §3 still wants that token in the read response. With no readable copy
+        left on the server, the endpoint echoes back whatever the client presented."""
         assert self.registration_token
         response = self.client.get(self.management_url, **_bearer(self.registration_token))
         assert response.status_code == 200
-
-    def test_get_returns_the_presented_token(self):
-        """RFC 7592 §3 puts the registration access token in the read response, and the
-        server no longer holds a readable copy, so it echoes what the client presented."""
-        response = self.client.get(self.management_url, **_bearer(self.registration_token))
         assert response.json()["registration_access_token"] == self.registration_token
 
     def test_rotation_returns_a_usable_token_and_retires_the_old_one(self):

--- a/tests/test_dcr_views.py
+++ b/tests/test_dcr_views.py
@@ -2,6 +2,7 @@
 Tests for Dynamic Client Registration views (RFC 7591 / RFC 7592).
 """
 
+import hashlib
 import json
 
 import pytest
@@ -951,3 +952,82 @@ class TestDCRFullRoundtrip(TestCase):
         delete_response = self.client.delete(mgmt_url, **_bearer(new_token))
         assert delete_response.status_code == 204
         assert not Application.objects.filter(client_id=client_id).exists()
+
+
+# ---------------------------------------------------------------------------
+# RFC 9700 hashed-at-rest token storage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(
+    {
+        **presets.DCR_SETTINGS,
+        "COMPLIANT_BCP_RFC9700_TOKEN_STORAGE": True,
+    }
+)
+class TestDCRRegistrationTokenStorage(TestCase):
+    """Registration access tokens honour COMPLIANT_BCP_RFC9700_TOKEN_STORAGE.
+
+    These tokens are minted by the DCR views rather than by the validator's normal
+    issuance path, so they are the one kind that can keep being written in cleartext
+    after a deployment enables hashed-at-rest storage.
+    """
+
+    def setUp(self):
+        self.user = UserModel.objects.create_user("hashed_user", "hashed@example.com", "pass")
+        self.client.force_login(self.user)
+        response = _post_register(
+            self.client,
+            {
+                "redirect_uris": ["https://example.com/cb"],
+                "grant_types": ["authorization_code"],
+                "client_name": "Hashed App",
+            },
+        )
+        assert response.status_code == 201
+        body = response.json()
+        self.client_id = body["client_id"]
+        self.registration_token = body["registration_access_token"]
+        self.management_url = _management_url(self.client_id)
+        self.client.logout()
+
+    def test_registration_token_is_not_persisted_in_cleartext(self):
+        checksum = hashlib.sha256(self.registration_token.encode()).hexdigest()
+        token = AccessToken.objects.get(token_checksum=checksum)
+        assert token.token == ""
+        assert token.token_checksum == checksum
+
+    def test_registration_response_returns_a_usable_token(self):
+        """Redacting the column must not cost the client the token it was issued."""
+        assert self.registration_token
+        response = self.client.get(self.management_url, **_bearer(self.registration_token))
+        assert response.status_code == 200
+
+    def test_get_returns_the_presented_token(self):
+        """RFC 7592 §3 puts the registration access token in the read response, and the
+        server no longer holds a readable copy, so it echoes what the client presented."""
+        response = self.client.get(self.management_url, **_bearer(self.registration_token))
+        assert response.json()["registration_access_token"] == self.registration_token
+
+    def test_rotated_token_is_returned_and_usable(self):
+        response = self.client.put(
+            self.management_url,
+            data=json.dumps(
+                {
+                    "redirect_uris": ["https://example.com/cb"],
+                    "grant_types": ["authorization_code"],
+                    "client_name": "Hashed App v2",
+                }
+            ),
+            content_type="application/json",
+            **_bearer(self.registration_token),
+        )
+        assert response.status_code == 200
+        rotated = response.json()["registration_access_token"]
+        assert rotated
+        assert rotated != self.registration_token
+
+        stored = AccessToken.objects.get(token_checksum=hashlib.sha256(rotated.encode()).hexdigest())
+        assert stored.token == ""
+        assert self.client.get(self.management_url, **_bearer(rotated)).status_code == 200

--- a/tests/test_dcr_views.py
+++ b/tests/test_dcr_views.py
@@ -1010,7 +1010,7 @@ class TestDCRRegistrationTokenStorage(TestCase):
         response = self.client.get(self.management_url, **_bearer(self.registration_token))
         assert response.json()["registration_access_token"] == self.registration_token
 
-    def test_rotated_token_is_returned_and_usable(self):
+    def test_rotation_returns_a_usable_token_and_retires_the_old_one(self):
         response = self.client.put(
             self.management_url,
             data=json.dumps(
@@ -1031,3 +1031,6 @@ class TestDCRRegistrationTokenStorage(TestCase):
         stored = AccessToken.objects.get(token_checksum=hashlib.sha256(rotated.encode()).hexdigest())
         assert stored.token == ""
         assert self.client.get(self.management_url, **_bearer(rotated)).status_code == 200
+
+        rotated_away = self.client.get(self.management_url, **_bearer(self.registration_token))
+        assert rotated_away.status_code == 401


### PR DESCRIPTION
## What

RFC 7592 registration access tokens are issued outside the validator's normal token path, so they do not honour `COMPLIANT_BCP_RFC9700_TOKEN_STORAGE`. `_issue_registration_token()` assigns the value straight onto the model:

```python
token = AccessToken.objects.create(
    ...
    token=generate_client_secret(),
)
```

Every other token DOT issues goes through `OAuth2Validator._set_token_value()`, which blanks the `token` column and keeps only the lookup checksum when the setting is enabled. This one does not, so a deployment that has explicitly opted into hashed-at-rest storage still has its registration access tokens persisted in cleartext — and nothing surfaces the divergence.

This is a latent gap rather than a live vulnerability: the setting defaults to `False`, and with it off `_set_token_value()` does exactly what the current code does. It only bites deployments that turned hashing on and reasonably assumed it applied to every token in the table.

## The fix

The redaction logic moves out of the validator and into `oauth2_provider.models.set_token_value()`, sitting next to `TokenChecksumField` where the `_raw_token` protocol it drives already lives. `OAuth2Validator._set_token_value()` stays put as a thin delegating wrapper, so a custom validator that overrides it keeps working for every token the validator issues; the DCR view calls the model helper directly rather than reaching into validator internals.

That alone would break the feature, which is why the diff is larger than the one-line cause suggests. Once the column is redacted, `registration_token.token` is `""`, and three response paths read it:

- **POST** `/register/` — returns the token it just minted.
- **GET** `/register/{client_id}/` — RFC 7592 §3 includes the registration access token in the read response. The server no longer holds a readable copy, so it echoes back the token the request presented (it was just validated, so it is necessarily the right one).
- **PUT** `/register/{client_id}/` — returns the rotated value when `DCR_ROTATE_REGISTRATION_TOKEN_ON_UPDATE` is on.

So `_issue_registration_token()` now returns the raw token string instead of the model instance, and `_application_to_response()` takes that raw string.

The management endpoints need the presented token too, which means the auth helper has to hand back three things instead of one. Rather than widen its tuple — a `tuple[App, Token, str] | tuple[None, HttpResponse, None]` cannot be narrowed by a type checker, since testing the first element for `None` says nothing about the third — `_get_application_from_registration_token()` becomes `_authenticate_registration_request()`, returning either a frozen `_AuthenticatedRegistration` dataclass or the `HttpResponse` to send. A single `isinstance(auth, HttpResponse)` check narrows all three values at once, so no type-narrowing asserts are needed and an `AssertionError` cannot surface as a 500 on an auth path if a later refactor breaks the invariant. The error returns stay single-value, so nothing in the helper reformats. mypy is clean on this file.

Uniqueness is unaffected: `AccessToken.token` is a plain `TextField` and the unique constraint lives on `token_checksum`, which is derived from the raw value.

## Tests

New `TestDCRRegistrationTokenStorage` in `tests/test_dcr_views.py`, covering the full lifecycle with the setting on: the stored column is blank while the checksum matches, the token returned at registration still authenticates against the management endpoint and is echoed back by `GET`, and a rotated `PUT` token is both returned and usable while also being redacted at rest.

Two of the three fail on `master` for the right reason (the raw token found sitting in the column); the third is a regression guard on the response threading.

`tests/test_bcp_rfc9700.py` gains direct coverage of `set_token_value()` in both modes, matching the existing coverage of the validator method it was extracted from.

Full suite passes locally: `1074 passed, 1 skipped`.

## Docs

`docs/security.rst` already stated that enabling the setting means "a database read no longer discloses usable tokens" — the code simply did not match for this token. Added a short note that registration access tokens are covered, and that `GET` echoes the presented value as a consequence.

Note that `set_token_value()` is public, so it now appears on the Models page via `automodule`.

## Notes

Found while auditing 3.4.0 before adopting it.
