### PR TITLE
Support RFC 8252 private-use URI scheme redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `True` (the `id_token_hint` is a previously issued token per OIDC RP-Initiated Logout)
   and how to harden it.
 ### Fixed
+* #1796 Redirect URIs using an RFC 8252 §7.1 private-use URI scheme can now be registered.
+  Such a scheme has no naming authority, so only a single slash follows it
+  (`com.example.app:/oauth2redirect`), but `Application.clean()` reassembled every URI with
+  `://` before validating and rejected the result with "Enter a valid URL." — leaving native
+  apps no way to register the form the RFC prescribes and their clients actually send. The
+  double-slash variant was not a workaround: the two spellings parse to different hostnames
+  and produce `redirect_uri_mismatch` against each other. Schemes that require an authority
+  (`http`, `https`, `ws`, `wss`, `ftp`) must still include a host, and the redundant
+  `com.example.app:///oauth2redirect` and rootless `com.example.app:oauth2redirect` spellings
+  are rejected so that each callback has one canonical registration (RFC 9700 §2.1).
+  **Upgrade note:** the rootless spelling was previously accepted, but the same reassembly
+  rewrote it to `com.example.app://oauth2redirect` — registering `oauth2redirect` as a
+  *hostname*, which no client matches. It is now rejected at registration instead of being
+  silently reinterpreted; re-register any such URI in the single-slash form.
+* #1796 `redirect_to_uri_allowed()` no longer raises `AttributeError` when
+  `ALLOW_URI_WILDCARDS` is enabled and a redirect URI has no hostname, as is the case for
+  private-use URI scheme redirects.
 * #746 `REFRESH_TOKEN_EXPIRE_SECONDS` is now enforced when a refresh token is presented,
   not only by the `cleartokens` (`clear_expired`) cleanup job. Previously a refresh token
   past its configured lifetime kept working until a cleanup sweep happened to remove it —

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -53,6 +53,14 @@ assigned ports.
 Note that you may override ``Application.get_allowed_schemes()`` to set this on
 a per-application basis.
 
+Native apps using an RFC 8252 §7.1 private-use URI scheme should add that scheme here
+(e.g. ``["https", "com.example.app"]``) and register the redirect URI in the single-slash
+form the RFC prescribes, ``com.example.app:/oauth2redirect``. A private-use scheme has no
+naming authority, so the single-slash and double-slash spellings are *different* URIs and
+are not interchangeable at request time. The redundant ``com.example.app:///oauth2redirect``
+and the rootless ``com.example.app:oauth2redirect`` are rejected. Schemes that require an
+authority (``http``, ``https``, ``ws``, ``wss``, ``ftp``) must still include a host.
+
 ALLOW_URI_WILDCARDS
 ~~~~~~~~~~~~~~~~~~~
 Default: ``False``

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1172,11 +1172,15 @@ def redirect_to_uri_allowed(uri, allowed_uris):
             continue
 
         """ check hostname """
-        if oauth2_settings.ALLOW_URI_WILDCARDS and parsed_allowed_uri.hostname.startswith("*"):
+        # A private-use URI scheme redirect (RFC 8252 §7.1) has no naming
+        # authority, so hostname is None on either side; guard before matching.
+        allowed_hostname = parsed_allowed_uri.hostname
+        uri_hostname = parsed_uri.hostname
+        if oauth2_settings.ALLOW_URI_WILDCARDS and allowed_hostname and allowed_hostname.startswith("*"):
             """ wildcard hostname """
-            if not parsed_uri.hostname.endswith(parsed_allowed_uri.hostname[1:]):
+            if not uri_hostname or not uri_hostname.endswith(allowed_hostname[1:]):
                 continue
-        elif parsed_allowed_uri.hostname != parsed_uri.hostname:
+        elif allowed_hostname != uri_hostname:
             continue
 
         # From RFC 8252 (Section 7.3)

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -17,6 +17,21 @@ class URIValidator(URLValidator):
     path_re = r"(?:[/?#][^\s]*)?"
     regex = re.compile(scheme_re + host_re + port_re + path_re, re.IGNORECASE)
 
+    # RFC 8252 §7.1: a private-use URI scheme redirect has no naming authority
+    # (RFC 3986 §3.2), so exactly one slash follows the scheme component, e.g.
+    # "com.example.app:/oauth2redirect".  Requiring a non-slash after "scheme:/"
+    # also rejects "scheme:", "scheme://" and the redundant "scheme:///path"
+    # spelling; the latter is a valid absolute-URI (an empty authority) but
+    # aliases with the canonical single-slash form under redirect_to_uri_allowed(),
+    # and RFC 9700 §2.1 requires redirect URIs to match by exact string comparison.
+    authorityless_regex = re.compile(r"^[a-z][a-z0-9\.\-\+]*:/(?!/)[^\s]*\Z", re.IGNORECASE)
+
+    # Schemes whose own specifications require an authority component.  A
+    # single-slash URI in one of these is not a private-use scheme redirect:
+    # browsers normalize "https:/example.com" to "https://example.com/", so
+    # accepting it would register something other than what is redirected to.
+    schemes_requiring_authority = frozenset({"http", "https", "ws", "wss", "ftp"})
+
 
 class AllowedURIValidator(URIValidator):
     # TODO: find a way to get these associated with their form fields in place of passing name
