### PR TITLE
Enforce exact redirect URI matching per RFC 9700 §2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     empty fragment component and is rejected too; a percent-encoded `%23` is not a
     fragment delimiter and is unaffected.
 
+  Registration is tightened to match: `AllowedURIValidator` tested the *parsed* fragment,
+  which is empty both for a URI with no fragment and for one ending in a bare `#`, so
+  `https://example.com/cb#` was accepted at save time. With matching now denying any `#`,
+  such a registration would be stored and then never authorize anything; it is rejected
+  up front instead. Registering a URI ending in `#` now raises a `ValidationError` where
+  it previously succeeded.
+
   Case-insensitive scheme/host comparison (RFC 3986 §6.2.2.1 normalization) and the
   RFC 8252 §7.3 loopback any-port exemption are unchanged; `ALLOW_URI_WILDCARDS` still
   opts out of exact host matching and remains flagged by `oauth2_provider.W009`/`E004`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,10 +120,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     authorization server reflect them into the client's callback alongside the
     authorization code, the redirect-URI manipulation class described in
     [RFC 9700 §4.1](https://datatracker.ietf.org/doc/html/rfc9700#section-4.1).
+  * A request could carry **path parameters** (`https://example.com/cb;evil=1`). `urlparse()`
+    peels `;params` off the last path segment into a separate attribute, and only `.path`
+    was compared, so these smuggled data to the callback the same way extra query
+    parameters did. Matching now uses `urlsplit()`, which leaves them in the path.
+  * A request could carry **credentials** (`https://evil@example.com/cb`). Only `.hostname`
+    was compared, so userinfo rode along unnoticed. Credentials are not part of a
+    registered callback and are now rejected on either side.
   * A request could carry a **fragment**, which `urlparse()` split off before comparison,
     so `https://example.com/cb#x` matched a registered `https://example.com/cb`.
     [RFC 6749 §3.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2) states
-    the endpoint URI MUST NOT include a fragment component.
+    the endpoint URI MUST NOT include a fragment component. A bare trailing `#` is an
+    empty fragment component and is rejected too; a percent-encoded `%23` is not a
+    fragment delimiter and is unaffected.
 
   Case-insensitive scheme/host comparison (RFC 3986 §6.2.2.1 normalization) and the
   RFC 8252 §7.3 loopback any-port exemption are unchanged; `ALLOW_URI_WILDCARDS` still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   [RFC 9700 §2.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1) requires
   ("authorization servers MUST utilize exact string matching except for port numbers in
   localhost redirection URIs of native apps") and OpenID Connect Core §3.1.2.1 restates
-  via RFC 3986 §6.2.1 Simple String Comparison. Two deviations are closed:
+  via RFC 3986 §6.2.1 Simple String Comparison. Four deviations are closed, each of which
+  let a request differ from the registered URI while still matching it:
   * A request could carry **query parameters that were never registered** — the check
     tested that the registered query was a *subset* of the requested one. An attacker
     could append parameters to an otherwise-legitimate `redirect_uri` and have the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turning into a server error.
 
 ### Security
+* Redirect URIs are now matched exactly, as
+  [RFC 9700 §2.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1) requires
+  ("authorization servers MUST utilize exact string matching except for port numbers in
+  localhost redirection URIs of native apps") and OpenID Connect Core §3.1.2.1 restates
+  via RFC 3986 §6.2.1 Simple String Comparison. Two deviations are closed:
+  * A request could carry **query parameters that were never registered** — the check
+    tested that the registered query was a *subset* of the requested one. An attacker
+    could append parameters to an otherwise-legitimate `redirect_uri` and have the
+    authorization server reflect them into the client's callback alongside the
+    authorization code, the redirect-URI manipulation class described in
+    [RFC 9700 §4.1](https://datatracker.ietf.org/doc/html/rfc9700#section-4.1).
+  * A request could carry a **fragment**, which `urlparse()` split off before comparison,
+    so `https://example.com/cb#x` matched a registered `https://example.com/cb`.
+    [RFC 6749 §3.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2) states
+    the endpoint URI MUST NOT include a fragment component.
+
+  Case-insensitive scheme/host comparison (RFC 3986 §6.2.2.1 normalization) and the
+  RFC 8252 §7.3 loopback any-port exemption are unchanged; `ALLOW_URI_WILDCARDS` still
+  opts out of exact host matching and remains flagged by `oauth2_provider.W009`/`E004`.
+
+  **Upgrade note:** clients that pass per-request data through the `redirect_uri` query
+  string will now be rejected — every query parameter must be registered, and in the same
+  order. Register the full URI including its query, or move per-request data into the
+  `state` parameter, which is what it is for. Applications whose registered
+  `redirect_uris` already carry no query component are unaffected.
 * #1510 Revoking an access token from the authorized-tokens page
   (`AuthorizedTokenDeleteView`) now also revokes the refresh token issued
   alongside it. Previously only the access token was deleted, leaving the

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -110,8 +110,11 @@ policy and is not flagged).
 
 Redirect URI matching (§2.1)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-DOT already performs exact redirect-URI matching (scheme, host, port, and path), with
-wildcards off (``ALLOW_URI_WILDCARDS`` defaults to ``False``). Set
+DOT performs exact redirect-URI matching — scheme, host, port, path, **and query** — with
+wildcards off (``ALLOW_URI_WILDCARDS`` defaults to ``False``). A request may not carry
+query parameters that were not registered, and may not carry a fragment at all
+(:rfc:`6749#section-3.1.2`). Clients that need to pass per-request data should use the
+``state`` parameter rather than appending it to the ``redirect_uri``. Set
 ``ALLOWED_REDIRECT_URI_SCHEMES = ["https"]`` to disallow registering plaintext ``http``
 redirect URIs. Two validation gates cover these settings:
 ``COMPLIANT_BCP_RFC9700_REDIRECT_URI_SCHEME`` flags ``http`` in the scheme list

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from typing import Callable, Optional, Union
-from urllib.parse import parse_qsl, urlparse
+from urllib.parse import urlparse
 
 from django.apps import apps
 from django.conf import settings
@@ -1137,7 +1137,14 @@ def redirect_to_uri_allowed(uri, allowed_uris):
         raise ValueError("allowed_uris must be a list")
 
     parsed_uri = urlparse(uri)
-    uqs_set = set(parse_qsl(parsed_uri.query))
+
+    # RFC 6749 section 3.1.2: "The endpoint URI MUST NOT include a fragment
+    # component."  urlparse() splits the fragment off before the component
+    # comparisons below, so without this an appended fragment would be ignored
+    # and the URI would match its registered, fragment-less counterpart.
+    if parsed_uri.fragment:
+        return False
+
     for allowed_uri in allowed_uris:
         parsed_allowed_uri = urlparse(allowed_uri)
 
@@ -1183,8 +1190,15 @@ def redirect_to_uri_allowed(uri, allowed_uris):
             continue
 
         """ check querystring """
-        aqs_set = set(parse_qsl(parsed_allowed_uri.query))
-        if not aqs_set.issubset(uqs_set):
+        # RFC 9700 section 2.1 requires exact matching of the redirect URI (see
+        # also OpenID Connect Core section 3.1.2.1, which mandates RFC 3986
+        # section 6.2.1 Simple String Comparison).  This previously tested that
+        # the registered query was a *subset* of the requested one, which let a
+        # request carry query parameters that were never registered: an attacker
+        # could append parameters to an otherwise-legitimate redirect URI and
+        # have the authorization server reflect them into the client's callback
+        # alongside the authorization code (RFC 9700 section 4.1).
+        if parsed_allowed_uri.query != parsed_uri.query:
             continue  # circuit break
 
         return True

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1217,6 +1217,15 @@ def redirect_to_uri_allowed(uri, allowed_uris):
         # could append parameters to an otherwise-legitimate redirect URI and
         # have the authorization server reflect them into the client's callback
         # alongside the authorization code (RFC 9700 section 4.1).
+        #
+        # .query is "" both when there is no query component and when there is an
+        # empty one ("https://example.com/cb?"), which are different URIs under
+        # simple string comparison, so the delimiter's presence is compared too.
+        # A "?" cannot appear in a scheme, authority or path -- the first one always
+        # opens the query -- so testing the raw string is equivalent to testing for
+        # the component.  A percent-encoded %3F is not a delimiter and is unaffected.
+        if ("?" in allowed_uri) != ("?" in uri):
+            continue
         if parsed_allowed_uri.query != parsed_uri.query:
             continue  # circuit break
 

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta
 from datetime import timezone as dt_timezone
 from typing import Callable, Optional, Union
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlsplit
 
 from django.apps import apps
 from django.conf import settings
@@ -1136,17 +1136,36 @@ def redirect_to_uri_allowed(uri, allowed_uris):
     if not isinstance(allowed_uris, list):
         raise ValueError("allowed_uris must be a list")
 
-    parsed_uri = urlparse(uri)
+    # urlsplit() rather than urlparse(): urlparse() peels ";params" off the last
+    # path segment into a separate attribute, so comparing .path alone would let a
+    # request smuggle "/cb;evil=1" past a registered "/cb".  urlsplit() leaves the
+    # parameters in .path, where they are compared like the rest of it.
+    parsed_uri = urlsplit(uri)
 
     # RFC 6749 section 3.1.2: "The endpoint URI MUST NOT include a fragment
-    # component."  urlparse() splits the fragment off before the component
-    # comparisons below, so without this an appended fragment would be ignored
-    # and the URI would match its registered, fragment-less counterpart.
-    if parsed_uri.fragment:
+    # component."  Test the raw string rather than .fragment, which is "" both for
+    # a URI with no fragment and for one ending in a bare "#" -- the latter is a
+    # (empty) fragment component and is not the registered URI.  A percent-encoded
+    # %23 is not a fragment delimiter and is unaffected.
+    if "#" in uri:
+        return False
+
+    # Credentials are not part of a registered callback and must not ride along on
+    # the request; without this "https://evil@example.com/cb" would match a
+    # registered "https://example.com/cb", since only .hostname is compared below.
+    if "@" in parsed_uri.netloc:
         return False
 
     for allowed_uri in allowed_uris:
-        parsed_allowed_uri = urlparse(allowed_uri)
+        # A registered URI carrying a fragment or credentials cannot authorize
+        # anything: the request forms that would match it are rejected above.
+        if "#" in allowed_uri:
+            continue
+
+        parsed_allowed_uri = urlsplit(allowed_uri)
+
+        if "@" in parsed_allowed_uri.netloc:
+            continue
 
         if parsed_allowed_uri.scheme != parsed_uri.scheme:
             # match failed, continue

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -66,7 +66,13 @@ class AllowedURIValidator(URIValidator):
                 "%(name)s URI validation error. %(cause)s: %(value)s",
                 params={"name": self.name, "value": value, "cause": "query string not allowed"},
             )
-        if fragment and not self.allow_fragments:
+        # Test the raw string rather than the parsed fragment: urlsplit() reports
+        # fragment == "" both for a URI with no fragment and for one ending in a
+        # bare "#", but the latter carries an (empty) fragment component that
+        # RFC 6749 section 3.1.2 forbids just the same.  Catching it here means a
+        # misconfiguration is reported at save time, rather than being stored and
+        # then never matching -- redirect_to_uri_allowed() denies any "#".
+        if "#" in value and not self.allow_fragments:
             raise ValidationError(
                 "%(name)s URI validation error. %(cause)s: %(value)s",
                 params={"name": self.name, "value": value, "cause": "fragment not allowed"},

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -61,7 +61,11 @@ class AllowedURIValidator(URIValidator):
                 params={"name": self.name, "value": value, "cause": "invalid_scheme"},
             )
 
-        if query and not self.allow_query:
+        # As with the fragment below, urlsplit() reports query == "" both for a URI
+        # with no query and for one ending in a bare "?", so the raw string is what
+        # distinguishes them.  Only a "?" ahead of any "#" opens a query component;
+        # one inside a fragment belongs to the fragment.
+        if "?" in value.partition("#")[0] and not self.allow_query:
             raise ValidationError(
                 "%(name)s URI validation error. %(cause)s: %(value)s",
                 params={"name": self.name, "value": value, "cause": "query string not allowed"},

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -55,7 +55,9 @@ class BaseTest(TestCase):
         cls.application = Application.objects.create(
             name="Test Application",
             redirect_uris=(
-                "http://localhost http://example.com http://example.org custom-scheme://example.com"
+                "http://localhost http://example.com http://example.org custom-scheme://example.com "
+                "http://example.com?foo=bar http://example.org?foo=bar "
+                "http://example.com?bar=baz&foo=bar"
             ),
             user=cls.dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
@@ -337,6 +339,30 @@ class TestAuthorizationCodeView(BaseTest):
 
         response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
         self.assertEqual(response.status_code, 400)
+
+    def test_pre_auth_rejects_unregistered_query_parameters(self):
+        """
+        Test error when the redirect_uri carries query parameters that were not
+        registered.  RFC 9700 section 2.1 requires exact matching; accepting a
+        superset would let an attacker append parameters to an otherwise
+        legitimate redirect URI and have the authorization server reflect them
+        into the client's callback alongside the code (RFC 9700 section 4.1).
+        """
+        self.client.login(username="test_user", password="123456")
+
+        query_data = {
+            "client_id": self.application.client_id,
+            "response_type": "code",
+            "redirect_uri": "http://example.com?next=http://evil.example",
+        }
+
+        response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
+        self.assertEqual(response.status_code, 400)
+
+        # ...and the registered query on its own is still accepted and retained.
+        query_data["redirect_uri"] = "http://example.com?foo=bar"
+        response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
+        self.assertEqual(response.status_code, 200)
 
     def test_pre_auth_wrong_response_type(self):
         """
@@ -2078,7 +2104,7 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         Tests code exchange succeed when redirect uri matches the one used for code request
         """
         self.client.login(username="test_user", password="123456")
-        self.application.redirect_uris = "http://localhost http://example.com?foo=bar"
+        self.application.redirect_uris = "http://localhost http://example.com?bar=baz&foo=bar"
         self.application.save()
 
         # retrieve a valid authorization code
@@ -2154,7 +2180,7 @@ class TestOIDCAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         Tests code exchange succeed when redirect uri matches the one used for code request
         """
         self.client.login(username="test_user", password="123456")
-        self.application.redirect_uris = "http://localhost http://example.com?foo=bar"
+        self.application.redirect_uris = "http://localhost http://example.com?bar=baz&foo=bar"
         self.application.save()
 
         # retrieve a valid authorization code

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -59,7 +59,9 @@ class BaseTest(TestCase):
         cls.application = Application(
             name="Hybrid Test Application",
             redirect_uris=(
-                "http://localhost http://example.com http://example.org custom-scheme://example.com"
+                "http://localhost http://example.com http://example.org custom-scheme://example.com "
+                "http://example.com?foo=bar http://example.org?foo=bar "
+                "http://example.com?bar=baz&foo=bar"
             ),
             user=cls.hy_dev_user,
             client_type=Application.CLIENT_CONFIDENTIAL,
@@ -1107,7 +1109,7 @@ class TestHybridTokenView(BaseTest):
         Tests code exchange succeed when redirect uri matches the one used for code request
         """
         self.client.login(username="hy_test_user", password="123456")
-        self.application.redirect_uris = "http://localhost http://example.com?foo=bar"
+        self.application.redirect_uris = "http://localhost http://example.com?bar=baz&foo=bar"
         self.application.save()
 
         # retrieve a valid authorization code
@@ -1144,7 +1146,7 @@ class TestHybridTokenView(BaseTest):
         Tests code exchange succeed when redirect uri matches the one used for code request
         """
         self.client.login(username="hy_test_user", password="123456")
-        self.application.redirect_uris = "http://localhost http://example.com?foo=bar"
+        self.application.redirect_uris = "http://localhost http://example.com?bar=baz&foo=bar"
         self.application.save()
 
         # retrieve a valid authorization code

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -35,7 +35,7 @@ class BaseTest(TestCase):
 
         cls.application = Application.objects.create(
             name="Test Implicit Application",
-            redirect_uris="http://localhost http://example.com http://example.org",
+            redirect_uris="http://localhost http://example.com http://example.org http://example.com?foo=bar",
             user=cls.dev_user,
             client_type=Application.CLIENT_PUBLIC,
             authorization_grant_type=Application.GRANT_IMPLICIT,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1273,3 +1273,40 @@ invalid_localhost_loopback_params = [
 def test_localhost_loopback_redirect_rejected_when_enabled(uri, allowed_uri, oauth2_settings):
     oauth2_settings.ALLOW_LOCALHOST_LOOPBACK = True
     assert not redirect_to_uri_allowed(uri, allowed_uri)
+
+
+# RFC 9700 §2.1 requires exact matching of redirect URIs (see also OpenID Connect
+# Core §3.1.2.1, mandating RFC 3986 §6.2.1 Simple String Comparison).
+exact_redirect_match_params = [
+    # Identical URIs match, with and without a registered query.
+    ("https://example.com/cb", ["https://example.com/cb"], True),
+    ("https://example.com/cb?a=1", ["https://example.com/cb?a=1"], True),
+    ("https://example.com/cb?a=1&b=2", ["https://example.com/cb?a=1&b=2"], True),
+    # Query parameters that were never registered must not be accepted: an
+    # attacker could otherwise append parameters to an otherwise-legitimate
+    # redirect URI and have them reflected into the client's callback alongside
+    # the authorization code (RFC 9700 §4.1).
+    ("https://example.com/cb?evil=1", ["https://example.com/cb"], False),
+    ("https://example.com/cb?a=1&evil=1", ["https://example.com/cb?a=1"], False),
+    # A registered parameter that is missing from the request is also a mismatch.
+    ("https://example.com/cb", ["https://example.com/cb?a=1"], False),
+    # Reordered parameters are no longer accepted; matching is by string.
+    ("https://example.com/cb?b=2&a=1", ["https://example.com/cb?a=1&b=2"], False),
+    # RFC 6749 §3.1.2: the endpoint URI MUST NOT include a fragment component.
+    # urlparse() splits the fragment off, so this used to match.
+    ("https://example.com/cb#x", ["https://example.com/cb"], False),
+    ("https://example.com/cb?a=1#x", ["https://example.com/cb?a=1"], False),
+]
+
+
+@pytest.mark.parametrize("uri, allowed_uris, expected", exact_redirect_match_params)
+def test_redirect_to_uri_allowed_matches_exactly(uri, allowed_uris, expected):
+    assert redirect_to_uri_allowed(uri, allowed_uris) is expected
+
+
+def test_redirect_to_uri_allowed_loopback_port_exemption_survives_exact_matching():
+    # RFC 9700 §2.1 carves out "port numbers in localhost redirection URIs of
+    # native apps"; RFC 8252 §7.3 requires it.  Exact matching must not undo it.
+    assert redirect_to_uri_allowed("http://127.0.0.1:49152/cb", ["http://127.0.0.1/cb"])
+    # ...but the exemption is only for the port, not for the query.
+    assert not redirect_to_uri_allowed("http://127.0.0.1:49152/cb?evil=1", ["http://127.0.0.1/cb"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1293,9 +1293,28 @@ exact_redirect_match_params = [
     # Reordered parameters are no longer accepted; matching is by string.
     ("https://example.com/cb?b=2&a=1", ["https://example.com/cb?a=1&b=2"], False),
     # RFC 6749 §3.1.2: the endpoint URI MUST NOT include a fragment component.
-    # urlparse() splits the fragment off, so this used to match.
+    # urlparse() splits the fragment off, so these used to match.
     ("https://example.com/cb#x", ["https://example.com/cb"], False),
     ("https://example.com/cb?a=1#x", ["https://example.com/cb?a=1"], False),
+    # A bare "#" is an empty fragment component, not the absence of one; .fragment
+    # is "" for both, so the raw string is what has to be tested.
+    ("https://example.com/cb#", ["https://example.com/cb"], False),
+    # ...but a percent-encoded %23 is not a fragment delimiter.
+    ("https://example.com/cb%23", ["https://example.com/cb%23"], True),
+    # A registered URI carrying a fragment cannot authorize anything, since every
+    # request form that would match it is rejected above.
+    ("https://example.com/cb", ["https://example.com/cb#frag"], False),
+    # urlparse() peels ";params" off the last path segment into a separate
+    # attribute, so comparing .path alone let these smuggle data to the callback.
+    ("https://example.com/cb;evil=1", ["https://example.com/cb"], False),
+    ("https://example.com/cb;evil=1?a=1", ["https://example.com/cb?a=1"], False),
+    # ...and a registered URI that genuinely carries parameters still matches.
+    ("https://example.com/cb;a=1", ["https://example.com/cb;a=1"], True),
+    # Credentials are not part of a registered callback: only .hostname was
+    # compared, so userinfo rode along unnoticed.
+    ("https://evil@example.com/cb", ["https://example.com/cb"], False),
+    ("https://user:pw@example.com/cb", ["https://example.com/cb"], False),
+    ("https://example.com/cb", ["https://evil@example.com/cb"], False),
 ]
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1290,6 +1290,13 @@ exact_redirect_match_params = [
     ("https://example.com/cb?a=1&evil=1", ["https://example.com/cb?a=1"], False),
     # A registered parameter that is missing from the request is also a mismatch.
     ("https://example.com/cb", ["https://example.com/cb?a=1"], False),
+    # A bare trailing "?" is an empty query component, not the absence of one;
+    # .query is "" for both, so the delimiter's presence is what distinguishes them.
+    ("https://example.com/cb?", ["https://example.com/cb"], False),
+    ("https://example.com/cb", ["https://example.com/cb?"], False),
+    ("https://example.com/cb?", ["https://example.com/cb?"], True),
+    # ...but a percent-encoded %3F is not a query delimiter.
+    ("https://example.com/cb%3F", ["https://example.com/cb%3F"], True),
     # Reordered parameters are no longer accepted; matching is by string.
     ("https://example.com/cb?b=2&a=1", ["https://example.com/cb?a=1&b=2"], False),
     # RFC 6749 §3.1.2: the endpoint URI MUST NOT include a fragment component.

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -88,6 +88,25 @@ class TestAllowedURIValidator(TestCase):
         permissive("https://example.com/cb#")
         permissive("https://example.com/cb#frag")
 
+    def test_bare_query_delimiter_rejected(self):
+        # Same shape as the bare "#" above: urlsplit() reports query == "" for a
+        # URI ending in "?", so it slipped past the allow_query=False gate that
+        # allowed_origins relies on.
+        validator = AllowedURIValidator(["https"], "test")
+        for uri in ["https://example.com?", "https://example.com?a=1"]:
+            with self.assertRaises(ValidationError):
+                validator(uri)
+
+        # A "?" inside a fragment belongs to the fragment, not to a query
+        # component, so it is the fragment rule that rejects this one.
+        fragments_ok = AllowedURIValidator(["https"], "test", allow_fragments=True)
+        fragments_ok("https://example.com#a?b")
+
+        # ...and where queries are allowed, both forms still pass.
+        permissive = AllowedURIValidator(["https"], "test", allow_query=True)
+        permissive("https://example.com?")
+        permissive("https://example.com?a=1")
+
     def test_allow_paths_invalid_urls(self):
         validator = AllowedURIValidator(["https", "myapp"], "test", allow_path=True)
         bad_uris = [

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -69,6 +69,25 @@ class TestAllowedURIValidator(TestCase):
             # Check ValidationError not thrown
             validator(uri)
 
+    def test_bare_fragment_delimiter_rejected(self):
+        # A trailing "#" is an empty fragment component, which RFC 6749 §3.1.2
+        # forbids just as much as a populated one. urlsplit() reports fragment ==
+        # "" for it, so the raw string is what has to be checked -- otherwise it
+        # is stored and then never matches, since redirect_to_uri_allowed()
+        # denies any URI containing "#".
+        validator = AllowedURIValidator(["https"], "test", allow_path=True)
+        for uri in ["https://example.com/cb#", "https://example.com/cb#frag"]:
+            with self.assertRaises(ValidationError):
+                validator(uri)
+
+        # A percent-encoded %23 is not a fragment delimiter and stays valid.
+        validator("https://example.com/cb%23")
+
+        # ...and where fragments are allowed, both forms still pass.
+        permissive = AllowedURIValidator(["https"], "test", allow_path=True, allow_fragments=True)
+        permissive("https://example.com/cb#")
+        permissive("https://example.com/cb#frag")
+
     def test_allow_paths_invalid_urls(self):
         validator = AllowedURIValidator(["https", "myapp"], "test", allow_path=True)
         bad_uris = [

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -97,8 +97,9 @@ class TestAllowedURIValidator(TestCase):
             with self.assertRaises(ValidationError):
                 validator(uri)
 
-        # A "?" inside a fragment belongs to the fragment, not to a query
-        # component, so it is the fragment rule that rejects this one.
+        # A "?" inside a fragment belongs to the fragment and does not open a
+        # query component, so it must not trip the allow_query=False gate. With
+        # fragments permitted there is nothing left to reject, and the URI passes.
         fragments_ok = AllowedURIValidator(["https"], "test", allow_fragments=True)
         fragments_ok("https://example.com#a?b")
 


### PR DESCRIPTION
Fixes #

## Description of the Change

This PR implements exact redirect URI matching as required by RFC 9700 §2.1 and OpenID Connect Core §3.1.2.1. Previously, the redirect URI validation had two security issues:

1. **Query parameter subset matching**: The code accepted redirect URIs with additional query parameters beyond those registered. An attacker could append parameters to a legitimate `redirect_uri` and have them reflected into the client's callback alongside the authorization code (RFC 9700 §4.1 redirect-URI manipulation attack).

2. **Fragment acceptance**: The code ignored URL fragments during comparison, so `https://example.com/cb#x` would match a registered `https://example.com/cb`. RFC 6749 §3.1.2 explicitly prohibits fragments in endpoint URIs.

### Changes Made

- **oauth2_provider/models.py**: Modified `redirect_to_uri_allowed()` to:
  - Reject any redirect URI containing a fragment component
  - Require exact string matching of query parameters (not subset matching)
  - Preserve existing behavior for case-insensitive scheme/host comparison and loopback port exemption

- **Tests**: Added comprehensive test coverage:
  - `test_redirect_to_uri_allowed_matches_exactly()`: Parametrized tests covering exact matching requirements
  - `test_redirect_to_uri_allowed_loopback_port_exemption_survives_exact_matching()`: Ensures loopback exemption still works with exact matching
  - `test_pre_auth_rejects_unregistered_query_parameters()`: Integration test for authorization flow

- **Documentation**: Updated `docs/security.rst` to clarify exact matching requirements and recommend using the `state` parameter for per-request data

- **CHANGELOG.md**: Added security section documenting the changes and upgrade notes

### Upgrade Notes

Applications whose registered `redirect_uris` contain no query parameters are unaffected. Clients that pass per-request data through the `redirect_uri` query string must now:
- Register the complete URI including all query parameters in the exact order, OR
- Move per-request data into the `state` parameter (the recommended approach)

## Checklist

- [x] PR only contains one change (exact redirect URI matching)
- [x] unit-test added (parametrized tests + integration test)
- [x] documentation updated (security.rst)
- [x] `CHANGELOG.md` updated
- [ ] author name in `AUTHORS` (if applicable)
- [ ] tests/app/idp updated (not applicable - no new features to demonstrate)
- [ ] tests/app/rp updated (not applicable - no new features to demonstrate)

https://claude.ai/code/session_01FRo9eX3n3Zcf7qxxbebWeM