### PR TITLE
Make RefreshToken.token_checksum unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- ### Fixed -->
 <!-- ### Security -->
 
+## [unreleased]
+### Added
+* #1816 A system check (`oauth2_provider.W012`) that warns when
+  `REFRESH_TOKEN_REUSE_PROTECTION` is enabled while `ROTATE_REFRESH_TOKEN` is disabled.
+  Replay is detected by recognizing a token a previous rotation superseded, so without
+  rotation the protection never fires — a pairing `docs/settings.rst` already documented but
+  nothing enforced.
+### Fixed
+* #1816 `RefreshToken.token_checksum` is now unique. `AbstractRefreshToken.Meta` declared
+  `unique_together = ("token_checksum", "revoked")`, which enforced nothing: live rows have
+  `revoked IS NULL` and every supported backend treats NULLs as distinct in a unique index,
+  so any number of live refresh tokens could share one token value — while for revoked rows
+  it only forbade two revoked at the identical microsecond. Since a refresh token value is
+  the sole lookup key, duplicates left nothing to say which row a presented token meant.
+  `revoked` leaves the key entirely, so the constraint is a plain unique index enforced
+  identically on every backend, and the multi-row workarounds in `revoke_token` and
+  `validate_refresh_token` collapse into single-row lookups.
+
+  **Run `python manage.py migrate`.** Migration
+  `0023_refreshtoken_unique_token_checksum` deletes refresh tokens that share a token value
+  before applying the constraint, keeping the live row where there is one (so no active
+  client is logged out) and otherwise the most recently created row. Deleting refresh
+  tokens does not cascade into access tokens (`AccessToken.source_refresh_token` is
+  `SET_NULL`). **Swapped refresh token models need their own migration:** the schema
+  operations are skipped for a swapped model and the deduplication deliberately no-ops, so
+  run `makemigrations` for your app and add an equivalent cleanup if your rows may contain
+  duplicates.
+
+  A duplicate can now only arise from a custom `REFRESH_TOKEN_GENERATOR` that returns an
+  already-stored value; `_create_refresh_token` logs that and raises `InvalidGrantError`, so
+  the token endpoint answers `400 invalid_grant` rather than raising a 500.
+
 ## [3.4.1] - 2026-08-21
 
 This release is dominated by **security hardening of redirect URI matching, token revocation and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,10 +172,6 @@ unstyled.
   token table. What gets revoked is unchanged: every live member of the family, and the
   family's access tokens. If you swap in your own refresh token model, run `makemigrations` to
   pick up the index, and if you override `revoke()` override `revoke_family()` to match.
-  Where a family holds two live tokens sharing a checksum -- which `RefreshToken`'s
-  `(token_checksum, revoked)` uniqueness permits but the bulk write cannot express (#1816) --
-  the sweep falls back to revoking row by row, so reuse detection still returns
-  `invalid_grant` rather than raising.
 * #1796 Redirect URIs using an RFC 8252 §7.1 private-use URI scheme can now be registered.
   Such a scheme has no naming authority, so only a single slash follows it
   (`com.example.app:/oauth2redirect`), but `Application.clean()` reassembled every URI with

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -305,6 +305,10 @@ client that keeps replaying the same stale token pays for the sweep on every req
 ``makemigrations`` to pick up that index, and if you override ``revoke()`` override
 ``revoke_family()`` to match, so both paths revoke a token the same way.
 
+This requires ``ROTATE_REFRESH_TOKEN``: replay is detected by recognizing a token that a
+previous rotation superseded, and without rotation nothing ever does. Enabling reuse
+protection while rotation is off raises the ``oauth2_provider.W012`` system check.
+
 More details at https://datatracker.ietf.org/doc/html/draft-ietf-oauth-security-topics-29#name-recommendations
 
 ROTATE_REFRESH_TOKEN

--- a/oauth2_provider/checks.py
+++ b/oauth2_provider/checks.py
@@ -246,3 +246,40 @@ def validate_swapped_model_consistency(app_configs, **kwargs):
         ]
 
     return []
+
+
+@checks.register(checks.Tags.models)
+def validate_refresh_token_configuration(app_configs, **kwargs):
+    """
+    Warn when refresh token reuse protection is enabled without rotation.
+
+    Reuse protection detects a replay by recognizing a refresh token that a *previous*
+    rotation superseded. With ``ROTATE_REFRESH_TOKEN`` disabled nothing ever supersedes a
+    refresh token -- the same value is handed back on every refresh -- so a replayed token
+    is indistinguishable from a legitimate use and the family is never revoked. RFC 9700
+    section 4.14.2 likewise defines replay detection in terms of rotation (or
+    sender-constrained tokens), and ``docs/settings.rst`` already documents the pairing;
+    this check enforces it.
+
+    Unlike the RFC 9700 behavior gates in ``validate_bcp_configuration`` this is an
+    internal-consistency check -- the combination does not do what it says on any setting
+    of the compliance gates -- so it is always on rather than ``--deploy``-only.
+    """
+    if oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION and not oauth2_settings.ROTATE_REFRESH_TOKEN:
+        return [
+            checks.Warning(
+                "OAUTH2_PROVIDER['REFRESH_TOKEN_REUSE_PROTECTION'] is enabled but "
+                "OAUTH2_PROVIDER['ROTATE_REFRESH_TOKEN'] is disabled, so refresh token "
+                "replay cannot be detected.",
+                hint=(
+                    "Set OAUTH2_PROVIDER['ROTATE_REFRESH_TOKEN'] = True so each refresh "
+                    "supersedes the previous token and a replay of it is recognizable, or "
+                    "set OAUTH2_PROVIDER['REFRESH_TOKEN_REUSE_PROTECTION'] = False to stop "
+                    "claiming a protection that is not in effect. See RFC 9700 section "
+                    "4.14.2."
+                ),
+                id="oauth2_provider.W012",
+            )
+        ]
+
+    return []

