### PR TITLE
fix(oidc): make RP-initiated logout idempotent for orphaned id_token_hint

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -149,3 +149,4 @@ Emmanuel Angelo
 Apoorv Darshan
 Wojtek
 Rafa Audibert
+ArockiaRajamanickam

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `REQUIRE_PUSHED_AUTHORIZATION_REQUESTS` or per client via the application's
   `require_pushed_authorization_requests` field, and the endpoint is advertised in the RFC 8414
   metadata document. See `docs/pushed_authorization_requests.rst`.
+### Changed
+* #1287 RP-Initiated Logout no longer rejects an `id_token_hint` whose ID Token is no longer stored.
+  Such a request previously returned HTTP 400; it now takes the prompt-or-logout path, so deployments
+  relying on the 400 will see 200 (prompt) or 302 (redirect) instead. Verification itself is unchanged:
+  a hint that cannot be verified is still rejected, and a `client_id` supplied alongside it is still
+  required to match the RP the ID Token was issued for.
+* #1287 `RPInitiatedLogoutView.validate_logout_request_user()` now returns an `(id_token, claims)`
+  tuple rather than the `IDToken` alone, and `RPInitiatedLogoutView.get_request_application()` takes a
+  third `claims` argument. Subclasses overriding either method must be updated.
+
 ### Fixed
+* #1287 RP-Initiated Logout is now idempotent, as the specification requires. Once one RP logged an
+  End-User out, `do_logout()` deleted that user's ID Tokens, so every other RP's `id_token_hint`
+  referred to an IDToken that no longer existed and their logout requests failed with HTTP 400 and
+  never reached their `post_logout_redirect_uri`. A verified hint whose IDToken is gone is now
+  distinguished from one that could not be verified, and the requesting RP is recovered from the
+  token's verified `aud` claim so that the `client_id` and `post_logout_redirect_uri` checks still
+  apply.
 * #1816 `RefreshToken.token_checksum` is now unique. `AbstractRefreshToken.Meta` declared
   `unique_together = ("token_checksum", "revoked")`, which enforced nothing: live rows have
   `revoked IS NULL` and every supported backend treats NULLs as distinct in a unique index,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 * #1287 RP-Initiated Logout no longer rejects an `id_token_hint` whose ID Token is no longer stored.
   Such a request previously returned HTTP 400; it now takes the prompt-or-logout path, so deployments
-  relying on the 400 will see 200 (prompt) or 302 (redirect) instead. Verification itself is unchanged:
-  a hint that cannot be verified is still rejected, and a `client_id` supplied alongside it is still
-  required to match the RP the ID Token was issued for.
+  relying on the 400 will see 200 (prompt) or 302 (redirect) instead. "No longer stored" covers an ID
+  Token deliberately revoked (`IDToken.revoke()` deletes the row) and one that never existed, not only
+  one another RP's logout deleted. Verification itself is unchanged: a hint that cannot be verified is
+  still rejected, and a `client_id` supplied alongside it is still required to match the RP the ID
+  Token was issued for.
+* #1287 Orphaned-`id_token_hint` requests that are still rejected now report the error they actually
+  hit rather than a blanket invalid-ID-Token error, because the checks past that point are now
+  reached. A mismatched `client_id` reports "Mismatch between the Client ID of the ID Token and the
+  Client ID that was provided" and a `post_logout_redirect_uri` that is not the requesting RP's
+  reports "Invalid post logout redirect URI", both still `invalid_request` with HTTP 400; declining
+  the logout confirmation form now reports `logout_denied` rather than `invalid_request`. Deployments
+  that branch on the `error` code or match on the description -- in a custom `error_response()`, an
+  overridden `logout_confirm.html`, or log-based alerting -- should check those paths.
 * #1287 `RPInitiatedLogoutView.validate_logout_request_user()` now returns an `(id_token, claims)`
   tuple rather than the `IDToken` alone, and `RPInitiatedLogoutView.get_request_application()` takes a
   third `claims` argument. Subclasses overriding either method must be updated.

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -170,10 +170,12 @@ This feature has to be enabled separately as it is an extension to the core stan
 
 Logout requests are idempotent, as the specification requires. An ``id_token_hint`` that verifies but
 whose ID Token is no longer stored is therefore not treated as an error: this is the case once another
