### PR TITLE
fix(models): associate Application validation errors with their fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-standard and breaks interoperability with spec-compliant clients. It is scheduled for
   removal in 4.0.
 ### Changed
+* #1343 `Application.clean()` now reports its validation errors per field instead of as
+  non-field errors, and reports all of them at once instead of stopping at the first
+  problem. The application forms (the built-in registration/edit views and the Django
+  admin) render each message next to the offending input — a rejected redirect URI on
+  `redirect_uris`, a non-https CORS origin on `allowed_origins`, an unusable algorithm on
+  `algorithm`, and the HS256 client-secret conflicts on `client_secret` /
+  `hash_client_secret`. `ValidationError.message_dict` is keyed by those field names, so
+  callers of `Application.full_clean()` (including dynamic client registration and CIMD)
+  now surface the field name alongside the message. A custom `ModelForm` that omits one of
+  those fields still gets the message as a non-field error, provided it subclasses
+  `oauth2_provider.forms.ApplicationForm`.
 * The `AccessToken` and `RefreshToken` admins now invalidate tokens through a **"Revoke selected"**
   action instead of raw delete (delete is disabled on those two admins). A raw delete of an access
   token left its bound refresh token behind (`RefreshToken.access_token` is `SET_NULL`) — an orphan

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -65,6 +65,39 @@ That's all, now Django OAuth Toolkit will use your model wherever an Application
     is because of the way Django currently implements swappable models.
     See `issue #90 <https://github.com/django-oauth/django-oauth-toolkit/issues/90>`_ for details.
 
+Validating a custom Application model
+=====================================
+
+``AbstractApplication.clean()`` validates the fields that OAuth correctness depends on --
+the redirect URIs, the CORS origins, and the signing algorithm together with the client
+secret -- and raises a :class:`~django.core.exceptions.ValidationError` **keyed by field
+name**. Django then reports each message on the field it belongs to: the built-in
+application views and the Django admin render it next to the offending input, and
+``ValidationError.message_dict`` carries the field name for anything calling
+``Application.full_clean()`` directly. All problems found are reported together, so a
+single submit shows every error rather than one per attempt.
+
+When you add validation to a swapped application model, follow the same convention and
+raise field-keyed errors from ``clean()``, calling ``super()`` so the built-in checks still
+run::
+
+    from django.core.exceptions import ValidationError
+    from oauth2_provider.models import AbstractApplication
+
+    class MyApplication(AbstractApplication):
+        logo = models.ImageField()
+        agree = models.BooleanField()
+
+        def clean(self):
+            super().clean()
+            if not self.agree:
+                raise ValidationError({"agree": "You must accept the user agreement."})
+
+.. note:: Django raises ``ValueError`` when model validation names a field that the form
+    does not include, which a custom form with a narrower ``Meta.fields`` can trigger.
+    Subclass :class:`oauth2_provider.forms.ApplicationForm` to get those errors folded into
+    non-field errors instead.
+
 .. _extend_token_models:
 
 Extending the token models

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -171,6 +171,13 @@ This template gets passed the following template context variables:
     In the default implementation this template in extended by `application_registration_form.html`_.
     Be sure to provide the same blocks if you are only overriding this template.
 
+.. note::
+    Application validation errors are attached to the field they belong to (for example a
+    rejected redirect URI to ``redirect_uris``, or a non-https CORS origin to
+    ``allowed_origins``), so a custom template should render ``field.errors`` for every
+    field as the shipped one does. Keep rendering ``form.non_field_errors`` as well: an
+    error for a field the form does not include falls back to a non-field error.
+
 application_registration_form.html
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Rendered in :class:`~oauth2_provider.views.base.ApplicationRegistration` (``applications/register/``).

--- a/oauth2_provider/forms.py
+++ b/oauth2_provider/forms.py
@@ -1,5 +1,8 @@
+from typing import Any, Optional
+
 from django import forms
 from django.contrib.auth.hashers import identify_hasher
+from django.core.exceptions import NON_FIELD_ERRORS, ValidationError
 from django.utils.translation import gettext_lazy as _
 
 
@@ -133,6 +136,24 @@ class ApplicationForm(forms.ModelForm):
                 ),
             }
         )