--- a/oauth2_provider/migrations/0023_refreshtoken_unique_token_checksum.py
+++ b/oauth2_provider/migrations/0023_refreshtoken_unique_token_checksum.py
@@ -1,0 +1,77 @@
+from django.db import migrations, models
+
+import oauth2_provider.models
+from oauth2_provider.settings import oauth2_settings
+
+
+BATCH_SIZE = 1000
+
+
+def delete_duplicate_checksums(apps, schema_editor):
+    """
+    Drop duplicate refresh tokens so ``token_checksum`` can be made unique.
+
+    The old ``unique_together`` of (token_checksum, revoked) enforced nothing -- NULLs are
+    distinct in a unique index on every backend the toolkit supports -- so deployments may
+    hold several rows sharing one token value. They cannot all survive a unique column, and
+    a revoked duplicate cannot be kept the way the live/revoked split previously allowed, so
+    the extras are deleted.
+
+    The survivor is the live row when there is one, so an active client is never logged out;
+    otherwise it is the most recently created row. Deleting refresh tokens does not cascade
+    into access tokens: ``AccessToken.source_refresh_token`` is ``SET_NULL``, and
+    ``RefreshToken.access_token`` is the forward side of its own relation.
+    """
+    RefreshToken = apps.get_model(oauth2_settings.REFRESH_TOKEN_MODEL)
+    if RefreshToken._meta.label_lower != "oauth2_provider.refreshtoken":
+        # The refresh token model is swapped out. The schema operations in this migration
+        # are skipped for swapped models, so the swapped app has to deduplicate and add the
+        # constraint in its own migration (see CHANGELOG).
+        return
+    db_alias = schema_editor.connection.alias
+    manager = RefreshToken._default_manager.using(db_alias)
+
+    duplicated = (
+        manager.values("token_checksum")
+        .annotate(row_count=models.Count("pk"))
+        .filter(row_count__gt=1)
+        .values_list("token_checksum", flat=True)
+    )
+    # Bounded by the number of *duplicated* values rather than the table size, and read in
+    # one pass so the aggregate is not re-run for every batch of deletions.
+    checksums = list(duplicated)
+    for start in range(0, len(checksums), BATCH_SIZE):
+        doomed = []
+        for checksum in checksums[start : start + BATCH_SIZE]:
+            rows = list(manager.filter(token_checksum=checksum).values_list("pk", "revoked", "created"))
+            # Live first (``revoked is None``), then most recently created, then highest pk.
+            # Sorted in Python rather than with order_by so the NULL-ordering of the
+            # ``revoked`` column does not vary by backend.
+            survivor = max(rows, key=lambda row: (row[1] is None, row[2], row[0]))[0]
+            doomed.extend(pk for pk, _revoked, _created in rows if pk != survivor)
+        if doomed:
+            manager.filter(pk__in=doomed).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("oauth2_provider", "0022_refreshtoken_token_family_index"),
+        migrations.swappable_dependency(oauth2_settings.REFRESH_TOKEN_MODEL),
+    ]
+
+    operations = [
+        # Drop the old key before deduplicating: (token_checksum, revoked) would otherwise
+        # still be in force while rows are removed.
+        migrations.AlterUniqueTogether(
+            name="refreshtoken",
+            unique_together=set(),
+        ),
+        migrations.RunPython(delete_duplicate_checksums, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="refreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(
+                db_index=True, max_length=64, unique=True, verbose_name="token checksum"
+            ),
+        ),
+    ]

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -14,7 +14,7 @@ from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.hashers import identify_hasher, make_password
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.db import IntegrityError, models, router, transaction
+from django.db import models, router, transaction
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -814,8 +814,9 @@ class AbstractRefreshToken(models.Model):
         :meth:`revoke` -- refresh token, then access token -- so a concurrent rotation in
         the family cannot deadlock against the sweep.
 