-RP has already logged the same End-User out, since that deletes their ID Tokens. Such a request is
-handled as though no ``id_token_hint`` had been supplied, so the End-User is prompted if they still
-have a session with the OP. An ``id_token_hint`` that cannot be verified is still rejected, and a
-``client_id`` given alongside it is still required to match the RP the ID Token was issued for.
+RP has already logged the same End-User out, since that deletes their ID Tokens. The End-User is
+prompted if they still have a session with the OP, just as they are for a request carrying no
+``id_token_hint`` at all. The requesting RP is still identified, from the ID Token's ``aud`` claim, so
+a ``post_logout_redirect_uri`` is still validated against it. An ``id_token_hint`` that cannot be
+verified is still rejected, and a ``client_id`` given alongside it is still required to match the RP
+the ID Token was issued for.
 
 
 Setting up OIDC enabled clients

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -168,6 +168,13 @@ This feature has to be enabled separately as it is an extension to the core stan
        # ... any other settings you want
    }
 
+Logout requests are idempotent, as the specification requires. An ``id_token_hint`` that verifies but
+whose ID Token is no longer stored is therefore not treated as an error: this is the case once another
+RP has already logged the same End-User out, since that deletes their ID Tokens. Such a request is
+handled as though no ``id_token_hint`` had been supplied, so the End-User is prompted if they still
+have a session with the OP. An ``id_token_hint`` that cannot be verified is still rejected, and a
+``client_id`` given alongside it is still required to match the RP the ID Token was issued for.
+
 
 Setting up OIDC enabled clients
 ===============================

--- a/docs/oidc.rst
+++ b/docs/oidc.rst
@@ -170,7 +170,8 @@ This feature has to be enabled separately as it is an extension to the core stan
 
 Logout requests are idempotent, as the specification requires. An ``id_token_hint`` that verifies but
 whose ID Token is no longer stored is therefore not treated as an error: this is the case once another
-RP has already logged the same End-User out, since that deletes their ID Tokens. The End-User is
+RP has already logged the same End-User out, since that deletes their ID Tokens, and equally for an ID
+Token that was deliberately revoked or that this OP never issued. The End-User is
 prompted if they still have a session with the OP, just as they are for a request carrying no
 ``id_token_hint`` at all. The requesting RP is still identified, from the ID Token's ``aud`` claim, so
 a ``post_logout_redirect_uri`` is still validated against it. An ``id_token_hint`` that cannot be

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -189,16 +189,34 @@ def _load_id_token(token):
             check_claims = None
         jwt_token = jwt.JWT(key=key, jwt=token, check_claims=check_claims)
         claims = json.loads(jwt_token.claims)
-
-        # Assumption: the `sub` claim and `user` property of the corresponding IDToken Object point to the
-        # same user.
-        # To verify that the IDToken was intended for the user it is therefore sufficient to check the `user`
-        # attribute on the IDToken Object later on.
-
-        return IDToken.objects.get(jti=claims["jti"]), claims
-
-    except (JWException, JWTExpired, IDToken.DoesNotExist):
+    except (JWException, JWTExpired):
+        # The token could not be verified.
         return None, None
+
+    # Assumption: the `sub` claim and `user` property of the corresponding IDToken Object point to the
+    # same user.
+    # To verify that the IDToken was intended for the user it is therefore sufficient to check the `user`
+    # attribute on the IDToken Object later on.
+
+    try:
+        return IDToken.objects.get(jti=claims["jti"]), claims
+    except IDToken.DoesNotExist:
+        # The token was verified but is no longer stored, which means the End-User is not logged in with
+        # the OP at the requesting RP. This happens once another RP has logged the same user out, as
+        # `do_logout()` deletes their ID Tokens. The verified claims are still returned so that callers
+        # can tell this apart from a token that could not be verified at all.
+        return None, claims
+
+
+def _get_application_from_claims(claims):
+    """
+    Resolves the Application an ID Token was issued for from its `aud` claim.
+
+    This is used when the corresponding IDToken is no longer stored. `_load_id_token()` has already
+    verified the token's signature with this Application's key, so `aud` can be relied upon.
+    """
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    return validator._get_client_by_audience(claims.get("aud", []))
 
 
 def _validate_claims(request, claims):