+
+    def add_error(self, field: Optional[str], error: Any) -> None:
+        """Fold model errors naming a field this form omits into non-field errors.
+
+        ``Application.clean()`` keys its errors by field so a ModelForm renders each one
+        next to the offending input. Django hands those to ``add_error(None, error_dict)``
+        and raises ``ValueError`` if a key is not a field of the form -- which a subclass
+        with a narrower ``Meta.fields`` can easily trigger (e.g. omitting ``redirect_uris``
+        while keeping ``authorization_grant_type``). Re-key the unknown ones so such a form
+        still shows the message, as a non-field error, instead of raising.
+        """
+        if field is None and hasattr(error, "error_dict"):
+            rekeyed = {}
+            for error_field, messages in error.error_dict.items():
+                key = error_field if error_field in self.fields else NON_FIELD_ERRORS
+                rekeyed.setdefault(key, []).extend(messages)
+            error = ValidationError(rekeyed)
+        super().add_error(field, error)
 
     class Media:
         js = ("oauth2_provider/js/application_form.js",)

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import time
 import uuid
+from collections import defaultdict
 from contextlib import suppress
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -292,7 +293,13 @@ class AbstractApplication(models.Model):
         """
         return self.allowed_origins and is_origin_allowed(origin, self.allowed_origins.split())
 
-    def clean(self):
+    def clean(self) -> None:
+        """Validate the application, reporting each problem on the field it belongs to.
+
+        Raises a :class:`~django.core.exceptions.ValidationError` keyed by field name, so
+        callers get a per-field ``message_dict`` and a ModelForm renders each message next
+        to its input. Every problem found is reported, not just the first one.
+        """
         from django.core.exceptions import ValidationError
 
         grant_types = (
@@ -304,6 +311,15 @@ class AbstractApplication(models.Model):
             AbstractApplication.GRANT_IMPLICIT,
             AbstractApplication.GRANT_OPENID_HYBRID,
         )
+
+        # Errors are keyed by the field they belong to and raised together at the end,
+        # rather than raised one at a time as they are found. Keying them means
+        # ``full_clean()`` reports them per field (``ValidationError.message_dict``) and a
+        # ModelForm -- the admin and the built-in application views both use one -- renders
+        # each message next to the offending input instead of as an anonymous non-field
+        # error at the top of the form. Collecting them means a single submit reports every
+        # problem at once instead of one per round trip.
+        field_errors = defaultdict(list)
 
         redirect_uris = self.redirect_uris.strip().split()
         allowed_schemes = set(s.lower() for s in self.get_allowed_schemes())
@@ -317,12 +333,17 @@ class AbstractApplication(models.Model):
                 allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
             )
             for uri in redirect_uris:
-                validator(uri)
+                try:
+                    validator(uri)
+                except ValidationError as exc:
+                    field_errors["redirect_uris"].extend(exc.error_list)
 
         elif self.authorization_grant_type in grant_types:
-            raise ValidationError(
-                _("redirect_uris cannot be empty with grant_type {grant_type}").format(
-                    grant_type=self.authorization_grant_type
+            field_errors["redirect_uris"].append(
+                ValidationError(
+                    _("redirect_uris cannot be empty with grant_type {grant_type}").format(
+                        grant_type=self.authorization_grant_type
+                    )
                 )
             )
         allowed_origins = self.allowed_origins.strip().split()
@@ -334,11 +355,16 @@ class AbstractApplication(models.Model):
                 allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
             )
             for uri in allowed_origins:
-                validator(uri)
+                try:
+                    validator(uri)
+                except ValidationError as exc:
+                    field_errors["allowed_origins"].extend(exc.error_list)
 
         if self.algorithm == AbstractApplication.RS256_ALGORITHM:
             if not oauth2_settings.OIDC_RSA_PRIVATE_KEY:
-                raise ValidationError(_("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm"))
+                field_errors["algorithm"].append(
+                    ValidationError(_("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm"))
+                )
 
         if self.algorithm == AbstractApplication.HS256_ALGORITHM:
             if any(
@@ -347,24 +373,35 @@ class AbstractApplication(models.Model):
                     self.client_type == Application.CLIENT_PUBLIC,
                 )
             ):
-                raise ValidationError(_("You cannot use HS256 with public grants or clients"))
+                field_errors["algorithm"].append(
+                    ValidationError(_("You cannot use HS256 with public grants or clients"))
+                )
             if not self.client_secret:
-                raise ValidationError(
-                    _("You cannot use HS256 without a client secret; it is the HMAC signing key.")
+                field_errors["client_secret"].append(
+                    ValidationError(
+                        _("You cannot use HS256 without a client secret; it is the HMAC signing key.")
+                    )
                 )
             # For HS256 the client secret is the shared HMAC signing key, so it must be stored
             # unhashed. Reject both the intent to hash (the flag) and an already-hashed stored
             # value (e.g. the flag was toggled after the secret was hashed, or a legacy row), so
             # the misconfiguration surfaces here instead of only failing later at signing time.
-            if self.hash_client_secret or self._client_secret_is_hashed(self.client_secret):
-                raise ValidationError(
-                    _(
-                        "You cannot use HS256 with a hashed client secret. For HS256 the client "
-                        "secret is the shared signing key and must be stored unhashed so the relying "
-                        "party can verify the token; set hash_client_secret=False and store an "
-                        "unhashed client_secret on this application."
+            # The error goes on whichever field has to change: the flag when it is still set,
+            # otherwise the already-hashed secret itself, which has to be re-entered unhashed.
+            elif self.hash_client_secret or self._client_secret_is_hashed(self.client_secret):
+                field_errors["hash_client_secret" if self.hash_client_secret else "client_secret"].append(
+                    ValidationError(
+                        _(
+                            "You cannot use HS256 with a hashed client secret. For HS256 the client "
+                            "secret is the shared signing key and must be stored unhashed so the relying "
+                            "party can verify the token; set hash_client_secret=False and store an "
+                            "unhashed client_secret on this application."
+                        )
                     )
                 )
+
+        if field_errors:
+            raise ValidationError(field_errors)
 
     def get_absolute_url(self):
         return reverse("oauth2_provider:detail", args=[str(self.pk)])

--- a/tests/test_application_views.py
+++ b/tests/test_application_views.py
@@ -67,6 +67,113 @@ class TestApplicationRegistrationView(BaseTest):
 
 
 @pytest.mark.usefixtures("oauth2_settings")
+class TestApplicationFormFieldErrors(BaseTest):
+    """Model validation errors are reported on the field they belong to (#1343)."""
+
+    def _register(self, **overrides):
+        self.client.login(username="foo_user", password="123456")
+        form_data = {
+            "name": "Foo app",
+            "client_id": "client_id",
+            "client_secret": "client_secret",
+            "client_type": Application.CLIENT_CONFIDENTIAL,
+            "redirect_uris": "http://example.com",
+            "post_logout_redirect_uris": "http://other_example.com",
+            "authorization_grant_type": Application.GRANT_AUTHORIZATION_CODE,
+            "algorithm": "",
+        }
+        form_data.update(overrides)
+        return self.client.post(reverse("oauth2_provider:register"), form_data)
+
+    def test_invalid_redirect_uri_error_is_on_redirect_uris(self):
+        response = self._register(redirect_uris="invalid")
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertEqual(list(form.errors), ["redirect_uris"])
+        self.assertEqual(form.non_field_errors(), [])
+
+    def test_missing_redirect_uris_error_is_on_redirect_uris(self):
+        response = self._register(redirect_uris="")
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertIn("redirect_uris cannot be empty", form.errors["redirect_uris"][0])
+        self.assertEqual(form.non_field_errors(), [])
+
+    def test_invalid_allowed_origin_error_is_on_allowed_origins(self):
+        response = self._register(allowed_origins="http://example.com")
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertEqual(list(form.errors), ["allowed_origins"])
+        self.assertEqual(form.non_field_errors(), [])
+
+    def test_hs256_with_public_client_error_is_on_algorithm(self):
+        response = self._register(
+            algorithm=Application.HS256_ALGORITHM,
+            client_type=Application.CLIENT_PUBLIC,
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertIn("algorithm", form.errors)
+        self.assertEqual(form.non_field_errors(), [])
+
+    def test_hs256_with_hashed_secret_error_is_on_hash_client_secret(self):
+        response = self._register(
+            algorithm=Application.HS256_ALGORITHM,
+            hash_client_secret="on",
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertEqual(list(form.errors), ["hash_client_secret"])
+        self.assertEqual(form.non_field_errors(), [])
+
+    def test_every_error_is_reported_in_a_single_submit(self):
+        response = self._register(
+            redirect_uris="invalid",
+            allowed_origins="http://example.com",
+            algorithm=Application.HS256_ALGORITHM,
+            client_type=Application.CLIENT_PUBLIC,
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context["form"]
+        self.assertEqual(
+            set(form.errors),
+            {"redirect_uris", "allowed_origins", "algorithm"},
+        )
+
+    def test_error_is_rendered_next_to_its_field(self):
+        response = self._register(redirect_uris="invalid")
+        self.assertContains(response, "invalid_scheme: invalid")
+        content = response.content.decode()
+        # The message renders inside the redirect_uris control group -- everything from
+        # its label up to the close of the surrounding controls div -- rather than in the
+        # non-field block at the bottom of the form.
+        controls = content.split('for="id_redirect_uris"')[1].split("</div>")[0]
+        self.assertIn("invalid_scheme: invalid", controls)
+
+    def test_error_for_a_field_the_form_omits_falls_back_to_non_field(self):
+        """A narrower form must still show the message rather than raise ValueError.
+
+        Django raises ``ValueError`` when model validation names a field the form does
+        not include; ApplicationForm re-keys those to non-field errors instead.
+        """
+        form_class = modelform_factory(
+            Application,
+            form=ApplicationForm,
+            fields=("name", "client_id", "client_type", "authorization_grant_type"),
+        )
+        form = form_class(
+            data={
+                "name": "Foo app",
+                "client_id": "client_id",
+                "client_type": Application.CLIENT_CONFIDENTIAL,
+                "authorization_grant_type": Application.GRANT_AUTHORIZATION_CODE,
+            }
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("redirect_uris cannot be empty", form.non_field_errors()[0])
+
+
+@pytest.mark.usefixtures("oauth2_settings")
 @pytest.mark.oauth2_settings({"ALLOW_URI_WILDCARDS": True})
 class TestApplicationRegistrationViewRedirectURIWithWildcard(BaseTest):
     def _test_valid(self, redirect_uri):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 import pytest
 from django.contrib.auth import get_user_model
-from django.contrib.auth.hashers import check_password
+from django.contrib.auth.hashers import check_password, make_password
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.test.utils import override_settings
 from django.utils import timezone
@@ -1104,6 +1104,103 @@ def test_application_clean(oauth2_settings, application):
     assert "allowed origin URI Validation error. invalid_scheme: http://example.com" in str(exc.value)
     application.allowed_origins = "https://example.com"
     application.clean()
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_clean_errors_are_associated_with_their_field(oauth2_settings, application):
+    """Every ``clean()`` error names the field it belongs to (see #1343)."""
+    # An unusable redirect uri belongs to redirect_uris.
+    application.redirect_uris = "invalid"
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["redirect_uris"]
+    assert "invalid_scheme: invalid" in exc.value.message_dict["redirect_uris"][0]
+
+    # So does an empty redirect_uris for a grant type that requires one.
+    application.redirect_uris = ""
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["redirect_uris"]
+    assert "redirect_uris cannot be empty" in exc.value.message_dict["redirect_uris"][0]
+    application.redirect_uris = "https://example.org"
+
+    # A non-https origin belongs to allowed_origins, not to the whole form.
+    application.allowed_origins = "http://example.com"
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["allowed_origins"]
+    application.allowed_origins = ""
+
+    # A missing RSA key is only actionable on the algorithm field.
+    oauth2_settings.OIDC_RSA_PRIVATE_KEY = None
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["algorithm"]
+
+    # HS256 with a public client: again the algorithm is what has to change.
+    application.algorithm = Application.HS256_ALGORITHM
+    application.hash_client_secret = False
+    application.client_secret = CLEARTEXT_SECRET
+    application.client_type = Application.CLIENT_PUBLIC
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["algorithm"]
+    application.client_type = Application.CLIENT_CONFIDENTIAL
+
+    # HS256 without a secret: the secret is the missing piece.
+    application.client_secret = ""
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["client_secret"]
+
+    # HS256 while hashing is enabled: the flag is the thing to uncheck.
+    application.client_secret = CLEARTEXT_SECRET
+    application.hash_client_secret = True
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["hash_client_secret"]
+
+    # HS256 with a secret that is already hashed: hashing is off, so the stored
+    # secret itself has to be replaced with an unhashed one.
+    application.hash_client_secret = False
+    application.client_secret = make_password(CLEARTEXT_SECRET)
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["client_secret"]
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_clean_reports_every_error_at_once(oauth2_settings, application):
+    """Unrelated problems are collected, not reported one save at a time."""
+    application.redirect_uris = "invalid"
+    application.allowed_origins = "http://example.com"
+    application.algorithm = Application.HS256_ALGORITHM
+    application.client_type = Application.CLIENT_PUBLIC
+    application.hash_client_secret = True
+
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert set(exc.value.message_dict) == {
+        "redirect_uris",
+        "allowed_origins",
+        "algorithm",
+        "hash_client_secret",
+    }
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_clean_reports_every_invalid_uri(oauth2_settings, application):
+    """Each bad uri in a multi-line field gets its own message."""
+    application.redirect_uris = "invalid-one\ninvalid-two"
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    messages = exc.value.message_dict["redirect_uris"]
+    assert len(messages) == 2
+    assert "invalid-one" in messages[0]
+    assert "invalid-two" in messages[1]
 
 
 def _test_wildcard_redirect_uris_valid(oauth2_settings, application, uris):


### PR DESCRIPTION
Fixes #1343

## Description of the Change

`Application.clean()` raised every failure as a non-field `ValidationError`, so the application forms (the registration/edit views and the Django admin) showed messages such as *"allowed origin URI Validation error. invalid_scheme: http://example.com"* at the top of the form with no indication of which input was at fault — the exact complaint in #1343 — and each save reported only the first problem found.

`clean()` now collects its errors keyed by the field they belong to and raises them together:

| problem | field |
| --- | --- |
| rejected redirect URI, or empty `redirect_uris` for a grant type that requires one | `redirect_uris` |
| non-https / otherwise rejected CORS origin | `allowed_origins` |
| RS256 without `OIDC_RSA_PRIVATE_KEY`; HS256 with a public grant or client | `algorithm` |
| HS256 with no client secret, or with a stored secret that is already hashed | `client_secret` |
| HS256 while `hash_client_secret` is still set | `hash_client_secret` |

Consequences:

* The shipped `application_form.html` already renders `field.errors`, so each message now appears next to the offending input, and a single submit reports every problem instead of one per round trip.
* `ValidationError.message_dict` is keyed by those field names, so callers of `Application.full_clean()` — dynamic client registration, CIMD, `createapplication` — now surface the field name alongside the message. The message texts themselves are unchanged.
* Django raises `ValueError` when model validation names a field a form omits, which a custom form with a narrower `Meta.fields` can trigger (e.g. omitting `redirect_uris` while keeping `authorization_grant_type`). `ApplicationForm.add_error()` re-keys those to non-field errors — the pre-existing behavior — so such forms keep working.

The remaining piece of #1343 was moving this validation off non-field errors; the HS256/hashed-secret live form warning noted in the issue thread is already in place.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features — n/a, this changes the built-in application form/admin behavior
- [ ] tests/app/rp updated to demonstrate new features — n/a

Tests: `tests/test_models.py` gains coverage that each error names its field, that unrelated problems are collected into one `message_dict`, and that every invalid URI in a multi-line field gets its own message; `tests/test_application_views.py` gains a `TestApplicationFormFieldErrors` class asserting the errors land on the form fields (and render inside the field's control group), plus the narrower-form fallback to non-field errors. Full suite, ruff, sphinx-lint and the docs build pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_017m1dpRYGScha2uf7badQyz)_