### PR TITLE
feat(templates): serve default styles from a bundled stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now surface the field name alongside the message. A custom `ModelForm` that omits one of
   those fields still gets the message as a non-field error, provided it subclasses
   `oauth2_provider.forms.ApplicationForm`.
+* #730 The templates shipped with the toolkit no longer load Bootstrap 2.3.2 from a
+  third-party CDN. `oauth2_provider/base.html` now links a small stylesheet distributed
+  with the package (`static/oauth2_provider/css/oauth2_provider.css`), which also absorbs
+  the inline `<style>` block that template carried. The built-in pages therefore render in
+  air-gapped installs and under a strict Content Security Policy such as
+  `default-src 'self'`, which blocks a foreign style host and an inline style block alike,
+  and the authorization page no longer makes an unpinned (no Subresource Integrity)
+  third-party request while the user is making a consent decision. The stylesheet is served
+  through `staticfiles`, so run `collectstatic` for the pages to be styled. The Bootstrap 2
+  class names used by the templates are unchanged, and the `css` block of `base.html` is
+  still the supported way to substitute your own styles.
 * The `AccessToken` and `RefreshToken` admins now invalidate tokens through a **"Revoke selected"**
   action instead of raw delete (delete is disabled on those two admins). A raw delete of an access
   token left its bound refresh token behind (`RefreshToken.access_token` is `SET_NULL`) — an orphan

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -456,3 +456,8 @@ by overriding :class:`~oauth2_provider.views.AuthorizationView` (see :ref:`overr
 
 Scope the added origins as narrowly as possible — to the requesting application's redirect
 URIs, as above — rather than relaxing ``form-action`` globally.
+
+The rest of the shipped pages need no CSP exceptions: their styles come from a stylesheet
+served with the package's own static files, so ``style-src 'self'`` is enough — no
+third-party style host and no inline ``<style>``. See :ref:`default-stylesheet` if you
+replace those styles with your own.

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -47,6 +47,42 @@ The blocks defined in it are:
 
     See ` Django docs on template inheritance <https://docs.djangoproject.com/en/dev/ref/templates/language/#template-inheritance>`_ for more information on the use of blocks.
 
+.. _default-stylesheet:
+
+Default stylesheet
+~~~~~~~~~~~~~~~~~~
+
+The ``css`` block loads a small stylesheet that ships with the package, from
+``static/oauth2_provider/css/oauth2_provider.css``::
+
+    {% block css %}
+        <link href="{% static 'oauth2_provider/css/oauth2_provider.css' %}" rel="stylesheet">
+    {% endblock css %}
+
+It is served like any other static file, so run ``collectstatic`` (or serve the app's
+static files some other way) for the built-in pages to be styled. Because nothing is
+fetched from a third-party host and no inline ``<style>`` is used, the shipped pages
+render offline and under a strict Content Security Policy such as
+``default-src 'self'`` (see :ref:`csp-authorization-form`).
+
+To use your own styles — a CSS framework, or your site's stylesheet — override the
+``css`` block::
+
+    {% extends "oauth2_provider/base.html" %}
+    {% load static %}
+
+    {% block css %}
+        <link href="{% static 'my_project/css/oauth2.css' %}" rel="stylesheet">
+    {% endblock css %}
+
+The shipped templates use these class names, which a replacement stylesheet needs to
+cover: ``container``, ``block-center``, ``block-center-heading``, ``unstyled``,
+``control-group`` (plus ``error``), ``control-label``, ``controls``, ``form-horizontal``,
+``input-block-level``, ``help-block``, ``help-inline``, ``btn``, ``btn-large``,
+``btn-primary``, ``btn-danger``, ``btn-success`` and ``btn-toolbar``. They are the
+Bootstrap 2 names the templates have always used, so a Bootstrap-based override keeps
+working.
+
 authorize.html
 --------------
 

--- a/oauth2_provider/static/oauth2_provider/css/oauth2_provider.css
+++ b/oauth2_provider/static/oauth2_provider/css/oauth2_provider.css
@@ -1,0 +1,200 @@
+/*
+ * Default styles for the templates shipped with Django OAuth Toolkit.
+ *
+ * These replace the Bootstrap 2.3.2 stylesheet that ``oauth2_provider/base.html``
+ * used to pull from a third-party CDN, together with the inline ``<style>`` block
+ * that lived in the same template. Both are served from this file so the built-in
+ * pages render without an outbound request (air-gapped installs) and under a strict
+ * Content Security Policy such as ``default-src 'self'``, which blocks a foreign
+ * style host and an inline style block alike.
+ *
+ * The class names are the ones the shipped templates already used, so projects that
+ * override only some of those templates keep a consistent look. To restore Bootstrap
+ * (or any other framework), override the ``css`` block of
+ * ``oauth2_provider/base.html``; see the "Templates" page of the documentation.
+ */
+
+:root {
+    --dot-font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --dot-body-bg: #f5f5f5;
+    --dot-surface-bg: #fff;
+    --dot-text: #333;
+    --dot-muted-text: #6c757d;
+    --dot-border: #e5e5e5;
+    --dot-input-border: #ccc;
+    --dot-error: #b94a48;
+    --dot-link: #0b5ed7;
+    --dot-btn-bg: #f0f0f0;
+    --dot-btn-text: #333;
+    --dot-btn-primary-bg: #0d6efd;
+    --dot-btn-danger-bg: #dc3545;
+    --dot-btn-success-bg: #198754;
+    --dot-btn-inverse-text: #fff;
+    --dot-radius: 5px;
+}
+
+body {
+    margin: 0;
+    padding-top: 40px;
+    padding-bottom: 40px;
+    background-color: var(--dot-body-bg);
+    color: var(--dot-text);
+    font-family: var(--dot-font-family);
+    font-size: 14px;
+    line-height: 1.5;
+}
+
+a {
+    color: var(--dot-link);
+}
+
+.container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+/* Centered card holding the content of every shipped page. */
+.block-center {
+    max-width: 500px;
+    padding: 19px 29px 29px;
+    margin: 0 auto 20px;
+    background-color: var(--dot-surface-bg);
+    border: 1px solid var(--dot-border);
+    border-radius: var(--dot-radius);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.block-center .block-center-heading {
+    margin-top: 0;
+    margin-bottom: 10px;
+}
+
+/* Lists rendered without markers (application detail). */
+.unstyled {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+/* Forms. */
+.control-group {
+    margin-bottom: 15px;
+}
+
+.control-label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: 600;
+}
+
+.form-horizontal .controls,
+.controls {
+    display: block;
+}
+
+input[type="text"],
+input[type="url"],
+input[type="email"],
+input[type="password"],
+input[type="number"],
+select,
+textarea {
+    box-sizing: border-box;
+    padding: 6px 8px;
+    color: var(--dot-text);
+    background-color: var(--dot-surface-bg);
+    border: 1px solid var(--dot-input-border);
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: inherit;
+}
+
+textarea {
+    min-height: 70px;
+}
+
+/* Full-width control, used for the read-only credential fields. */
+.input-block-level {
+    display: block;
+    width: 100%;
+}
+
+.help-block {
+    display: block;
+    margin-top: 5px;
+    color: var(--dot-muted-text);
+}
+
+.help-inline {
+    display: inline-block;
+    margin-top: 5px;
+    color: var(--dot-error);
+}
+
+.control-group.error .control-label,
+.control-group.error .help-inline {
+    color: var(--dot-error);
+}
+
+.control-group.error input,
+.control-group.error select,
+.control-group.error textarea {
+    border-color: var(--dot-error);
+}
+
+/* Buttons. Applied to <a>, <button> and <input type="submit"> alike. */
+.btn {
+    display: inline-block;
+    padding: 6px 12px;
+    margin-bottom: 0;
+    color: var(--dot-btn-text);
+    background-color: var(--dot-btn-bg);
+    border: 1px solid var(--dot-input-border);
+    border-radius: 4px;
+    font-family: inherit;
+    font-size: inherit;
+    line-height: 1.5;
+    text-align: center;
+    text-decoration: none;
+    vertical-align: middle;
+    cursor: pointer;
+}
+
+.btn:hover,
+.btn:focus {
+    filter: brightness(0.95);
+    text-decoration: none;
+}
+
+.btn-large {
+    padding: 9px 16px;
+    font-size: 16px;
+}
+
+.btn-primary,
+.btn-danger,
+.btn-success {
+    color: var(--dot-btn-inverse-text);
+    border-color: transparent;
+}
+
+.btn-primary {
+    background-color: var(--dot-btn-primary-bg);
+}
+
+.btn-danger {
+    background-color: var(--dot-btn-danger-bg);
+}
+
+.btn-success {
+    background-color: var(--dot-btn-success-bg);
+}
+
+/* Row of buttons (application detail). */
+.btn-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 15px;
+}

--- a/oauth2_provider/templates/oauth2_provider/base.html
+++ b/oauth2_provider/templates/oauth2_provider/base.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8">
@@ -8,33 +8,8 @@
     <meta name="author" content="">
 
     {% block css %}
-        <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap-combined.no-icons.min.css" rel="stylesheet">
+        <link href="{% static 'oauth2_provider/css/oauth2_provider.css' %}" rel="stylesheet">
     {% endblock css %}
-
-    <style>
-        body {
-            padding-top: 40px;
-            padding-bottom: 40px;
-            background-color: #f5f5f5;
-        }
-        .block-center {
-            max-width: 500px;
-            padding: 19px 29px 29px;
-            margin: 0 auto 20px;
-            background-color: #fff;
-            border: 1px solid #e5e5e5;
-            -webkit-border-radius: 5px;
-            -moz-border-radius: 5px;
-            border-radius: 5px;
-            -webkit-box-shadow: 0 1px 2px rgba(0,0,0,.05);
-            -moz-box-shadow: 0 1px 2px rgba(0,0,0,.05);
-            box-shadow: 0 1px 2px rgba(0,0,0,.05);
-        }
-        .block-center .block-center-heading {
-            margin-bottom: 10px;
-        }
-
-    </style>
 </head>
 
 <body>

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,72 @@
+"""Tests for the templates and static assets shipped with the toolkit.
+
+The built-in pages must render without pulling assets from a third-party host and
+without inline styles, so they work in air-gapped installs and under a strict
+Content Security Policy (see issue #730).
+"""
+
+import re
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.staticfiles import finders
+from django.template.loader import render_to_string
+from django.urls import reverse
+
+from .common_testing import OAuth2ProviderTestCase as TestCase
+
+
+UserModel = get_user_model()
+
+STYLESHEET = "oauth2_provider/css/oauth2_provider.css"
+
+# Any src/href pointing at another host: an absolute URL, or a protocol-relative one
+# such as the ``//netdna.bootstrapcdn.com/...`` link the base template used to carry.
+EXTERNAL_ASSET_RE = re.compile(r"""(?:href|src)\s*=\s*["'](?:[a-z][a-z0-9+.-]*:)?//""", re.IGNORECASE)
+
+
+class TestBaseTemplate(TestCase):
+    def test_stylesheet_is_served_from_static_files(self):
+        html = render_to_string("oauth2_provider/base.html")
+        self.assertIn(f"/static/{STYLESHEET}", html)
+
+    def test_no_external_assets(self):
+        html = render_to_string("oauth2_provider/base.html")
+        self.assertIsNone(EXTERNAL_ASSET_RE.search(html))
+
+    def test_no_inline_style_block(self):
+        # An inline <style> is blocked by ``style-src 'self'`` just like a foreign
+        # style host is, so the default styles must live in the static file.
+        html = render_to_string("oauth2_provider/base.html")
+        self.assertNotIn("<style", html)
+
+    def test_stylesheet_is_findable_by_staticfiles(self):
+        self.assertIsNotNone(finders.find(STYLESHEET))
+
+    def test_css_block_can_be_overridden(self):
+        # Projects replace the default styles through the ``css`` block; keep that
+        # documented extension point working.
+        from django.template import Context, Template
+
+        html = Template(
+            '{% extends "oauth2_provider/base.html" %}{% block css %}<link href="/mine.css">{% endblock %}'
+        ).render(Context({}))
+        self.assertIn("/mine.css", html)
+        self.assertNotIn(STYLESHEET, html)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class TestRenderedViews(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserModel.objects.create_user("foo_user", "test@example.com", "123456")
+
+    def test_application_list_uses_local_stylesheet(self):
+        self.client.login(username="foo_user", password="123456")
+
+        response = self.client.get(reverse("oauth2_provider:list"))
+
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        self.assertIn(f"/static/{STYLESHEET}", html)
+        self.assertIsNone(EXTERNAL_ASSET_RE.search(html))


### PR DESCRIPTION
Fixes #730

## Description of the Change

`oauth2_provider/base.html` loaded Bootstrap 2.3.2 from a third-party CDN
(`//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/...`) and carried an inline `<style>`
block. A strict Content Security Policy such as `default-src 'self'` blocks both, so every
built-in page — authorization, logout confirmation, device flow, application management —
renders unstyled, and neither works in an air-gapped install. The CDN link also carried no
Subresource Integrity hash, so the consent page depended on an unpinned third-party asset
at the moment the user makes a trust decision.

Both are replaced by `static/oauth2_provider/css/oauth2_provider.css`, distributed with the
package and served through `staticfiles` like the existing `application_form.js`. The
stylesheet covers exactly the Bootstrap 2 class names the shipped templates already use
(`container`, `block-center`, `control-group`/`error`, `help-inline`, `btn` and its
variants, …), so the markup is unchanged and existing template overrides keep their look.
`{% block css %}` remains the supported way to substitute other styles.

Notes for review:

- `{% load static %}` sits on the same line as the doctype so nothing precedes it in the
  rendered output. `{% static %}` resolves through `django.templatetags.static`, which
  falls back to joining `STATIC_URL` when `django.contrib.staticfiles` is not installed —
  no new hard dependency.
- Verified the CSS ships in both the wheel and the sdist (`MANIFEST.in` already had
  `recursive-include oauth2_provider/static *`).
- Rendered the consent, application-form (including the per-field error state added in
  #1343) and application-detail pages in Chromium to check the result.
- Behaviour change worth calling out in review: a project that overrode only sibling
  templates while relying on Bootstrap 2 arriving via the base template will see a visual
  change. This is noted in the CHANGELOG entry.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

`tests/app/idp` and `tests/app/rp` need no changes: the IdP app already renders the shipped
templates, so it exercises the new stylesheet as-is.

---
_Generated by [Claude Code](https://claude.ai/code/session_016u8kPFdPEoiU5M6hdM2DFn)_