@@ -324,29 +342,42 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
     def validate_logout_request_user(self, id_token_hint, client_id):
         """
         Validate the an OIDC RP-Initiated Logout Request user
+
+        `(id_token, claims)` is returned. `claims` are the verified claims of `id_token_hint`, if one was
+        given. `id_token` is the stored IDToken that `id_token_hint` refers to; it is `None` when that
+        IDToken is no longer stored, meaning the End-User is not logged in with the OP at that RP.
         """
 
         if not id_token_hint:
-            return
+            return None, None
 
         # Only basic validation has been done on the IDToken at this point.
         id_token, claims = _load_id_token(id_token_hint)
 
-        if not id_token or not _validate_claims(self.request, claims):
+        if not claims or not _validate_claims(self.request, claims):
             raise InvalidIDTokenError()
 
         # If both id_token_hint and client_id are given it must be verified that they match.
         if client_id:
-            if id_token.application.client_id != client_id:
+            # When the IDToken is no longer stored, the requesting RP is recovered from the verified
+            # `aud` claim so that this check is still enforced. Not being able to resolve it counts as
+            # a mismatch.
+            application = id_token.application if id_token else _get_application_from_claims(claims)
+            if application is None or application.client_id != client_id:
                 raise ClientIdMissmatch()
 
-        return id_token
+        return id_token, claims
 
-    def get_request_application(self, id_token, client_id):
+    def get_request_application(self, id_token, client_id, claims=None):
         if client_id:
             return get_application_model().objects.get(client_id=client_id)
         if id_token:
             return id_token.application
+        if claims:
+            # `id_token_hint` was verified but its IDToken is no longer stored. The requesting RP is
+            # recovered from the verified `aud` claim so that `post_logout_redirect_uri` is still
+            # validated against the Application that asked for the logout.
+            return _get_application_from_claims(claims)
 
     def validate_logout_request(self, id_token_hint, client_id, post_logout_redirect_uri):
         """
@@ -360,8 +391,8 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
         will be validated against each other.
         """
 
-        id_token = self.validate_logout_request_user(id_token_hint, client_id)
-        application = self.get_request_application(id_token, client_id)
+        id_token, claims = self.validate_logout_request_user(id_token_hint, client_id)
+        application = self.get_request_application(id_token, client_id, claims)
         self.validate_post_logout_redirect_uri(application, post_logout_redirect_uri)
 
         return application, id_token.user if id_token else None

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -197,16 +197,34 @@ def _load_id_token(token):
             check_claims = None
         jwt_token = jwt.JWT(key=key, jwt=token, check_claims=check_claims)
         claims = json.loads(jwt_token.claims)
-
-        # Assumption: the `sub` claim and `user` property of the corresponding IDToken Object point to the
-        # same user.
-        # To verify that the IDToken was intended for the user it is therefore sufficient to check the `user`
-        # attribute on the IDToken Object later on.
-
-        return IDToken.objects.get(jti=claims["jti"]), claims
-
-    except (JWException, JWTExpired, IDToken.DoesNotExist):
+    except (JWException, JWTExpired):
+        # The token could not be verified.
         return None, None
+
+    # Assumption: the `sub` claim and `user` property of the corresponding IDToken Object point to the
+    # same user.
+    # To verify that the IDToken was intended for the user it is therefore sufficient to check the `user`
+    # attribute on the IDToken Object later on.
+
+    try:
+        return IDToken.objects.get(jti=claims["jti"]), claims
+    except IDToken.DoesNotExist:
+        # The token was verified but is no longer stored, which means the End-User is not logged in with
+        # the OP at the requesting RP. This happens once another RP has logged the same user out, as
+        # `do_logout()` deletes their ID Tokens. The verified claims are still returned so that callers
+        # can tell this apart from a token that could not be verified at all.
+        return None, claims
+
+
+def _get_application_from_claims(claims):
+    """
+    Resolves the Application an ID Token was issued for from its `aud` claim.
+
+    This is used when the corresponding IDToken is no longer stored. `_load_id_token()` has already
+    verified the token's signature with this Application's key, so `aud` can be relied upon.
+    """
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    return validator._get_client_by_audience(claims.get("aud", []))
 
 
 def _validate_claims(request, claims):
