### PR TITLE
Log why a redirect URI failed to match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   emitted for `post_logout_redirect_uri` and for the token endpoint's comparison against the
   URI recorded on the grant. The error response is unchanged: the registered URIs are never
   disclosed to the requester, only to the server's log. See "Debugging redirect URI
-  mismatches" in the documentation.
+  mismatches" in the documentation. Note that `AbstractApplication.redirect_uri_allowed()`
+  and `post_logout_redirect_uri_allowed()` now call the new `check_redirect_to_uri_allowed()`
+  (same verdict, plus the mismatch reasons) instead of `redirect_to_uri_allowed()`, so code
+  that wrapped or patched the latter to influence those methods must target the former.
 * #634 A system check (`oauth2_provider.W011`) that warns when the `AccessToken` and
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+* #681 Redirect URI mismatches are now diagnosed on the `oauth2_provider` logger at `DEBUG`,
+  reporting the requested URI, every registered candidate it was compared against, and which
+  component of each one differed (scheme, hostname, port, path, query). The same detail is
+  emitted for `post_logout_redirect_uri` and for the token endpoint's comparison against the
+  URI recorded on the grant. The error response is unchanged: the registered URIs are never
+  disclosed to the requester, only to the server's log. See "Debugging redirect URI
+  mismatches" in the documentation.
 * #634 A system check (`oauth2_provider.W011`) that warns when the `AccessToken` and
   `RefreshToken` models are swapped into different apps, and a new
   "Extending the token models" documentation section explaining how to swap the

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -509,8 +509,10 @@ The same messages cover ``post_logout_redirect_uri`` for RP-initiated logout.
 
 .. note::
 
-    The requested URI is client-controlled input. It is truncated and escaped before
-    being logged, but the registered URIs are printed in full, and the log records that
-    someone attempted a particular callback. Enable ``DEBUG`` on a server whose logs you
-    treat accordingly; leaving the ``oauth2_provider`` logger at its default level keeps
-    these messages off entirely.
+    Both the requested URI and the registered URIs are truncated and escaped before
+    being logged, and at most ten registered candidates are listed per message, since
+    under dynamic client registration the registered URIs are supplied by the registrant
+    rather than by you. The log still records that someone attempted a particular
+    callback, so enable ``DEBUG`` on a server whose logs you treat accordingly; leaving
+    the ``oauth2_provider`` logger at its default level keeps these messages off
+    entirely.

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -461,3 +461,56 @@ The rest of the shipped pages need no CSP exceptions: their styles come from a s
 served with the package's own static files, so ``style-src 'self'`` is enough — no
 third-party style host and no inline ``<style>``. See :ref:`default-stylesheet` if you
 replace those styles with your own.
+
+.. _debug-redirect-uri:
+
+Debugging redirect URI mismatches
+=================================
+
+When a client sends a ``redirect_uri`` that does not match anything registered for it,
+the authorization server answers with oauthlib's ``Mismatching redirect URI.`` and
+nothing more. That is deliberate: the error is rendered to whoever made the request, so
+naming the registered URIs there would let anyone holding a client ID enumerate that
+client's callbacks. The response says nothing, and it stays that way.
+
+The detail goes to the log instead. Django OAuth Toolkit logs to the ``oauth2_provider``
+logger; set it to ``DEBUG`` to see which URIs were compared and which component of each
+one differed::
+
+    LOGGING = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {
+            "console": {"class": "logging.StreamHandler"},
+        },
+        "loggers": {
+            "oauth2_provider": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+            },
+        },
+    }
+
+A failed match on the authorization endpoint then reports every registered candidate::
+
+    DEBUG redirect_uri 'https://app.example.com/callback/' does not match any redirect_uri
+    registered for client_id 'SDbfPCoJIzPeXwPGfMzZ1TIVfjBqvnMYCfSHTPSc':
+    'https://app.example.com/callback': path differs;
+    'http://app.example.com/callback/': scheme differs
+
+The token endpoint compares against the URI recorded on the grant instead, which
+RFC 6749 section 4.1.3 requires to be identical to the one used at authorization::
+
+    DEBUG redirect_uri 'https://app.example.com/callback' does not match the redirect_uri
+    'https://app.example.com/callback/' recorded on grant #42 at authorization time;
+    RFC 6749 section 4.1.3 requires them to be identical
+
+The same messages cover ``post_logout_redirect_uri`` for RP-initiated logout.
+
+.. note::
+
+    The requested URI is client-controlled input. It is truncated and escaped before
+    being logged, but the registered URIs are printed in full, and the log records that
+    someone attempted a particular callback. Enable ``DEBUG`` on a server whose logs you
+    treat accordingly; leaving the ``oauth2_provider`` logger at its default level keeps
+    these messages off entirely.

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -282,21 +282,27 @@ class AbstractApplication(models.Model):
         # (the assert would also be stripped entirely under `python -O`). See #958.
         raise errors.MissingRedirectURIError()
 