@@ -86,6 +101,26 @@ class AllowedURIValidator(URIValidator):
                 "%(name)s URI validation error. %(cause)s: %(value)s",
                 params={"name": self.name, "value": value, "cause": "path not allowed"},
             )
+
+        # A private-use URI scheme redirect (RFC 8252 §7.1) has no authority, so
+        # urlsplit() reports an empty netloc and the "{scheme}://{netloc}{path}"
+        # reassembly below would rebuild "com.example.app:/oauth2redirect" as
+        # "com.example.app:///oauth2redirect".  URIValidator cannot match that:
+        # every alternative in host_re consumes at least one character and the
+        # next one is "/".  Validate the authority-less form here instead — the
+        # scheme is already checked above and there is no host to validate.
+        if not netloc:
+            if scheme in self.schemes_requiring_authority:
+                raise ValidationError(
+                    "%(name)s URI validation error. %(cause)s: %(value)s",
+                    params={"name": self.name, "value": value, "cause": "missing host"},
+                )
+            if not self.authorityless_regex.match(value):
+                raise ValidationError(
+                    "%(name)s URI validation error. %(cause)s: %(value)s",
+                    params={"name": self.name, "value": value, "cause": "invalid URI"},
+                )
+            return
 
         if self.allow_hostname_wildcard and "*" in netloc:
             domain_parts = netloc.split(".")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1336,3 +1336,28 @@ def test_redirect_to_uri_allowed_loopback_port_exemption_survives_exact_matching
     assert redirect_to_uri_allowed("http://127.0.0.1:49152/cb", ["http://127.0.0.1/cb"])
     # ...but the exemption is only for the port, not for the query.
     assert not redirect_to_uri_allowed("http://127.0.0.1:49152/cb?evil=1", ["http://127.0.0.1/cb"])
+
+
+def test_private_use_uri_scheme_redirect_allowed():
+    # RFC 8252 §7.1: a private-use URI scheme redirect has no naming authority,
+    # so a single slash follows the scheme and urlparse() reports hostname None.
+    uri = "com.example.app:/oauth2redirect/example-provider"
+    assert redirect_to_uri_allowed(uri, [uri])
+    assert redirect_to_uri_allowed("com.example.app:/oauth2redirect", ["com.example.app:/oauth2redirect"])
+    # The single-slash and double-slash spellings parse to different hostnames
+    # (None vs "oauth2redirect"), so they are not interchangeable.
+    single, double = "com.example.app:/oauth2redirect", "com.example.app://oauth2redirect"
+    assert not redirect_to_uri_allowed(single, [double])
+    assert not redirect_to_uri_allowed(double, [single])
+    # A different path is a different endpoint.
+    assert not redirect_to_uri_allowed("com.example.app:/other", ["com.example.app:/oauth2redirect"])
+
+
+def test_private_use_uri_scheme_redirect_allowed_with_wildcards_enabled(oauth2_settings):
+    # Regression: the wildcard branch used to call .startswith() on the hostname
+    # unguarded, raising AttributeError for authority-less private-use URIs.
+    oauth2_settings.ALLOW_URI_WILDCARDS = True
+    assert redirect_to_uri_allowed("com.example.app:/oauth2redirect", ["com.example.app:/oauth2redirect"])
+    assert not redirect_to_uri_allowed("com.example.app:/oauth2redirect", ["https://*.example.com/cb"])
+    # ...and from the other side: an authority-less request against a wildcard.
+    assert not redirect_to_uri_allowed("https:/oauth2redirect", ["https://*.example.com/cb"])

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -239,3 +239,71 @@ class TestAllowedURIValidator(TestCase):
         for uri in bad_uris:
             with self.assertRaises(ValidationError):
                 validator(uri)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class TestPrivateUseURISchemeValidator(TestCase):