@@ -332,29 +350,42 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
     def validate_logout_request_user(self, id_token_hint, client_id):
         """
         Validate the an OIDC RP-Initiated Logout Request user
+
+        `(id_token, claims)` is returned. `claims` are the verified claims of `id_token_hint`, if one was
+        given. `id_token` is the stored IDToken that `id_token_hint` refers to; it is `None` when that
+        IDToken is no longer stored, meaning the End-User is not logged in with the OP at that RP.
         """
 
         if not id_token_hint:
-            return
+            return None, None
 
         # Only basic validation has been done on the IDToken at this point.
         id_token, claims = _load_id_token(id_token_hint)
 
-        if not id_token or not _validate_claims(self.request, claims):
+        if not claims or not _validate_claims(self.request, claims):
             raise InvalidIDTokenError()
 
         # If both id_token_hint and client_id are given it must be verified that they match.
         if client_id:
-            if id_token.application.client_id != client_id:
+            # When the IDToken is no longer stored, the requesting RP is recovered from the verified
+            # `aud` claim so that this check is still enforced. Not being able to resolve it counts as
+            # a mismatch.
+            application = id_token.application if id_token else _get_application_from_claims(claims)
+            if application is None or application.client_id != client_id:
                 raise ClientIdMissmatch()
 
-        return id_token
+        return id_token, claims
 
-    def get_request_application(self, id_token, client_id):
+    def get_request_application(self, id_token, client_id, claims=None):
         if client_id:
             return get_application_model().objects.get(client_id=client_id)
         if id_token:
             return id_token.application
+        if claims:
+            # `id_token_hint` was verified but its IDToken is no longer stored. The requesting RP is
+            # recovered from the verified `aud` claim so that `post_logout_redirect_uri` is still
+            # validated against the Application that asked for the logout.
+            return _get_application_from_claims(claims)
 
     def validate_logout_request(self, id_token_hint, client_id, post_logout_redirect_uri):
         """
@@ -368,8 +399,8 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
         will be validated against each other.
         """
 
-        id_token = self.validate_logout_request_user(id_token_hint, client_id)
-        application = self.get_request_application(id_token, client_id)
+        id_token, claims = self.validate_logout_request_user(id_token_hint, client_id)
+        application = self.get_request_application(id_token, client_id, claims)
         self.validate_post_logout_redirect_uri(application, post_logout_redirect_uri)
 
         return application, id_token.user if id_token else None

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -237,10 +237,18 @@ def _get_application_from_claims(claims: dict) -> Application | None:
     """
     Resolves the Application an ID Token was issued for from its `aud` claim.
 
-    This is used when the corresponding IDToken is no longer stored. `aud` can be relied upon because
-    this resolves through the same `_get_client_by_audience()` helper that `_get_key_for_token()`
-    already used to select the key the token's signature was then verified with. The Application
-    returned here is therefore the one that signature was verified against.
+    This is used when the corresponding IDToken is no longer stored.
+
+    `aud` can be relied upon because it is covered by the signature `_load_id_token()` has already
+    verified, and this OP only ever sets it to the issuing client's `client_id`, which is unique. Note
+    that verification alone does not identify the RP: under `RS256` every Application signs with the
+    same OP key, so a signature that verifies for one RS256 Application verifies for all of them. It
+    is `aud` that names the RP, not the key that checked the signature.
+
+    For a deployment that issues a multi-valued `aud`, `_get_client_by_audience()` returns one member
+    of it, and which one is not defined -- it is a `.first()` over an unordered queryset. Such a
+    deployment should override that hook, which exists to be overridden, if it needs a particular
+    member chosen.
     """
     validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
     return validator._get_client_by_audience(claims.get("aud", []))