-    def redirect_uri_allowed(self, uri):
+    def redirect_uri_allowed(self, uri: str) -> bool:
         """
         Checks if given url is one of the items in :attr:`redirect_uris` string
 
         :param uri: Url to check
         """
-        return redirect_to_uri_allowed(uri, self.redirect_uris.split())
+        allowed, reasons = check_redirect_to_uri_allowed(uri, self.redirect_uris.split())
+        if not allowed:
+            _log_registered_uri_mismatch("redirect_uri", uri, self.client_id, reasons)
+        return allowed
 
-    def post_logout_redirect_uri_allowed(self, uri):
+    def post_logout_redirect_uri_allowed(self, uri: str) -> bool:
         """
         Checks if given URI is one of the items in :attr:`post_logout_redirect_uris` string
 
         :param uri: URI to check
         """
-        return redirect_to_uri_allowed(uri, self.post_logout_redirect_uris.split())
+        allowed, reasons = check_redirect_to_uri_allowed(uri, self.post_logout_redirect_uris.split())
+        if not allowed:
+            _log_registered_uri_mismatch("post_logout_redirect_uri", uri, self.client_id, reasons)
+        return allowed
 
     def origin_allowed(self, origin):
         """
@@ -552,8 +558,19 @@ class AbstractGrant(models.Model):
 
         return timezone.now() >= self.expires
 
-    def redirect_uri_allowed(self, uri):
-        return uri == self.redirect_uri
+    def redirect_uri_allowed(self, uri: str) -> bool:
+        allowed = uri == self.redirect_uri
+        if not allowed and logger.isEnabledFor(logging.DEBUG):
+            # Never log self.code alongside this: an authorization code in a log
+            # file is a credential, which is why __str__ below omits it too.
+            logger.debug(
+                "redirect_uri %s does not match the redirect_uri %s recorded on grant #%s at "
+                "authorization time; RFC 6749 section 4.1.3 requires them to be identical",
+                _loggable_uri(uri),
+                _loggable_uri(self.redirect_uri),
+                self.pk,
+            )
+        return allowed
 
     def __str__(self):
         # Never render the authorization code itself: __str__ appears in the admin
@@ -1228,11 +1245,88 @@ def clear_expired():
     logger.info("%s Expired grant tokens deleted", grants_deleted_no)
 
 
-def redirect_to_uri_allowed(uri, allowed_uris):
-    """
-    Checks if a given uri can be redirected to based on the provided allowed_uris configuration.
+# A registered URI is operator configuration and is logged in full; a requested URI
+# is unbounded client input (redirect_uri is a TextField on Grant, see #902) and is
+# not.  256 characters is well past any legitimate redirect URI while still short
+# enough that a flood of junk cannot fill the log.
+_MAX_LOGGED_URI_LENGTH = 256
 