-        Falls back to revoking row by row if the bulk write hits the uniqueness of
-        ``(token_checksum, revoked)``; see the handler below and #1816.
+        One ``timezone.now()`` is stamped across the whole family. That is safe because
+        ``token_checksum`` is unique on its own: two live members cannot share a checksum,
+        so the shared timestamp has no uniqueness to collide with (#1816).
         """
         if not token_family:
             return
@@ -823,34 +824,21 @@ class AbstractRefreshToken(models.Model):
         access_token_model = get_access_token_model()
         access_token_database = router.db_for_write(access_token_model)
 
-        try:
-            with transaction.atomic(using=access_token_database):
-                now = timezone.now()
-                # ``updated`` is ``auto_now``, which a queryset update does not trigger.
-                cls.objects.filter(token_family=token_family, revoked__isnull=True).update(
-                    revoked=now, updated=now
-                )
-                # Deleting is what ``AccessToken.revoke()`` does, and ``access_token`` is
-                # ``SET_NULL``, so this clears the pointer on the rows revoked above as well.
-                # The family is re-read rather than snapshotted before the update, so a member
-                # rotated in concurrently loses its access token too and is left an orphan,
-                # which ``validate_refresh_token`` rejects. Sub-selecting through the forward
-                # FK avoids the reverse accessor, whose name a swapped model may change.
-                access_token_model.objects.filter(
-                    pk__in=cls.objects.filter(token_family=token_family).values("access_token_id")
-                ).delete()
-        except IntegrityError:
-            # Uniqueness is ``(token_checksum, revoked)``, so one shared timestamp cannot
-            # cover two live members holding the same checksum -- a state the constraint
-            # ought to forbid outright but does not, since NULLs compare distinct and live
-            # rows have ``revoked`` NULL (#1816). Reuse detection must not raise on the way
-            # to ``invalid_grant``, so fall back to the pre-#1809 sweep, which gives every
-            # row its own ``timezone.now()``. This costs a locking SELECT per family member
-            # again, but only for a family that is already in a state it cannot reach by
-            # rotating: the ``revoke()`` per row is the whole point of the fallback.
-            # Delete once #1816 takes ``revoked`` out of the unique key.
-            for related_rt in cls.objects.filter(token_family=token_family):
-                related_rt.revoke()
+        with transaction.atomic(using=access_token_database):
+            now = timezone.now()
+            # ``updated`` is ``auto_now``, which a queryset update does not trigger.
+            cls.objects.filter(token_family=token_family, revoked__isnull=True).update(
+                revoked=now, updated=now
+            )
+            # Deleting is what ``AccessToken.revoke()`` does, and ``access_token`` is
+            # ``SET_NULL``, so this clears the pointer on the rows revoked above as well.
+            # The family is re-read rather than snapshotted before the update, so a member
+            # rotated in concurrently loses its access token too and is left an orphan,
+            # which ``validate_refresh_token`` rejects. Sub-selecting through the forward
+            # FK avoids the reverse accessor, whose name a swapped model may change.
+            access_token_model.objects.filter(
+                pk__in=cls.objects.filter(token_family=token_family).values("access_token_id")
+            ).delete()
 
     def revoke(self):
         """

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -764,9 +764,17 @@ class AbstractRefreshToken(models.Model):
         verbose_name=_("user"),
     )
     token = models.TextField(verbose_name=_("token"))
