### PR TITLE
fix: unbreak CI against pytest-django 4.14 and Django 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to `True` (the `id_token_hint` is a previously issued token per OIDC RP-Initiated Logout)
   and how to harden it.
 ### Fixed
+* The system check that verifies the `AccessToken`, `IDToken`, and `RefreshToken` models are
+  routed to a single database is now registered under the `models` tag instead of `database`.
+  Django 6.1 stopped running `database`-tagged checks unless a database alias is passed
+  explicitly (`manage.py check --database default`), because such checks may do more than
+  static analysis; this one only asks the configured routers where the token models would be
+  written and never opens a connection, so under the old tag a plain `manage.py check` would
+  have silently stopped reporting a cross-database token configuration on Django 6.1.
 * #1796 Redirect URIs using an RFC 8252 §7.1 private-use URI scheme can now be registered.
   Such a scheme has no naming authority, so only a single slash follows it
   (`com.example.app:/oauth2redirect`), but `Application.clean()` reassembled every URI with

--- a/oauth2_provider/checks.py
+++ b/oauth2_provider/checks.py
@@ -178,7 +178,13 @@ def validate_bcp_configuration(app_configs, **kwargs):
     return messages
 
 
-@checks.register(checks.Tags.database)
+# Registered under the ``models`` tag rather than ``database``: this check only asks the
+# configured routers where the token models would be written, which is static analysis and
+# never opens a connection. Django 6.1 stopped running ``database``-tagged checks unless a
+# database alias is passed explicitly (``manage.py check --database default``), because
+# those checks may do more than static analysis -- keeping this one under that tag would
+# silently disable it for everyone running a plain ``manage.py check``.
+@checks.register(checks.Tags.models)
 def validate_token_configuration(app_configs, **kwargs):
     databases = set(
         router.db_for_write(apps.get_model(model))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,7 +57,10 @@ class OAuthSettingsWrapper:
         return getattr(_oauth2_settings, attr)
 
     def finalize(self):
-        self.settings.finalize()
+        # pytest-django 4.14 renamed the settings fixture's SettingsWrapper.finalize()
+        # to Settings._finalize(); support both so the suite runs on either version.
+        finalize = getattr(self.settings, "_finalize", None) or self.settings.finalize
+        finalize()
         _oauth2_settings.reload()
 
 

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -4,7 +4,7 @@ from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import override_settings
 
-from oauth2_provider.checks import validate_swapped_model_consistency
+from oauth2_provider.checks import validate_swapped_model_consistency, validate_token_configuration
 
 from .common_testing import OAuth2ProviderTestCase as TestCase
 
@@ -22,6 +22,14 @@ class DjangoChecksTestCase(TestCase):
         message = "The token models are expected to be stored in the same database."
         with self.assertRaisesMessage(SystemCheckError, message):
             call_command("check")
+
+    def test_token_configuration_check_runs_without_a_database_alias(self):
+        # Django 6.1 skips `database`-tagged checks unless an alias is passed explicitly
+        # (`manage.py check --database default`). This check only asks the routers where the
+        # token models would be written -- it never opens a connection -- so it must not carry
+        # that tag, or a plain `manage.py check` would silently stop running it.
+        self.assertNotIn(checks.Tags.database, validate_token_configuration.tags)
+        self.assertIn(checks.Tags.models, validate_token_configuration.tags)
 
 
 @pytest.mark.usefixtures("oauth2_settings")


### PR DESCRIPTION
## Description of the Change

CI went red on `master` and on every open PR without a code change on our side — two upstream releases landed since master's last green run (2026-07-28). This fixes both.

### 1. pytest-django 4.14 renamed the `settings` fixture API

pytest-django **4.14.0** renamed the `settings` fixture's `SettingsWrapper` class to `Settings` and its `finalize()` method to `_finalize()`. Test dependencies are installed unpinned, so all jobs resolve to 4.14 and `OAuthSettingsWrapper.finalize()` in `tests/conftest.py` falls through `Settings.__getattr__` to the Django settings object:

```
self = <UserSettingsHolder>, name = 'finalize'

    def __getattr__(self, name):
        if not name.isupper() or name in self._deleted:
>           raise AttributeError
E           AttributeError
```

That fires at teardown of every test using the `oauth2_settings` fixture — ~725 errors per cell — and, because the overrides are then never disabled, settings leak between tests.

`tests/conftest.py` now calls `_finalize()` when the fixture object provides it and falls back to `finalize()` otherwise, so the suite runs on 4.14 and on earlier releases alike.

### 2. Django 6.1 stopped running `database`-tagged system checks by default

Django **6.1** added this to `CheckRegistry.run_checks()`:

```python
elif not databases:
    # By default, 'database'-tagged checks are not run if an alias
    # is not explicitly specified as they do more than mere static
    # code analysis.
    checks = [check for check in checks if Tags.database not in check.tags]
```

`validate_token_configuration` was registered under `Tags.database`, so on Django 6.1 a plain `manage.py check` silently stopped reporting a cross-database token configuration — visible in CI as `test_checks_fail_when_router_crosses_databases` failing with `SystemCheckError not raised`. This is a user-facing regression, not only a test failure.

The check only asks the configured routers where the `AccessToken`/`IDToken`/`RefreshToken` models would be written and never opens a connection, so it is static analysis and does not belong under that tag. It is now registered under `Tags.models` — the same tag as the sibling `validate_swapped_model_consistency` check — and a test asserts the tag so it cannot regress.

### Verification

Full suite (`tests/`; the e2e suite runs separately):

| Environment | result |
| --- | --- |
| Django 5.2 + pytest-django 4.12.0 (current lockfile) | 1069 passed, 1 skipped |
| Django 5.2 + pytest-django 4.14.0 | 1069 passed, 1 skipped |
| Django 6.1 + pytest-django 4.14.0 | 1034 passed, 1 skipped |
| Django 4.2 + pytest-django 4.12.0 | 1034 passed, 1 skipped |

Without these changes, Django 5.2 + pytest-django 4.14.0 gives `1068 passed, 725 errors`, and Django 6.1 additionally fails `test_checks_fail_when_router_crosses_databases`.

### Note for maintainers: the tox matrix is not testing the Django versions it names

Worth a separate look — this PR does not touch it. `djangorestframework` **3.18.0** requires `django>=5.2`, and it is installed *after* the tox `deps` pin, so pip upgrades Django in the older cells:

```
py312-dj42-multi-db: install_deps> python -I -m pip install 'Django<4.3,>=4.2'
py312-dj42-multi-db: install_package_deps> python -I -m pip install ... 'django>=4.2' djangorestframework ...
py312-dj42-multi-db: freeze> ... Django==6.1 ... djangorestframework==3.18.0 ...
```

So `dj42`/`dj50`/`dj51` currently run Django 6.1 on Python 3.12+ and Django 5.2 on 3.10/3.11 — which is why the Django 6.1 failure surfaced in cells labelled `dj42`. Relatedly, pytest-django 4.14 declares support for Django 5.2 and 6.0 only (`django>=5.2` in its `django` extra), and `pytest_django.asserts` imports `django.contrib.messages.test`, which does not exist before Django 5.0 — so on a *real* Django 4.2, collection of `tests/test_oidc_views.py` fails outright with 4.14. Pinning `pytest-django<4.14` (and a compatible DRF) in the older cells, or dropping those Django versions, is a maintainer call.

## Checklist

- [x] PR only contains one change (considered splitting up PR) — two upstream breakages, both required for a green CI run
- [x] unit-test added — `test_token_configuration_check_runs_without_a_database_alias`; the conftest change repairs existing fixtures
- [ ] documentation updated — n/a
- [x] `CHANGELOG.md` updated (only for user relevant changes) — the check-tag fix; the conftest change is test-only
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features — n/a
- [ ] tests/app/rp updated to demonstrate new features — n/a