+    """
+    RFC 8252 §7.1 private-use URI scheme redirects have no naming authority
+    (RFC 3986 §3.2), so only a single slash follows the scheme component.
+    """
+
+    def test_valid_private_use_uris(self):
+        validator = AllowedURIValidator(["com.example.app", "myapp"], "test", allow_path=True)
+        good_uris = [
+            # The complete example given in RFC 8252 §7.1.
+            "com.example.app:/oauth2redirect/example-provider",
+            "com.example.app:/oauth2redirect",
+            "com.example.app:/",
+            "myapp:/callback",
+            # urlsplit() lowercases the scheme, so matching is case-insensitive.
+            "COM.EXAMPLE.APP:/oauth2redirect",
+            # The double-slash spelling remains valid; it is simply a different
+            # URI, parsing to a hostname rather than to no authority at all.
+            "com.example.app://oauth2redirect",
+        ]
+        for uri in good_uris:
+            # Check ValidationError not thrown
+            validator(uri)
+
+    def test_valid_private_use_uri_with_query(self):
+        validator = AllowedURIValidator(["com.example.app"], "test", allow_path=True, allow_query=True)
+        validator("com.example.app:/oauth2redirect?state=xyz")
+
+    def test_invalid_private_use_uris(self):
+        validator = AllowedURIValidator(["com.example.app", "myapp"], "test", allow_path=True)
+        bad_uris = [
+            # No callback target at all.
+            "com.example.app:",
+            "com.example.app://",
+            # Valid absolute-URIs per RFC 3986 §4.3, but rejected as
+            # non-canonical: "scheme:///path" aliases with the single-slash form
+            # under redirect_to_uri_allowed(), and RFC 9700 §2.1 requires exact
+            # string matching.  "scheme:path" (path-rootless) is not the shape
+            # RFC 8252 §7.1 prescribes.
+            "com.example.app:///oauth2redirect",
+            "com.example.app:oauth2redirect",
+            # Whitespace is never part of a redirect URI.
+            "com.example.app:/oauth2 redirect",
+            # Scheme still has to be allowed.
+            "com.other.app:/oauth2redirect",
+        ]
+        for uri in bad_uris:
+            with self.assertRaises(ValidationError):
+                validator(uri)
+
+    def test_schemes_requiring_an_authority_still_require_a_host(self):
+        # "https:/example.com" is a valid absolute-URI, but browsers normalize it
+        # to "https://example.com/", so registering it would not describe what is
+        # actually redirected to.  Only non-special schemes may omit the authority.
+        validator = AllowedURIValidator(["https", "http", "ws", "wss", "ftp"], "test", allow_path=True)
+        for uri in ["https:/example.com", "http:/example.com", "ws:/x", "wss:/x", "ftp:/x"]:
+            with self.assertRaises(ValidationError):
+                validator(uri)
+
+    def test_private_use_uri_rejected_when_paths_are_not_allowed(self):
+        # allowed_origins uses allow_path=False, so a private-use redirect URI is
+        # still rejected there — an origin has no path and needs a host.
+        validator = AllowedURIValidator(["com.example.app"], "test")
+        with self.assertRaises(ValidationError):
+            validator("com.example.app:/oauth2redirect")


### PR DESCRIPTION
Fixes #1796

## Description of the Change

This PR adds support for RFC 8252 §7.1 private-use URI scheme redirects in native applications. Private-use URI schemes (e.g., `com.example.app:/oauth2redirect`) have no naming authority, so they use a single slash after the scheme rather than the double-slash (`://`) used by schemes with authority.

### Key Changes

**oauth2_provider/validators.py:**
- Added `authorityless_regex` to validate private-use URI schemes that have no authority component
- Added `schemes_requiring_authority` frozenset to identify schemes that must have a host (http, https, ws, wss, ftp)
- Modified `AllowedURIValidator.__call__()` to handle authority-less URIs by validating them separately before the standard hostname validation logic
- Schemes requiring authority are rejected if they lack a host, preventing silent reinterpretation

**oauth2_provider/models.py:**
- Fixed `redirect_to_uri_allowed()` to guard against `AttributeError` when `ALLOW_URI_WILDCARDS` is enabled and a redirect URI has no hostname
- Added null checks before calling `.startswith()` and `.endswith()` on hostnames

**tests/test_validators.py:**
- Added comprehensive test suite `TestPrivateUseURISchemeValidator` covering:
  - Valid private-use URIs in single-slash form
  - Valid URIs with query parameters
  - Invalid URIs (missing callback, triple-slash, rootless, whitespace, disallowed schemes)
  - Schemes requiring authority still require a host
  - Private-use URIs rejected when paths are not allowed

**tests/test_models.py:**
- Added tests for `redirect_to_uri_allowed()` with private-use URI schemes
- Added regression test for wildcard matching with authority-less URIs

**docs/settings.rst:**
- Added documentation explaining how to register private-use URI schemes and the single-slash form requirement

**CHANGELOG.md:**
- Documented the fix with upgrade notes about the rootless spelling being rejected

### Behavior Changes

- Private-use URI schemes can now be registered in the canonical single-slash form
- The redundant triple-slash (`com.example.app:///oauth2redirect`) and rootless (`com.example.app:oauth2redirect`) spellings are rejected to ensure one canonical registration per callback
- Single-slash and double-slash spellings are treated as different URIs (they parse to different hostnames)
- Schemes requiring authority (http, https, ws, wss, ftp) must still include a host

## Checklist

- [x] PR only contains one change (single feature: private-use URI scheme support)
- [x] unit-test added (comprehensive test suite in test_validators.py and test_models.py)
- [x] documentation updated (docs/settings.rst)
- [x] `CHANGELOG.md` updated
- [ ] author name in `AUTHORS` (not applicable to this diff)
- [ ] tests/app/idp updated (not applicable - this is a core feature, not an IDP feature)
- [ ] tests/app/rp updated (not applicable - this is a core feature, not an RP feature)

https://claude.ai/code/session_01FRo9eX3n3Zcf7qxxbebWeM