+    # Unique across every row, live or revoked -- not scoped to the live ones. A refresh
+    # token value is a bearer credential and is the sole lookup key
+    # (``validate_refresh_token``), so two rows sharing one value leave nothing to say
+    # which row a presented token means. Rotation always mints a fresh value, and a
+    # non-rotating refresh leaves the existing row in place instead of inserting a second
+    # one, so a collision here points at a broken REFRESH_TOKEN_GENERATOR.
     token_checksum = TokenChecksumField(
         max_length=64,
         blank=False,
+        unique=True,
+        db_index=True,
         verbose_name=_("token checksum"),
     )
     application = models.ForeignKey(
@@ -873,10 +881,6 @@ class AbstractRefreshToken(models.Model):
 
     class Meta:
         abstract = True
-        unique_together = (
-            "token_checksum",
-            "revoked",
-        )
         indexes = [
             # ``revoke_family()`` filters on ``token_family`` on the ``/token/`` path,
             # and without an index that is a scan of the whole refresh token table.

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -17,8 +17,7 @@ import requests
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.hashers import check_password, identify_hasher
-from django.db import router, transaction
-from django.db.models import F
+from django.db import IntegrityError, router, transaction
 from django.http import HttpRequest
 from django.utils import dateformat, timezone
 from django.utils.crypto import constant_time_compare
@@ -1133,7 +1132,29 @@ class OAuth2Validator(RequestValidator):
             resource=getattr(request, "resource", []),  # RFC 8707
         )
         self._set_token_value(refresh_token, refresh_token_code)
-        refresh_token.save()
+        try:
+            refresh_token.save()
+        except IntegrityError as exc:
+            # The row collided with one already stored -- in practice on the unique
+            # ``token_checksum``, since rotation always mints a fresh value and a
+            # non-rotating refresh leaves the existing row in place, so a duplicate points
+            # at a REFRESH_TOKEN_GENERATOR that returns predictable or repeated values.
+            # (The one-to-one ``access_token`` can also collide, if a concurrent rotation
+            # claimed it between the lookup in ``_save_bearer_token`` and this insert.)
+            #
+            # Either way the grant cannot be completed, so fail it rather than letting the
+            # IntegrityError surface as a 500: it propagates out of ``save_bearer_token``'s
+            # atomic block, rolling it back, and ``OAuthLibCore.create_token_response``
+            # renders it as an error response. Nothing is queried in between -- on
+            # PostgreSQL the transaction is already poisoned and any query would raise
+            # TransactionManagementError -- so the cause is reported, not narrowed.
+            log.error(
+                "Refusing to issue a refresh token: it collides with a token already "
+                "stored (%s). If this recurs, check that REFRESH_TOKEN_GENERATOR returns "
+                "unpredictable, unique values.",
+                exc,
+            )
+            raise errors.InvalidGrantError(request=request) from exc
         return refresh_token
 
     def revoke_token(self, token, token_type_hint, request, *args, **kwargs):
@@ -1168,8 +1189,7 @@ class OAuth2Validator(RequestValidator):
         if application_pk is None:
             return
 
-        # RefreshToken uniqueness is (token_checksum, revoked), so several rows may share a
-        # checksum; revoke every match instead of get() to avoid MultipleObjectsReturned.
+        # ``token_checksum`` is unique on both token models, so this matches at most one row.
         lookup = {"token_checksum": token_checksum, "application_id": application_pk}
         tokens = list(token_type.objects.filter(**lookup))
         if not tokens:
@@ -1245,14 +1265,7 @@ class OAuth2Validator(RequestValidator):
         """
 
         token_checksum = hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
-        # Several rows may share a checksum (uniqueness is (token_checksum, revoked)):
-        # prefer the unrevoked row, otherwise the most recently revoked one.
-        rt = (
-            RefreshToken.objects.filter(token_checksum=token_checksum)
-            .select_related("access_token")
-            .order_by(F("revoked").desc(nulls_first=True))
-            .first()
-        )
+        rt = RefreshToken.objects.filter(token_checksum=token_checksum).select_related("access_token").first()
 
         if not rt:
             return False

--- a/tests/migrations/0019_refreshtoken_unique_token_checksum.py
+++ b/tests/migrations/0019_refreshtoken_unique_token_checksum.py
@@ -1,0 +1,33 @@
+import oauth2_provider.models
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tests", "0018_refreshtoken_token_family_index"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="custompkrefreshtoken",
+            unique_together=set(),
+        ),
+        migrations.AlterUniqueTogether(
+            name="samplerefreshtoken",
+            unique_together=set(),
+        ),
+        migrations.AlterField(
+            model_name="custompkrefreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(
+                db_index=True, max_length=64, unique=True, verbose_name="token checksum"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="samplerefreshtoken",
+            name="token_checksum",
+            field=oauth2_provider.models.TokenChecksumField(
+                db_index=True, max_length=64, unique=True, verbose_name="token checksum"
+            ),
+        ),
+    ]

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -1240,6 +1240,23 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         self.oauth2_settings.ROTATE_REFRESH_TOKEN = False
         self._assert_revoked_refresh_token_is_not_honored()
 
+    def test_refresh_token_generator_collision_is_invalid_grant(self):
+        # ``token_checksum`` is unique, so a generator that returns an already-stored value
+        # cannot mint a second row. That must surface as a failed grant, not a 500 (#1816).
+        self.client.login(username="test_user", password="123456")
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+        self.oauth2_settings.REFRESH_TOKEN_GENERATOR = lambda request: "a-constant-refresh-token"
+        content = self._issue_token_pair(auth_headers)
+        self.assertEqual(content["refresh_token"], "a-constant-refresh-token")
+
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={"grant_type": "refresh_token", "refresh_token": content["refresh_token"]},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content.decode("utf-8"))["error"], "invalid_grant")
+
     def test_refresh_invalidates_old_tokens(self):
         """
         Ensure existing refresh tokens are cleaned up when issuing new ones

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -4,7 +4,11 @@ from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import override_settings
 
-from oauth2_provider.checks import validate_swapped_model_consistency, validate_token_configuration
+from oauth2_provider.checks import (
+    validate_refresh_token_configuration,
+    validate_swapped_model_consistency,
+    validate_token_configuration,
+)
 
 from .common_testing import OAuth2ProviderTestCase as TestCase
 
@@ -68,3 +72,40 @@ class SwappedModelConsistencyCheckTestCase(TestCase):
         self.oauth2_settings.ACCESS_TOKEN_MODEL = "app_a.AccessToken"
         self.oauth2_settings.REFRESH_TOKEN_MODEL = "app_b.RefreshToken"
         self.assertIn("oauth2_provider.W011", self._ids())
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class RefreshTokenConfigurationCheckTestCase(TestCase):
+    def _ids(self):
+        return {m.id for m in validate_refresh_token_configuration(None)}
+
+    def test_check_is_registered(self):
+        from django.core.checks.registry import registry as checks_registry
+
+        self.assertIn(
+            validate_refresh_token_configuration,
+            checks_registry.get_checks(include_deployment_checks=True),
+        )
+
+    def test_defaults_pass(self):
+        # ROTATE_REFRESH_TOKEN defaults to True and reuse protection to False.
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_reuse_protection_with_rotation_passes(self):
+        self.oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION = True
+        self.oauth2_settings.ROTATE_REFRESH_TOKEN = True
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_rotation_off_without_reuse_protection_passes(self):
+        # Non-rotating refresh tokens are legitimate for confidential clients
+        # (RFC 6749 section 6); only the combination with reuse protection is incoherent.
+        self.oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION = False
+        self.oauth2_settings.ROTATE_REFRESH_TOKEN = False
+        self.assertNotIn("oauth2_provider.W012", self._ids())
+
+    def test_reuse_protection_without_rotation_warns(self):
+        self.oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION = True
+        self.oauth2_settings.ROTATE_REFRESH_TOKEN = False
+        messages = validate_refresh_token_configuration(None)
+        self.assertEqual([m.id for m in messages], ["oauth2_provider.W012"])
+        self.assertIsInstance(messages[0], checks.Warning)

--- a/tests/test_migration_0023_dedupe.py
+++ b/tests/test_migration_0023_dedupe.py
@@ -1,0 +1,172 @@
+"""Tests for ``0023_refreshtoken_unique_token_checksum``'s duplicate cleanup (#1816).
+
+The old ``unique_together`` of (token_checksum, revoked) enforced nothing, so existing
+installs may hold several refresh tokens sharing one value. Making ``token_checksum``
+unique means the extras have to go, and which row survives is the part that matters: a
+live row is a credential some client is still using, so it must never lose to a revoked
+one.
+
+Each test provisions a throwaway sqlite database on its own alias, exactly as
+``test_migration_db_alias.py`` does, so nothing here touches the shared test databases.
+"""
+
+import hashlib
+from datetime import timedelta
+
+import pytest
+from django.db import IntegrityError, connections
+from django.db.migrations.executor import MigrationExecutor
+from django.utils import timezone
+
+
+ALIAS = "migration_0023"
+BEFORE = ("oauth2_provider", "0022_refreshtoken_token_family_index")
+AFTER = ("oauth2_provider", "0023_refreshtoken_unique_token_checksum")
+
+
+@pytest.fixture
+def alias(db, settings, tmp_path):
+    settings.DATABASE_ROUTERS = []
+    connections.databases[ALIAS] = {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": str(tmp_path / "dot-migration-0023.sqlite3"),
+        "ATOMIC_REQUESTS": False,
+        "AUTOCOMMIT": True,
+        "CONN_MAX_AGE": 0,
+        "CONN_HEALTH_CHECKS": False,
+        "OPTIONS": {},
+        "TIME_ZONE": None,
+        "USER": "",
+        "PASSWORD": "",
+        "HOST": "",
+        "PORT": "",
+        "TEST": {"CHARSET": None, "COLLATION": None, "MIGRATE": True, "MIRROR": None, "NAME": None},
+    }
+    connection = None
+    try:
+        connection = connections[ALIAS]
+        del connections.databases[ALIAS]
+        yield ALIAS
+    finally:
+        connections.databases.pop(ALIAS, None)
+        if connection is not None:
+            connection.close()
+            del connections[ALIAS]
+
+
+def _migrate_to(target):
+    executor = MigrationExecutor(connections[ALIAS])
+    executor.migrate([target])
+    return executor.loader.project_state([target]).apps
+
+
+def _seed(apps):
+    User = apps.get_model("auth", "User")
+    Application = apps.get_model("oauth2_provider", "Application")
+    user = User.objects.using(ALIAS).create(username="migration-user")
+    application = Application.objects.using(ALIAS).create(
+        name="migration-test-client",
+        client_type="confidential",
+        authorization_grant_type="client-credentials",
+        client_secret="plain-secret",
+    )
+    return user, application
+
+
+def _make_refresh_token(apps, user, application, token, revoked=None, created=None):
+    RefreshToken = apps.get_model("oauth2_provider", "RefreshToken")
+    refresh_token = RefreshToken.objects.using(ALIAS).create(
+        user=user,
+        application=application,
+        token=token,
+        token_checksum=hashlib.sha256(token.encode("utf-8")).hexdigest(),
+        revoked=revoked,
+    )
+    if created is not None:
+        # ``created`` is auto_now_add, so it has to be forced after the insert.
+        RefreshToken.objects.using(ALIAS).filter(pk=refresh_token.pk).update(created=created)
+        refresh_token.created = created
+    return refresh_token
+
+
+def test_live_row_survives_against_revoked_duplicates(alias):
+    apps_before = _migrate_to(BEFORE)
+    user, application = _seed(apps_before)
+    now = timezone.now()
+
+    # The live row is deliberately the *oldest*, so "newest wins" alone would drop it.
+    live = _make_refresh_token(apps_before, user, application, "dup", created=now - timedelta(days=3))
+    revoked_old = _make_refresh_token(
+        apps_before,
+        user,
+        application,
+        "dup",
+        revoked=now - timedelta(days=2),
+        created=now - timedelta(days=2),
+    )
+    revoked_new = _make_refresh_token(
+        apps_before,
+        user,
+        application,
+        "dup",
+        revoked=now - timedelta(days=1),
+        created=now - timedelta(days=1),
+    )
+
+    apps_after = _migrate_to(AFTER)
+    RefreshToken = apps_after.get_model("oauth2_provider", "RefreshToken")
+    surviving = list(RefreshToken.objects.using(alias).values_list("pk", flat=True))
+
+    assert surviving == [live.pk]
+    assert not RefreshToken.objects.using(alias).filter(pk__in=[revoked_old.pk, revoked_new.pk]).exists()
+
+
+def test_newest_row_survives_when_none_are_live(alias):
+    apps_before = _migrate_to(BEFORE)
+    user, application = _seed(apps_before)
+    now = timezone.now()
+
+    older = _make_refresh_token(
+        apps_before,
+        user,
+        application,
+        "dup",
+        revoked=now - timedelta(days=2),
+        created=now - timedelta(days=2),
+    )
+    newer = _make_refresh_token(
+        apps_before,
+        user,
+        application,
+        "dup",
+        revoked=now - timedelta(days=1),
+        created=now - timedelta(days=1),
+    )
+
+    apps_after = _migrate_to(AFTER)
+    RefreshToken = apps_after.get_model("oauth2_provider", "RefreshToken")
+
+    assert list(RefreshToken.objects.using(alias).values_list("pk", flat=True)) == [newer.pk]
+    assert not RefreshToken.objects.using(alias).filter(pk=older.pk).exists()
+
+
+def test_distinct_tokens_are_left_alone_and_the_column_becomes_unique(alias):
+    apps_before = _migrate_to(BEFORE)
+    user, application = _seed(apps_before)
+
+    keep_a = _make_refresh_token(apps_before, user, application, "one")
+    keep_b = _make_refresh_token(apps_before, user, application, "two", revoked=timezone.now())
+
+    apps_after = _migrate_to(AFTER)
+    RefreshToken = apps_after.get_model("oauth2_provider", "RefreshToken")
+
+    assert set(RefreshToken.objects.using(alias).values_list("pk", flat=True)) == {keep_a.pk, keep_b.pk}
+
+    # The constraint is now in force, revoked rows included. Re-fetch the related rows
+    # through the post-migration state: model classes are per-state and not interchangeable.
+    user_after = apps_after.get_model("auth", "User").objects.using(ALIAS).get(pk=user.pk)
+    application_after = (
+        apps_after.get_model("oauth2_provider", "Application").objects.using(ALIAS).get(pk=application.pk)
+    )
+    with pytest.raises(IntegrityError):
+        _make_refresh_token(apps_after, user_after, application_after, "two")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -532,49 +532,6 @@ class TestRefreshTokenModel(BaseTestModels):
         self.assertIsNone(no_family.revoked)
         self.assertIsNotNone(no_family.access_token_id)
 
-    def test_revoke_family_falls_back_when_two_live_members_share_a_checksum(self):
-        """
-        Uniqueness is (token_checksum, revoked), so the bulk update cannot stamp one
-        timestamp across two live members holding the same checksum. No request path mints
-        that state today -- rotation draws a fresh token every time, and #1818 closed the
-        non-rotating re-issue that used to resurrect a revoked token as a live row with the
-        same value -- but the schema still permits it (#1816), so a custom
-        REFRESH_TOKEN_GENERATOR, a data migration or a direct write can leave a family in
-        it. Reuse detection is a security path and must not raise on the way to
-        invalid_grant, so fall back to the pre-#1809 per-row sweep instead.
-        """
-        family = uuid.uuid4()
-        first = self._make_refresh_token(family)
-        first_access_token_pk = first.access_token_id
-        second = RefreshToken.objects.create(
-            user=self.user,
-            token=first.token,
-            application=self.app,
-            access_token=AccessToken.objects.create(
-                user=self.user,
-                token=f"access token for {secrets.token_urlsafe(8)}",
-                application=self.app,
-                expires=timezone.now() + timedelta(hours=1),
-                scope="read write",
-            ),
-            token_family=family,
-        )
-        second_access_token_pk = second.access_token_id
-        self.assertEqual(first.token_checksum, second.token_checksum)
-
-        RefreshToken.revoke_family(family)
-
-        for member in (first, second):
-            member.refresh_from_db()
-            self.assertIsNotNone(member.revoked, "every live member must still be revoked")
-            self.assertIsNone(member.access_token_id)
-        # The per-row fallback gives each row its own timezone.now(), which is what keeps
-        # the two rows apart under the constraint.
-        self.assertNotEqual(first.revoked, second.revoked)
-        self.assertFalse(
-            AccessToken.objects.filter(pk__in=[first_access_token_pk, second_access_token_pk]).exists()
-        )
-
     def test_revoke_family_query_count_does_not_grow_with_the_family(self):
         """
         The whole point of the set-based sweep: a family that has been rotating for weeks

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import check_password, make_password
 from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.db import connection
+from django.db import IntegrityError, connection
 from django.db import models as django_models
 from django.test.utils import CaptureQueriesContext, override_settings
 from django.utils import timezone
@@ -441,7 +441,18 @@ class TestRefreshTokenModel(BaseTestModels):
             hashlib.sha256(token.encode()).hexdigest(),
         )
 
-    def test_same_token_allowed_with_different_revoked_timestamps(self):
+    def test_duplicate_token_rejected_against_a_live_row(self):
+        # A refresh token value is the sole lookup key, so a second row carrying it -- live
+        # or revoked -- would leave nothing to say which row a presented token means.
+        token = secrets.token_urlsafe(32)
+        RefreshToken.objects.create(user=self.user, token=token, application=self.app)
+
+        with self.assertRaises(IntegrityError):
+            RefreshToken.objects.create(user=self.user, token=token, application=self.app)
+
+    def test_duplicate_token_rejected_against_a_revoked_row(self):
+        # Revoking does not free the value for re-insertion: ``revoked`` is not part of the
+        # key, so the uniqueness holds across the whole table (see #1816).
         token = secrets.token_urlsafe(32)
         RefreshToken.objects.create(
             user=self.user,
@@ -449,14 +460,9 @@ class TestRefreshTokenModel(BaseTestModels):
             application=self.app,
             revoked=timezone.now(),
         )
-        active = RefreshToken.objects.create(
-            user=self.user,
-            token=token,
-            application=self.app,
-        )
 
-        self.assertIsNone(active.revoked)
-        self.assertEqual(RefreshToken.objects.filter(token_checksum=active.token_checksum).count(), 2)
+        with self.assertRaises(IntegrityError):
+            RefreshToken.objects.create(user=self.user, token=token, application=self.app)
 
     def _make_refresh_token(self, token_family, revoked=None, with_access_token=True):
         access_token = None

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -415,33 +415,6 @@ class TestOAuth2Validator(TransactionTestCase):
         refresh_token.refresh_from_db()
         self.assertIsNotNone(refresh_token.revoked)
 
-    def test_validate_refresh_token_prefers_unrevoked_row_over_revoked_duplicate(self):
-        # (token_checksum, revoked) uniqueness allows the same token value to exist
-        # as both a revoked row and an active row; validation must pick the active one.
-        token = "duplicate-refresh-token"
-        RefreshToken.objects.create(
-            user=self.user,
-            token=token,
-            application=self.application,
-            revoked=timezone.now() - datetime.timedelta(days=1),
-        )
-        access_token = AccessToken.objects.create(
-            user=self.user,
-            token="dup-active-access-token",
-            application=self.application,
-            expires=timezone.now() + datetime.timedelta(days=1),
-        )
-        RefreshToken.objects.create(
-            user=self.user,
-            token=token,
-            application=self.application,
-            access_token=access_token,
-        )
-        request = mock.MagicMock(wraps=Request)
-
-        self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
-        self.assertIsNone(request.refresh_token_instance.revoked)
-
     def test_validate_refresh_token_rejects_revoked_token_that_was_not_superseded(self):
         # A token revoked deliberately (/revoke/, the admin, RP-initiated logout) was never
         # consumed to mint a successor access token, so the grace window must not shield it:
@@ -577,27 +550,6 @@ class TestOAuth2Validator(TransactionTestCase):
         )
         request = mock.MagicMock(wraps=Request)
         self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
-
-    def test_revoke_token_with_duplicate_refresh_token_checksums(self):
-        token = "duplicate-refresh-token"
-        RefreshToken.objects.create(
-            user=self.user,
-            token=token,
-            application=self.application,
-            revoked=timezone.now() - datetime.timedelta(days=1),
-        )
-        active_token = RefreshToken.objects.create(
-            user=self.user,
-            token=token,
-            application=self.application,
-        )
-
-        request = mock.MagicMock(wraps=Request)
-        request.client = self.application
-        self.validator.revoke_token(token, "refresh_token", request)
-
-        active_token.refresh_from_db()
-        self.assertIsNotNone(active_token.revoked)
 
     def test_validate_refresh_token_invalid_expire_seconds_raises(self):
         # A non-numeric REFRESH_TOKEN_EXPIRE_SECONDS is a misconfiguration. Validation
@@ -754,7 +706,11 @@ class TestOAuth2Validator(TransactionTestCase):
         self.assertEqual(1, RefreshToken.objects.count())
         self.assertEqual(1, AccessToken.objects.count())
 
-    def test_save_bearer_token__with_new_token_equal_to_existing_token__revokes_old_tokens(self):
+    def test_save_bearer_token__with_new_token_equal_to_existing_token__fails_the_grant(self):
+        # Rotation mints a fresh value and a non-rotating refresh reuses the existing row,
+        # so a rotated token that collides with a stored one means REFRESH_TOKEN_GENERATOR
+        # is broken. That is a failed grant, not a 500 -- and the atomic block around
+        # save_bearer_token rolls back, so the old pair is left untouched (#1816).
         access_token = AccessToken.objects.create(
             token="123",
             user=self.user,
@@ -772,13 +728,19 @@ class TestOAuth2Validator(TransactionTestCase):
             "refresh_token": "abc",
             "access_token": "123",
         }
+        # A real oauthlib Request: InvalidGrantError reads redirect_uri/client_id/state off
+        # it to build the error response, which the class-wrapping MagicMock cannot supply.
+        request = Request("/token", http_method="POST")
+        request.user = self.user
+        request.client = self.application
+        request.refresh_token_instance = refresh_token
 
+        with self.assertRaises(rfc6749_errors.InvalidGrantError):
+            self.validator.save_bearer_token(token, request)
+
+        refresh_token.refresh_from_db()
+        self.assertIsNone(refresh_token.revoked)
         self.assertEqual(1, RefreshToken.objects.count())
-        self.assertEqual(1, AccessToken.objects.count())
-
-        self.validator.save_bearer_token(token, self.request)
-
-        self.assertEqual(1, RefreshToken.objects.filter(revoked__isnull=True).count())
         self.assertEqual(1, AccessToken.objects.count())
 
     def test_save_bearer_token__with_no_refresh_token__creates_new_access_token_only(self):


### PR DESCRIPTION
Fixes #1816

Rebased onto `master` at `db6c4f5` (3.4.1). The security half — revoked refresh tokens honored inside the grace window — was split out as #1818 and shipped in 3.4.1; this is the remaining schema change, and it also takes the follow-up cleanup that #1810 asked for.

Two commits:

1. **`fix(models): make RefreshToken.token_checksum unique`**
2. **`refactor(models): drop revoke_family's per-row fallback`** — #1810's `IntegrityError` handler, whose commit message says to delete it *"once #1816 takes revoked out of the unique key"*.

## Description of the Change

`AbstractRefreshToken.Meta` declared:

```python
unique_together = ("token_checksum", "revoked")
```

which enforced nothing. Live rows have `revoked IS NULL`, and every backend the toolkit supports treats NULLs as distinct in a unique index, so any number of **live** refresh tokens could share one token value. For revoked rows it only forbade two revoked at the identical microsecond. A refresh token value is the sole lookup key in `validate_refresh_token`, so duplicates left nothing to say which row a presented token means — `order_by(...).first()` picked a winner arbitrarily, and `request.user` came from whichever row won.

With #1818 shipped, a revoked token is no longer honored and re-issued, so `_create_refresh_token` can never receive a value that is already stored: rotation always mints a fresh one, and a non-rotating refresh leaves the existing row in place. Duplicates become unreachable, `revoked` leaves the key entirely, and `token_checksum` becomes plainly unique — matching `AccessToken.token_checksum`, which has been `unique=True` since #1447.

A plain unique index also sidesteps the partial-index question the issue raised. `UniqueConstraint(fields=["token_checksum"], condition=Q(revoked__isnull=True))` would be enforced on PostgreSQL and SQLite but silently create nothing on MySQL and Oracle, plus a `models.W036` for every one of those users. (`Meta.required_db_features` is not a way out — `Options.can_migrate()` consults it, so migrations would skip creating the whole `RefreshToken` **table** on MySQL.) The unique column is enforced identically everywhere.

`revoke_token` and `validate_refresh_token` collapse from multi-row handling into single-row lookups.

### `revoke_family()` fallback removed

`revoke_family()` stamps one `timezone.now()` across every live member of a family. Under the old key that timestamp could not cover two live members sharing a checksum, so #1810 caught the `IntegrityError` and fell back to the pre-#1809 per-row sweep. With `token_checksum` unique on its own, two live members cannot share one and the shared timestamp has no uniqueness left to collide with, so the handler is unreachable. `test_revoke_family_falls_back_when_two_live_members_share_a_checksum` goes with it — it does not merely go dead, it fails here, since it sets up two live rows carrying the same token. #1810's changelog sentence describing the fallback is dropped too.

### Migration

`0023_refreshtoken_unique_token_checksum` (renumbered past #1810's `0022_refreshtoken_token_family_index`) drops the old key, deletes refresh tokens sharing a token value, then applies the constraint. Revoked duplicates cannot survive a unique column, so they are deleted rather than revoked.

**Survivor per checksum: the live row where there is one, otherwise the most recently created.** A live row is a credential some client is still using, so it must never lose to a revoked one. Deleting refresh tokens does not cascade into access tokens — `AccessToken.source_refresh_token` is `on_delete=SET_NULL` — and `clear_expired` already deletes revoked refresh tokens routinely.

Schema operations are skipped for a swapped refresh token model and the deduplication deliberately no-ops there, so **a swapped model needs its own migration**; called out in the CHANGELOG. The test app's equivalent is `tests/migrations/0019_refreshtoken_unique_token_checksum.py`.

### Error handling

A duplicate can now only come from a custom `REFRESH_TOKEN_GENERATOR` returning an already-stored value. `_create_refresh_token` logs that and raises `InvalidGrantError`, so the token endpoint answers `400 invalid_grant` rather than a 500: it propagates out of `save_bearer_token`'s `transaction.atomic` (rolling it back), through oauthlib's `save_token` call — which sits outside `RefreshTokenGrant.create_token_response`'s own `try` — to `OAuthLibCore.create_token_response`. Nothing is queried between the catch and the raise, so PostgreSQL's poisoned transaction cannot turn it into a `TransactionManagementError`.

### New system check

`oauth2_provider.W012` warns when `REFRESH_TOKEN_REUSE_PROTECTION` is enabled while `ROTATE_REFRESH_TOKEN` is disabled. Replay is detected by recognizing a token a previous rotation superseded, so without rotation the protection never fires. `docs/settings.rst` already documented the pairing; nothing enforced it.

## Testing

Locally on SQLite: full suite and `multi_db_settings` (1169 passed), `makemigrations --check` under `tests.settings` and `tests.mig_settings` (one leaf per app — this is the guard that catches a renumber mistake), the swapped-model migrate scenario applying `0022 → 0023` and `tests.0018 → tests.0019` in order, ruff, docs build and sphinx-lint.

**Not verified locally:** the PostgreSQL and MySQL cells — no docker daemon in the environment. MySQL is the one worth watching, since it is the backend the plain unique index was chosen for and CI is the first real run of `AlterUniqueTogether` → `AlterField` there. The migration path itself is covered against a real file-backed SQLite database in `tests/test_migration_0023_dedupe.py`.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

<sub>No idp/rp demo changes: this is a schema constraint, with no new behavior to demonstrate.</sub>