--- a/oauth2_provider/views/oidc.py
+++ b/oauth2_provider/views/oidc.py
@@ -27,6 +27,7 @@ from ..forms import ConfirmLogoutForm
 from ..http import OAuth2ResponseRedirect
 from ..models import (
     AbstractGrant,
+    AbstractIDToken,
     get_access_token_model,
     get_application_model,
     get_id_token_model,
@@ -166,11 +167,20 @@ class UserInfoView(OIDCOnlyMixin, OAuthLibMixin, View):
         return response
 
 
-def _load_id_token(token):
+def _load_id_token(token: str) -> tuple[AbstractIDToken | None, dict | None]:
     """
     Loads an IDToken given its string representation for use with RP-Initiated Logout.
-    A tuple (IDToken, claims) is returned. Depending on the configuration expired tokens may be loaded.
-    If loading failed (None, None) is returned.
+    Depending on the configuration expired tokens may be loaded.
+
+    A tuple `(IDToken, claims)` is returned, with three possible outcomes:
+
+    - `(IDToken, claims)` when the token verified and its IDToken is still stored.
+    - `(None, claims)` when the token verified but its IDToken is no longer stored, which means the
+      End-User is not logged in with the OP at the requesting RP.
+    - `(None, None)` when the token could not be verified at all.
+
+    Callers must distinguish the last two: the second is not an error, because RP-Initiated Logout
+    requests are idempotent, while the third must be rejected.
     """
     IDToken = get_id_token_model()
     validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
@@ -204,7 +214,14 @@ def _load_id_token(token):
     # Assumption: the `sub` claim and `user` property of the corresponding IDToken Object point to the
     # same user.
     # To verify that the IDToken was intended for the user it is therefore sufficient to check the `user`
-    # attribute on the IDToken Object later on.
+    # attribute on the IDToken Object later on, when there is one.
+    #
+    # When the IDToken is gone there is no such object to check, and the user is deliberately *not*
+    # resolved from the `sub` claim instead. Leaving it unresolved keeps `token_user` as `None`, which
+    # makes `must_prompt()` prompt an End-User who still has an OP session, as the specification
+    # requires when the ID Token does not belong to the current OP session with the RP. Resolving the
+    # user from `sub` here would skip that prompt without any evidence of a session, and so would turn
+    # a leaked stale ID Token into a silent logout.
 
     try:
         return IDToken.objects.get(jti=claims["jti"]), claims
@@ -216,12 +233,14 @@ def _load_id_token(token):
         return None, claims
 
 
-def _get_application_from_claims(claims):
+def _get_application_from_claims(claims: dict) -> Application | None:
     """
     Resolves the Application an ID Token was issued for from its `aud` claim.
 
-    This is used when the corresponding IDToken is no longer stored. `_load_id_token()` has already
-    verified the token's signature with this Application's key, so `aud` can be relied upon.
+    This is used when the corresponding IDToken is no longer stored. `aud` can be relied upon because
+    this resolves through the same `_get_client_by_audience()` helper that `_get_key_for_token()`
+    already used to select the key the token's signature was then verified with. The Application
+    returned here is therefore the one that signature was verified against.
     """
     validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
     return validator._get_client_by_audience(claims.get("aud", []))
@@ -347,13 +366,18 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
         if not application.post_logout_redirect_uri_allowed(post_logout_redirect_uri):
             raise InvalidOIDCRedirectURIError("This client does not have this redirect uri registered.")
 
-    def validate_logout_request_user(self, id_token_hint, client_id):
+    def validate_logout_request_user(
+        self, id_token_hint: str | None, client_id: str | None
+    ) -> tuple[AbstractIDToken | None, dict | None]:
         """
         Validate the an OIDC RP-Initiated Logout Request user
 
         `(id_token, claims)` is returned. `claims` are the verified claims of `id_token_hint`, if one was
         given. `id_token` is the stored IDToken that `id_token_hint` refers to; it is `None` when that
         IDToken is no longer stored, meaning the End-User is not logged in with the OP at that RP.
+
+        Note for subclasses overriding this: it previously returned the `IDToken` alone, and now
+        returns a tuple.
         """
 
         if not id_token_hint:
@@ -376,7 +400,19 @@ class RPInitiatedLogoutView(OIDCLogoutOnlyMixin, FormView):
 
         return id_token, claims
 
-    def get_request_application(self, id_token, client_id, claims=None):
+    def get_request_application(
+        self,
+        id_token: AbstractIDToken | None,
+        client_id: str | None,
+        claims: dict | None = None,
+    ) -> Application | None:
+        """
+        Resolve the Application that is requesting the logout.
+
+        Note for subclasses overriding this: `claims` is new, and is the verified claims of the
+        `id_token_hint`. It is what identifies the requesting RP when `id_token` is `None` because
+        the IDToken is no longer stored.
+        """
         if client_id:
             return get_application_model().objects.get(client_id=client_id)
         if id_token:

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -756,31 +756,73 @@ def test_rp_initiated_logout_get_revoked_id_token(logged_in_client, oidc_tokens,
 
 
 @pytest.mark.django_db(databases="__all__")
-def test_rp_initiated_logout_second_rp_after_logout(logged_in_client, oidc_tokens, rp_settings):
+def test_rp_initiated_logout_second_rp_after_logout(
+    logged_in_client, oidc_tokens, oidc_non_confidential_tokens, rp_settings
+):
     """A second RP's logout request must still be honoured after the first RP logged the user out.
 
     Both RPs hold an ID Token for the same End-User. Once the first RP logs them out, `do_logout()`
     deletes the End-User's ID Tokens, so the second RP's `id_token_hint` refers to an IDToken that is
     gone. That request must not be rejected, and the second RP must still get its redirect.
-
     """
-    id_token_hint = oidc_tokens.id_token
+    assert oidc_tokens.application != oidc_non_confidential_tokens.application
 
-    # First RP logs the End-User out. This deletes their ID Tokens.
+    # First RP logs the End-User out. This deletes all of their ID Tokens.
     rsp = logged_in_client.get(
         reverse("oauth2_provider:rp-initiated-logout"),
-        data={"id_token_hint": id_token_hint, "post_logout_redirect_uri": "http://example.org"},
+        data={
+            "id_token_hint": oidc_tokens.id_token,
+            "post_logout_redirect_uri": "http://example.org",
+        },
     )
     assert rsp.status_code == 302
     assert not is_logged_in(logged_in_client)
 
-    # The second RP now presents its own, now orphaned, id_token_hint.
+    # The second RP now presents its own, now orphaned, id_token_hint. Redirecting to the second RP's
+    # own URI shows that it was validated against the second Application, recovered from `aud`.
     rsp = logged_in_client.get(
         reverse("oauth2_provider:rp-initiated-logout"),
-        data={"id_token_hint": id_token_hint, "post_logout_redirect_uri": "http://example.org"},
+        data={
+            "id_token_hint": oidc_non_confidential_tokens.id_token,
+            "post_logout_redirect_uri": "http://other.org",
+        },
     )
     assert rsp.status_code == 302
-    assert rsp["Location"] == "http://example.org"
+    assert rsp["Location"] == "http://other.org"
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rp_initiated_logout_orphaned_id_token_matching_client_id(logged_in_client, oidc_tokens, rp_settings):
+    """A `client_id` matching an orphaned `id_token_hint` is resolved via the verified `aud` claim."""
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    validator._load_id_token(oidc_tokens.id_token).revoke()
+    rsp = logged_in_client.get(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={
+            "id_token_hint": oidc_tokens.id_token,
+            "client_id": oidc_tokens.application.client_id,
+        },
+    )
+    assert rsp.status_code == 200
+    assert is_logged_in(logged_in_client)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rp_initiated_logout_orphaned_id_token_missmatch_client_id(
+    logged_in_client, oidc_tokens, rp_settings
+):
+    """A `client_id` that does not match an orphaned `id_token_hint` is still a mismatch.
+
+    Dropping the IDToken row must not mean dropping this check.
+    """
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    validator._load_id_token(oidc_tokens.id_token).revoke()
+    rsp = logged_in_client.get(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={"id_token_hint": oidc_tokens.id_token, "client_id": "not-the-right-one"},
+    )
+    assert rsp.status_code == 400
+    assert is_logged_in(logged_in_client)
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -743,13 +743,44 @@ def test_rp_initiated_logout_get_id_token(logged_in_client, oidc_tokens, rp_sett
 
 @pytest.mark.django_db(databases="__all__")
 def test_rp_initiated_logout_get_revoked_id_token(logged_in_client, oidc_tokens, rp_settings):
+    # A revoked ID Token means the End-User is not logged in with the OP at the requesting RP. Logout
+    # requests are idempotent, so this is explicitly not an error; the End-User is prompted instead,
+    # just as they are for a request that carries no `id_token_hint` at all.
     validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
     validator._load_id_token(oidc_tokens.id_token).revoke()
     rsp = logged_in_client.get(
         reverse("oauth2_provider:rp-initiated-logout"), data={"id_token_hint": oidc_tokens.id_token}
     )
-    assert rsp.status_code == 400
+    assert rsp.status_code == 200
     assert is_logged_in(logged_in_client)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rp_initiated_logout_second_rp_after_logout(logged_in_client, oidc_tokens, rp_settings):
+    """A second RP's logout request must still be honoured after the first RP logged the user out.
+
+    Both RPs hold an ID Token for the same End-User. Once the first RP logs them out, `do_logout()`
+    deletes the End-User's ID Tokens, so the second RP's `id_token_hint` refers to an IDToken that is
+    gone. That request must not be rejected, and the second RP must still get its redirect.
+
+    """
+    id_token_hint = oidc_tokens.id_token
+
+    # First RP logs the End-User out. This deletes their ID Tokens.
+    rsp = logged_in_client.get(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={"id_token_hint": id_token_hint, "post_logout_redirect_uri": "http://example.org"},
+    )
+    assert rsp.status_code == 302
+    assert not is_logged_in(logged_in_client)
+
+    # The second RP now presents its own, now orphaned, id_token_hint.
+    rsp = logged_in_client.get(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={"id_token_hint": id_token_hint, "post_logout_redirect_uri": "http://example.org"},
+    )
+    assert rsp.status_code == 302
+    assert rsp["Location"] == "http://example.org"
 
 
 @pytest.mark.django_db(databases="__all__")

--- a/tests/test_oidc_views.py
+++ b/tests/test_oidc_views.py
@@ -778,6 +778,10 @@ def test_rp_initiated_logout_second_rp_after_logout(
     assert rsp.status_code == 302
     assert not is_logged_in(logged_in_client)
 
+    # Pin the condition under test: the second RP's ID Token really is gone, so the request below
+    # cannot quietly take the stored-IDToken path and still satisfy the assertions.
+    assert not get_id_token_model().objects.exists()
+
     # The second RP now presents its own, now orphaned, id_token_hint. Redirecting to the second RP's
     # own URI shows that it was validated against the second Application, recovered from `aud`.
     rsp = logged_in_client.get(
@@ -804,6 +808,33 @@ def test_rp_initiated_logout_orphaned_id_token_matching_client_id(logged_in_clie
         },
     )
     assert rsp.status_code == 200
+    # The prompt, not an error page rendered with some other status.
+    assert "error" not in rsp.context
+    assert is_logged_in(logged_in_client)
+
+
+@pytest.mark.django_db(databases="__all__")
+def test_rp_initiated_logout_orphaned_id_token_other_rps_redirect_uri(
+    logged_in_client, oidc_tokens, oidc_non_confidential_tokens, rp_settings
+):
+    """An orphaned `id_token_hint` may not redirect to an RP other than the one it was issued for.
+
+    The requesting RP is recovered from the verified `aud` claim precisely so that
+    `post_logout_redirect_uri` is still validated against it rather than skipped.
+    """
+    assert oidc_tokens.application != oidc_non_confidential_tokens.application
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    validator._load_id_token(oidc_tokens.id_token).revoke()
+    rsp = logged_in_client.get(
+        reverse("oauth2_provider:rp-initiated-logout"),
+        data={
+            "id_token_hint": oidc_tokens.id_token,
+            # Registered to the *other* application, not to the one this hint names in `aud`.
+            "post_logout_redirect_uri": "http://other.org",
+        },
+    )
+    assert rsp.status_code == 400
+    assert isinstance(rsp.context["error"], InvalidOIDCRedirectURIError)
     assert is_logged_in(logged_in_client)
 
 
@@ -822,6 +853,10 @@ def test_rp_initiated_logout_orphaned_id_token_missmatch_client_id(
         data={"id_token_hint": oidc_tokens.id_token, "client_id": "not-the-right-one"},
     )
     assert rsp.status_code == 400
+    # Assert which check rejected this. Before the orphaned hint was distinguished from an
+    # unverifiable one it also produced a 400, but as an InvalidIDTokenError raised before the
+    # `client_id` comparison was ever reached, so the status code alone cannot tell them apart.
+    assert isinstance(rsp.context["error"], ClientIdMissmatch)
     assert is_logged_in(logged_in_client)
 
 
@@ -984,6 +1019,23 @@ def test_load_id_token_deny_expired(expired_id_token):
     id_token, claims = _load_id_token(expired_id_token)
     assert id_token is None
     assert claims is None
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RP_LOGOUT)
+def test_load_id_token_orphaned(oidc_tokens):
+    """A token that verifies but whose IDToken is gone returns its claims, not `(None, None)`.
+
+    This is the state that lets callers tell "the End-User is not logged in with the OP at this RP",
+    which is not an error, apart from "this token could not be verified", which is.
+    """
+    validator = oauth2_settings.OAUTH2_VALIDATOR_CLASS()
+    validator._load_id_token(oidc_tokens.id_token).revoke()
+
+    id_token, claims = _load_id_token(oidc_tokens.id_token)
+    assert id_token is None
+    assert claims is not None
+    assert claims["aud"] == oidc_tokens.application.client_id
 
 
 @pytest.mark.django_db(databases="__all__")


### PR DESCRIPTION
Fixes #1287.

## The problem

`_load_id_token()` handled `IDToken.DoesNotExist` in the same `except` as `JWException` and `JWTExpired`, so all four cases returned `(None, None)` and `validate_logout_request_user()` raised `InvalidIDTokenError` for all of them. But a verified token whose IDToken row is gone is not the same thing as a token that could not be verified.

That case is reached on any normal multi-RP logout. When the first RP logs the End-User out, `do_logout()` deletes their ID Tokens, so the second RP's `id_token_hint` now points at an IDToken that no longer exists. The second RP gets HTTP 400 and never receives its `post_logout_redirect_uri`.

The spec quoted in the issue is explicit that this must not be an error:

> Note that because RP-Initiated Logout Requests are intended to be idempotent, it is explicitly not an error for an RP to request that a logout be performed when the OP does not consider that the End-User is logged in with the OP at the requesting RP.

## The change

`_load_id_token()` now splits verification from the row lookup and returns `(None, claims)` when the token verified but its IDToken is gone, so callers can distinguish the two. `validate_logout_request_user()` keys the error on `claims` rather than on `id_token`, and returns both.

Nothing about verification is relaxed. A token that fails to deserialize, has no resolvable key, fails signature verification or is expired still returns `(None, None)` and is still rejected. `_validate_claims()` still enforces `iss`.

Two things needed care so that dropping the row does not lose a check:

- **`client_id` matching** previously used `id_token.application.client_id`. With no row, the RP is resolved from the verified `aud` claim via the existing `_get_client_by_audience()`, and failing to resolve it counts as a mismatch. So `client_id` is still validated rather than skipped.
- **`post_logout_redirect_uri`** is validated against the requesting Application. `get_request_application()` takes the claims so it can recover that Application the same way, instead of falling through to `None` and rejecting a legitimate RP's redirect.

`token_user` stays `None` in this case, so `must_prompt()` behaves exactly as it does for a request with no `id_token_hint`: an End-User who still has an OP session is prompted rather than silently logged out.

## Behaviour change

`test_rp_initiated_logout_get_revoked_id_token` asserted the old 400, and now asserts 200. I'd rather flag that plainly than bury it: `IDToken.revoke()` is `self.delete()`, so that test was already exercising exactly this case, and the assertion encoded the behaviour the issue reports as wrong. Callers who relied on a 400 for an orphaned hint will now see the prompt-or-logout path instead.

## Tests

`test_rp_initiated_logout_second_rp_after_logout` is new and reproduces the reported scenario end to end: log out via one RP, then present the now-orphaned hint from a second RP and assert it gets its redirect. On `main` it fails with `assert 400 == 302`; the updated revoked-token test fails with `assert 400 == 200`. Both pass with the change.

Full suite is 1069 passed, 1 skipped. `ruff check` and `ruff format --check` are clean, and the RP-Initiated Logout section of `docs/oidc.rst` now documents the idempotency behaviour and what is still enforced.

I used an AI assistant while working on this. The reproduction, the two failing-without-the-fix runs and the reasoning about which checks had to be preserved are mine.