-    On top of exact matches, this function also handles loopback IPs based on RFC 8252.
+
+def _loggable_uri(uri: Optional[str]) -> str:
+    """
+    Render a client-supplied URI for inclusion in a log message.
+
+    The value is truncated, and rendered with ``repr()`` so that control
+    characters -- CR/LF above all -- are escaped rather than forging log lines.
+
+    :param uri: URI to render
+    """
+    if uri is None:
+        return "None"
+    if len(uri) > _MAX_LOGGED_URI_LENGTH:
+        uri = uri[:_MAX_LOGGED_URI_LENGTH] + "...[truncated]"
+    return repr(uri)
+
+
+def _format_uri_mismatch_reasons(reasons: list[tuple[Optional[str], str]]) -> str:
+    """
+    Render the reasons collected by :func:`check_redirect_to_uri_allowed` as one
+    log-friendly string.
+
+    :param reasons: ``(candidate, reason)`` pairs; a ``None`` candidate is a
+        rejection of the requested URI itself rather than of a registered one
+    """
+    if not reasons:
+        return "no URIs are registered"
+    return "; ".join(
+        reason if candidate is None else "{0!r}: {1}".format(candidate, reason)
+        for candidate, reason in reasons
+    )
+
+
+def _log_registered_uri_mismatch(
+    uri_type: str, uri: str, client_id: str, reasons: list[tuple[Optional[str], str]]
+) -> None:
+    """
+    Log why a client-supplied URI matched none of the URIs registered for a client.
+
+    Without this the mismatch reaches the developer as nothing but oauthlib's bare
+    "Mismatching redirect URI." (see #681).  The detail is deliberately confined to
+    the log and must never be added to the error response: that response is
+    rendered to whoever made the request, so it would let an unauthenticated caller
+    read back a client's registered URIs by sending a junk URI with a known
+    client_id.
+
+    :param uri_type: name of the parameter being checked, for the log message
+    :param uri: the client-supplied URI that was rejected
+    :param client_id: client whose registered URIs were checked
+    :param reasons: ``(candidate, reason)`` pairs from :func:`check_redirect_to_uri_allowed`
+    """
+    if not logger.isEnabledFor(logging.DEBUG):
+        return
+    logger.debug(
+        "%s %s does not match any %s registered for client_id %r: %s",
+        uri_type,
+        _loggable_uri(uri),
+        uri_type,
+        client_id,
+        _format_uri_mismatch_reasons(reasons),
+    )
+
+
+def check_redirect_to_uri_allowed(
+    uri: str, allowed_uris: list[str]
+) -> tuple[bool, list[tuple[Optional[str], str]]]:
+    """
+    Same check as :func:`redirect_to_uri_allowed`, additionally reporting why the
+    URI was rejected.
+
+    Returns ``(allowed, reasons)``.  ``reasons`` is only meaningful when
+    ``allowed`` is ``False``: it holds one ``(candidate, reason)`` pair for every
+    registered URI that failed to match, plus pairs with a ``None`` candidate for
+    rejections of the requested URI itself.  A reason names the component that
+    differs instead of echoing the requested URI back, which callers log once and
+    only after passing it through :func:`_loggable_uri`.
 
     :param uri: URI to check
     :param allowed_uris: A list of URIs that are allowed
@@ -1240,6 +1334,8 @@ def redirect_to_uri_allowed(uri, allowed_uris):
 
     if not isinstance(allowed_uris, list):
         raise ValueError("allowed_uris must be a list")
+
+    reasons: list[tuple[Optional[str], str]] = []
 
     # urlsplit() rather than urlparse(): urlparse() peels ";params" off the last
     # path segment into a separate attribute, so comparing .path alone would let a
@@ -1253,39 +1349,46 @@ def redirect_to_uri_allowed(uri, allowed_uris):
     # (empty) fragment component and is not the registered URI.  A percent-encoded
     # %23 is not a fragment delimiter and is unaffected.
     if "#" in uri:
-        return False
+        return False, [(None, "the requested URI has a fragment, which RFC 6749 section 3.1.2 forbids")]
 
     # Credentials are not part of a registered callback and must not ride along on
     # the request; without this "https://evil@example.com/cb" would match a
     # registered "https://example.com/cb", since only .hostname is compared below.
     if "@" in parsed_uri.netloc:
-        return False
+        return False, [(None, "the requested URI carries userinfo credentials in its authority")]
 
     for allowed_uri in allowed_uris:
         # A registered URI carrying a fragment or credentials cannot authorize
         # anything: the request forms that would match it are rejected above.
         if "#" in allowed_uri:
+            reasons.append((allowed_uri, "the registered URI has a fragment and can never match"))
             continue
 
         parsed_allowed_uri = urlsplit(allowed_uri)
 
         if "@" in parsed_allowed_uri.netloc:
+            reasons.append(
+                (allowed_uri, "the registered URI carries userinfo credentials and can never match")
+            )
             continue
 
         if parsed_allowed_uri.scheme != parsed_uri.scheme:
             # match failed, continue
+            reasons.append((allowed_uri, "scheme differs"))
             continue
 
         """ check hostname """
-        # A private-use URI scheme redirect (RFC 8252 §7.1) has no naming
+        # A private-use URI scheme redirect (RFC 8252 section 7.1) has no naming
         # authority, so hostname is None on either side; guard before matching.
         allowed_hostname = parsed_allowed_uri.hostname
         uri_hostname = parsed_uri.hostname
         if oauth2_settings.ALLOW_URI_WILDCARDS and allowed_hostname and allowed_hostname.startswith("*"):
             """ wildcard hostname """
             if not uri_hostname or not uri_hostname.endswith(allowed_hostname[1:]):
+                reasons.append((allowed_uri, "hostname does not match the registered wildcard"))
                 continue
         elif allowed_hostname != uri_hostname:
+            reasons.append((allowed_uri, "hostname differs"))
             continue
 
         # From RFC 8252 (Section 7.3)
@@ -1311,10 +1414,12 @@ def redirect_to_uri_allowed(uri, allowed_uris):
         )
         """ check port """
         if not allowed_uri_is_loopback and parsed_allowed_uri.port != parsed_uri.port:
+            reasons.append((allowed_uri, "port differs"))
             continue
 
         """ check path """
         if parsed_allowed_uri.path != parsed_uri.path:
+            reasons.append((allowed_uri, "path differs"))
             continue
 
         """ check querystring """
@@ -1334,14 +1439,29 @@ def redirect_to_uri_allowed(uri, allowed_uris):
         # opens the query -- so testing the raw string is equivalent to testing for
         # the component.  A percent-encoded %3F is not a delimiter and is unaffected.
         if ("?" in allowed_uri) != ("?" in uri):
+            reasons.append((allowed_uri, "one URI has a query component and the other does not"))
             continue
         if parsed_allowed_uri.query != parsed_uri.query:
+            reasons.append((allowed_uri, "query string differs"))
             continue  # circuit break
 
-        return True
+        return True, []
 
     # if uris matched then it's not allowed
-    return False
+    return False, reasons
+
+
+def redirect_to_uri_allowed(uri: str, allowed_uris: list[str]) -> bool:
+    """
+    Checks if a given uri can be redirected to based on the provided allowed_uris configuration.
+
+    On top of exact matches, this function also handles loopback IPs based on RFC 8252.
+
+    :param uri: URI to check
+    :param allowed_uris: A list of URIs that are allowed
+    """
+    allowed, _reasons = check_redirect_to_uri_allowed(uri, allowed_uris)
+    return allowed
 
 
 def is_origin_allowed(origin, allowed_origins):

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -1245,11 +1245,14 @@ def clear_expired():
     logger.info("%s Expired grant tokens deleted", grants_deleted_no)
 
 
-# A registered URI is operator configuration and is logged in full; a requested URI
-# is unbounded client input (redirect_uri is a TextField on Grant, see #902) and is
-# not.  256 characters is well past any legitimate redirect URI while still short
-# enough that a flood of junk cannot fill the log.
+# Neither side of the comparison is trusted to be bounded.  The requested URI is
+# client input, and the registered URIs only look like operator configuration: under
+# RFC 7591 dynamic registration and CIMD they are supplied by the registrant, and
+# neither path caps their length or their number.  256 characters is well past any
+# legitimate redirect URI, and 10 candidates past any legitimate client, while both
+# stay short enough that a flood of junk cannot fill the log.
 _MAX_LOGGED_URI_LENGTH = 256
+_MAX_LOGGED_CANDIDATES = 10
 
 
 def _loggable_uri(uri: Optional[str]) -> str:
@@ -1273,15 +1276,22 @@ def _format_uri_mismatch_reasons(reasons: list[tuple[Optional[str], str]]) -> st
     Render the reasons collected by :func:`check_redirect_to_uri_allowed` as one
     log-friendly string.
 
+    Candidates are rendered through :func:`_loggable_uri` for the same reason the
+    requested URI is: a registered URI can be registrant-supplied and unbounded.
+
     :param reasons: ``(candidate, reason)`` pairs; a ``None`` candidate is a
         rejection of the requested URI itself rather than of a registered one
     """
     if not reasons:
         return "no URIs are registered"
-    return "; ".join(
-        reason if candidate is None else "{0!r}: {1}".format(candidate, reason)
-        for candidate, reason in reasons
+    listed = "; ".join(
+        reason if candidate is None else "{0}: {1}".format(_loggable_uri(candidate), reason)
+        for candidate, reason in reasons[:_MAX_LOGGED_CANDIDATES]
     )
+    remaining = len(reasons) - _MAX_LOGGED_CANDIDATES
+    if remaining > 0:
+        listed += "; ...and {0} further registered URI(s) not listed".format(remaining)
+    return listed
 
 
 def _log_registered_uri_mismatch(
@@ -1378,7 +1388,7 @@ def check_redirect_to_uri_allowed(
             continue
 
         """ check hostname """
-        # A private-use URI scheme redirect (RFC 8252 section 7.1) has no naming
+        # A private-use URI scheme redirect (RFC 8252 §7.1) has no naming
         # authority, so hostname is None on either side; guard before matching.
         allowed_hostname = parsed_allowed_uri.hostname
         uri_hostname = parsed_uri.hostname

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -134,6 +134,48 @@ class TestAuthorizationCodeView(BaseTest):
             "?error=invalid_request&error_description=Invalid+client_id+parameter+value.",
         )
 
+    def test_pre_auth_redirect_uri_mismatch_does_not_leak_registered_uris(self):
+        """
+        A mismatching redirect_uri is diagnosed in the log, never in the response.
+
+        #681 asked for the allowed and the actual redirect URI to be reported when
+        the match fails.  The response is rendered to whoever made the request, so
+        putting the registered URIs there would let an unauthenticated caller
+        enumerate a client's callbacks with nothing but its client_id; the detail
+        goes to the "oauth2_provider" logger at DEBUG instead, and the response is
+        left exactly as it was.
+        """
+        self.client.login(username="test_user", password="123456")
+
+        query_data = {
+            "client_id": self.application.client_id,
+            "response_type": "code",
+            "state": "random_state_string",
+            "scope": "read write",
+            # Deliberately not a superstring of any registered URI, so that the
+            # leak assertions below cannot pass on the request's own echo.
+            "redirect_uri": "http://not-registered.example.org/cb",
+        }
+
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            response = self.client.get(reverse("oauth2_provider:authorize"), data=query_data)
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("error=invalid_request", response.context_data["url"])
+        self.assertIn("error_description=Mismatching+redirect+URI.", response.context_data["url"])
+        # Nothing about the registered URIs may appear anywhere in the response.
+        body = response.content.decode()
+        for registered_uri in self.application.redirect_uris.split():
+            self.assertNotIn(registered_uri, body)
+            self.assertNotIn(registered_uri, response.context_data["url"])
+
+        # ...but the log says exactly which candidates were compared and why each
+        # one failed, which is what the issue asked for.
+        message = "\n".join(captured.output)
+        self.assertIn("redirect_uri 'http://not-registered.example.org/cb'", message)
+        self.assertIn("'http://example.com': hostname differs", message)
+        self.assertIn("'custom-scheme://example.com': scheme differs", message)
+
     def test_pre_auth_client_credentials_app_without_redirect_uri(self):
         """
         An application with no registered redirect_uris (here a client_credentials
@@ -917,6 +959,36 @@ class BaseAuthorizationCodeTokenView(BaseTest):
 
 @pytest.mark.oauth2_settings(presets.DEFAULT_SCOPES_RW)
 class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
+    def test_token_request_redirect_uri_mismatch_does_not_leak_the_grant_uri(self):
+        """
+        Same contract on the token endpoint leg: RFC 6749 section 4.1.3 requires
+        the redirect_uri to be identical to the one used at authorization, and the
+        mismatch is diagnosed in the log rather than in the token response.
+        """
+        self.client.login(username="test_user", password="123456")
+        authorization_code = self.get_auth()
+
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org/not-the-one-used",
+        }
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            response = self.client.post(
+                reverse("oauth2_provider:token"), data=token_request_data, **auth_headers
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertNotIn("http://example.org?foo=bar", response.content.decode())
+
+        message = "\n".join(captured.output)
+        self.assertIn("redirect_uri 'http://example.org/not-the-one-used'", message)
+        self.assertIn("RFC 6749 section 4.1.3", message)
+        # The authorization code is a credential; it must not reach the log.
+        self.assertNotIn(authorization_code, message)
+
     def test_basic_auth(self):
         """
         Request an access token using basic authentication for client authentication

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,6 +14,9 @@ from django.utils.functional import Promise
 
 from oauth2_provider import models as oauth2_models
 from oauth2_provider.models import (
+    _format_uri_mismatch_reasons,
+    _loggable_uri,
+    check_redirect_to_uri_allowed,
     clear_expired,
     get_access_token_model,
     get_application_model,
@@ -1485,3 +1488,178 @@ def test_model_field_labels_are_translatable(model):
         if not isinstance(field, django_models.AutoField) and not isinstance(field.verbose_name, Promise)
     )
     assert untranslated == []
+
+
+# Diagnostics for a redirect URI that matched nothing (#681).  The detail lives in
+# the log and nowhere else: see test_pre_auth_redirect_uri_mismatch_does_not_leak_
+# registered_uris in tests/test_authorization_code.py for the other half of that
+# contract.
+
+mismatch_reason_params = [
+    # (uri, allowed_uris, expected reason)
+    ("https://example.com/cb#frag", ["https://example.com/cb"], "fragment"),
+    ("https://evil@example.com/cb", ["https://example.com/cb"], "userinfo credentials"),
+    ("https://example.com/cb", ["https://example.com/cb#frag"], "registered URI has a fragment"),
+    ("https://example.com/cb", ["https://evil@example.com/cb"], "registered URI carries userinfo"),
+    ("http://example.com/cb", ["https://example.com/cb"], "scheme differs"),
+    ("https://other.com/cb", ["https://example.com/cb"], "hostname differs"),
+    ("https://example.com:8443/cb", ["https://example.com/cb"], "port differs"),
+    ("https://example.com/other", ["https://example.com/cb"], "path differs"),
+    ("https://example.com/cb?a=1", ["https://example.com/cb"], "query component"),
+    ("https://example.com/cb?a=2", ["https://example.com/cb?a=1"], "query string differs"),
+]
+
+
+@pytest.mark.parametrize("uri, allowed_uris, expected_reason", mismatch_reason_params)
+def test_check_redirect_to_uri_allowed_reports_reason(uri, allowed_uris, expected_reason):
+    allowed, reasons = check_redirect_to_uri_allowed(uri, allowed_uris)
+    assert not allowed
+    assert expected_reason in _format_uri_mismatch_reasons(reasons)
+
+
+def test_check_redirect_to_uri_allowed_reports_wildcard_reason(oauth2_settings):
+    oauth2_settings.ALLOW_URI_WILDCARDS = True
+    allowed, reasons = check_redirect_to_uri_allowed("https://other.com/cb", ["https://*.example.com/cb"])
+    assert not allowed
+    assert "registered wildcard" in _format_uri_mismatch_reasons(reasons)
+
+
+def test_check_redirect_to_uri_allowed_reports_every_candidate():
+    allowed, reasons = check_redirect_to_uri_allowed(
+        "https://example.com/cb", ["https://example.com/other", "http://example.com/cb"]
+    )
+    assert not allowed
+    assert [candidate for candidate, _reason in reasons] == [
+        "https://example.com/other",
+        "http://example.com/cb",
+    ]
+    assert _format_uri_mismatch_reasons(reasons) == (
+        "'https://example.com/other': path differs; 'http://example.com/cb': scheme differs"
+    )
+
+
+def test_format_uri_mismatch_reasons_with_nothing_registered():
+    allowed, reasons = check_redirect_to_uri_allowed("https://example.com/cb", [])
+    assert not allowed
+    assert _format_uri_mismatch_reasons(reasons) == "no URIs are registered"
+
+
+@pytest.mark.parametrize(
+    "uri, allowed_uris, expected",
+    exact_redirect_match_params + [(u, a, True) for u, a in valid_wildcard_redirect_to_params],
+)
+def test_check_redirect_to_uri_allowed_agrees_with_redirect_to_uri_allowed(
+    uri, allowed_uris, expected, oauth2_settings
+):
+    # check_redirect_to_uri_allowed() is the matcher; redirect_to_uri_allowed() is
+    # a thin wrapper over it.  The two must never diverge.
+    oauth2_settings.ALLOW_URI_WILDCARDS = True
+    allowed, _reasons = check_redirect_to_uri_allowed(uri, allowed_uris)
+    assert allowed is redirect_to_uri_allowed(uri, allowed_uris)
+
+
+def test_check_redirect_to_uri_allowed_expects_allowed_uri_list():
+    with pytest.raises(ValueError):
+        check_redirect_to_uri_allowed("https://example.com", "https://example.com")
+
+
+def test_loggable_uri_escapes_control_characters():
+    # A raw CR/LF in a client-supplied URI would otherwise forge log lines.
+    rendered = _loggable_uri("https://example.com/cb\r\nWARNING forged log line")
+    assert "\r" not in rendered
+    assert "\n" not in rendered
+    assert "\\r\\n" in rendered
+
+
+def test_loggable_uri_truncates_long_uris():
+    rendered = _loggable_uri("https://example.com/cb?x=" + "a" * 10000)
+    assert len(rendered) < 300
+    assert rendered.endswith("...[truncated]'")
+
+
+def test_loggable_uri_handles_none():
+    assert _loggable_uri(None) == "None"
+
+
+class TestRedirectURIMismatchLogging(BaseTestModels):
+    """The mismatch detail requested in #681 is emitted to the log, at DEBUG."""
+
+    def setUp(self):
+        super().setUp()
+        self.application = Application.objects.create(
+            name="Test Application",
+            redirect_uris="https://example.com/cb",
+            post_logout_redirect_uris="https://example.com/logout",
+            user=self.user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_AUTHORIZATION_CODE,
+        )
+
+    def test_application_redirect_uri_mismatch_is_logged(self):
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            assert not self.application.redirect_uri_allowed("https://example.com/other")
+        message = "\n".join(captured.output)
+        assert "redirect_uri 'https://example.com/other'" in message
+        assert "does not match any redirect_uri registered" in message
+        assert repr(self.application.client_id) in message
+        assert "'https://example.com/cb': path differs" in message
+
+    def test_application_post_logout_redirect_uri_mismatch_is_logged(self):
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            assert not self.application.post_logout_redirect_uri_allowed("https://example.com/elsewhere")
+        message = "\n".join(captured.output)
+        assert "post_logout_redirect_uri 'https://example.com/elsewhere'" in message
+        assert "does not match any post_logout_redirect_uri registered" in message
+        assert "'https://example.com/logout': path differs" in message
+
+    def test_matching_redirect_uri_is_not_logged(self):
+        with self.assertNoLogs("oauth2_provider", level="DEBUG"):
+            assert self.application.redirect_uri_allowed("https://example.com/cb")
+
+    def test_nothing_is_logged_above_debug(self):
+        # The detail must stay out of production logs unless the operator opts in
+        # by lowering the level of the "oauth2_provider" logger, and the message
+        # must not even be assembled when it would be discarded.
+        with mock.patch.object(oauth2_models, "_format_uri_mismatch_reasons") as format_reasons:
+            with self.assertNoLogs("oauth2_provider", level="INFO"):
+                assert not self.application.redirect_uri_allowed("https://example.com/other")
+        format_reasons.assert_not_called()
+
+    def test_logged_requested_uri_is_truncated_and_escaped(self):
+        hostile = "https://example.com/cb?x=" + "a" * 10000 + "\r\nWARNING forged"
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            assert not self.application.redirect_uri_allowed(hostile)
+        message = "\n".join(captured.output)
+        assert "...[truncated]" in message
+        assert "\r" not in message
+        assert "WARNING forged" not in message
+
+    def test_grant_redirect_uri_mismatch_is_logged_without_the_code(self):
+        grant = Grant.objects.create(
+            user=self.user,
+            code="grant_code_that_must_not_be_logged",
+            application=self.application,
+            expires=timezone.now() + timedelta(days=1),
+            redirect_uri="https://example.com/cb",
+            scope="",
+        )
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            assert not grant.redirect_uri_allowed("https://example.com/other")
+        message = "\n".join(captured.output)
+        assert "redirect_uri 'https://example.com/other'" in message
+        assert "'https://example.com/cb'" in message
+        assert "grant #%s" % grant.pk in message
+        # An authorization code is a credential and must never reach the log.
+        assert grant.code not in message
+
+    def test_grant_redirect_uri_match_is_not_logged(self):
+        grant = Grant.objects.create(
+            user=self.user,
+            code="another_grant_code",
+            application=self.application,
+            expires=timezone.now() + timedelta(days=1),
+            redirect_uri="https://example.com/cb",
+            scope="",
+        )
+        with self.assertNoLogs("oauth2_provider", level="DEBUG"):
+            assert grant.redirect_uri_allowed("https://example.com/cb")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1552,10 +1552,15 @@ def test_check_redirect_to_uri_allowed_agrees_with_redirect_to_uri_allowed(
     uri, allowed_uris, expected, oauth2_settings
 ):
     # check_redirect_to_uri_allowed() is the matcher; redirect_to_uri_allowed() is
-    # a thin wrapper over it.  The two must never diverge.
+    # a thin wrapper over it.  Assert the verdict against `expected` on both, not
+    # just that the two agree -- agreement alone holds by construction and would
+    # survive the matcher returning the wrong answer.  Wildcards are enabled here
+    # because this is the only place the wildcard configuration is exercised
+    # against the exact-match corpus.
     oauth2_settings.ALLOW_URI_WILDCARDS = True
     allowed, _reasons = check_redirect_to_uri_allowed(uri, allowed_uris)
-    assert allowed is redirect_to_uri_allowed(uri, allowed_uris)
+    assert allowed is expected
+    assert redirect_to_uri_allowed(uri, allowed_uris) is expected
 
 
 def test_check_redirect_to_uri_allowed_expects_allowed_uri_list():
@@ -1625,14 +1630,36 @@ class TestRedirectURIMismatchLogging(BaseTestModels):
                 assert not self.application.redirect_uri_allowed("https://example.com/other")
         format_reasons.assert_not_called()
 
-    def test_logged_requested_uri_is_truncated_and_escaped(self):
+    def test_logged_requested_uri_is_escaped(self):
+        # Short enough to survive truncation, so the CRLF really is neutralised by
+        # escaping rather than by being cut off past the truncation point.
+        hostile = "https://example.com/cb?x=1\r\nWARNING forged log line"
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            assert not self.application.redirect_uri_allowed(hostile)
+        message = "\n".join(captured.output)
+        assert "...[truncated]" not in message
+        assert "\r" not in message
+        assert "\\r\\n" in message
+
+    def test_logged_requested_uri_is_truncated(self):
         hostile = "https://example.com/cb?x=" + "a" * 10000 + "\r\nWARNING forged"
         with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
             assert not self.application.redirect_uri_allowed(hostile)
         message = "\n".join(captured.output)
         assert "...[truncated]" in message
-        assert "\r" not in message
         assert "WARNING forged" not in message
+
+    def test_logged_registered_uris_are_escaped_truncated_and_capped(self):
+        # Registered URIs are registrant-supplied under DCR/CIMD, so they get the
+        # same treatment as the requested URI: escaped, truncated, and capped.
+        self.application.redirect_uris = " ".join(
+            ["https://example.com/cb%d" % i for i in range(25)] + ["https://example.com/" + "b" * 10000]
+        )
+        with self.assertLogs("oauth2_provider", level="DEBUG") as captured:
+            assert not self.application.redirect_uri_allowed("https://example.com/nope")
+        message = "\n".join(captured.output)
+        assert "...and 16 further registered URI(s) not listed" in message
+        assert message.count("path differs") == 10
 
     def test_grant_redirect_uri_mismatch_is_logged_without_the_code(self):
         grant = Grant.objects.create(


### PR DESCRIPTION
Fixes #681

## Description of the Change

A mismatching `redirect_uri` surfaces as oauthlib's bare `Mismatching redirect URI.` and nothing else, so the only way to find out *which* component actually differed has been to patch `AbstractApplication.redirect_uri_allowed()` and add prints — which is exactly what the issue reports.

This reports it on the `oauth2_provider` logger at `DEBUG` instead: the requested URI, every registered candidate it was compared against, and which component of each one differed.

```
DEBUG redirect_uri 'https://app.example.com/callback/' does not match any redirect_uri
registered for client_id 'SDbfPCoJIzPeXwPGfMzZ1TIVfjBqvnMYCfSHTPSc':
'https://app.example.com/callback': path differs;
'http://app.example.com/callback/': scheme differs
```

The same detail is emitted for `post_logout_redirect_uri`, and for the token endpoint's comparison against the URI recorded on the grant:

```
DEBUG redirect_uri 'https://app.example.com/callback' does not match the redirect_uri
'https://app.example.com/callback/' recorded on grant #42 at authorization time;
RFC 6749 section 4.1.3 requires them to be identical
```

### The detail stays in the log

The error response is rendered to whoever made the request, so naming the registered URIs there would let an unauthenticated caller enumerate a client's callbacks with nothing but its client ID. The response is left byte-for-byte unchanged, and tests on both the authorization and token endpoints assert that no registered URI (nor the grant's stored URI) reaches the response body or the error URL.

### Logging client-controlled input safely

- The requested URI is truncated at 256 characters — `redirect_uri` is an unbounded `TextField` on `Grant` — so a flood of junk cannot fill the log, and it is rendered with `repr()` so that CR/LF cannot forge log lines. Covered by a test that passes a 10 KB URI carrying an embedded `\r\nWARNING …`.
- Every message is behind `logger.isEnabledFor(DEBUG)`, so nothing is assembled or emitted in a default production configuration. A test patches the formatting helper and asserts it is never called, which fails if that guard is removed.
- The grant's authorization code is never logged alongside its `redirect_uri`, matching the reasoning already recorded on `AbstractGrant.__str__`. Asserted by test.

Enabling `DEBUG` is an explicit operator choice, and the new documentation section says plainly what it means: the registered URIs are printed in full, and the log records that someone attempted a particular callback.

### The matcher itself is untouched

`redirect_to_uri_allowed()` becomes a thin wrapper over a new `check_redirect_to_uri_allowed()`, which returns the same verdict plus the per-candidate reasons. Since this is the code path that RFC 9700 §2.1 exact matching and the RFC 8252 loopback / private-use carve-outs run through, the refactor was verified mechanically rather than by eye: stripping the `reasons.append` bookkeeping and unwrapping the return tuples yields an AST **identical** to the original function. There is also a test asserting the two functions never disagree, run across the existing exact-match and wildcard parameter sets.

### Verification

- Full suite: 1150 passed, 1 skipped
- `ruff format --check` + `ruff check`: clean
- `sphinx-lint` clean; docs build produces no diagnostics beyond those already present on `master`
- `makemigrations --check`: no changes detected (no schema impact)

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [x] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

`tests/app/idp` already configures the `oauth2_provider` logger at `DEBUG` ("log oauth2_provider issues to facilitate troubleshooting"), so the demo IdP prints these messages with no further configuration — no change was needed there. `tests/app/rp` is the client side and is unaffected.