### PR TITLE
Stop honoring revoked refresh tokens inside the grace window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turning into a server error.
 
 ### Security
+* #1816 A refresh token that was **deliberately revoked** is no longer honored inside
+  `REFRESH_TOKEN_GRACE_PERIOD_SECONDS`. The grace window exists to shield the token a
+  client retries when it did not receive the rotated response, but `revoked` records both
+  that supersession *and* a deliberate revocation (the RFC 7009 `/revoke/` endpoint,
+  `AuthorizedTokenDeleteView`, the admin, RP-initiated logout, revoking the bound access
+  token), and validation could not tell them apart. A revoked token was therefore usable
+  for the length of the window, contrary to
+  [RFC 7009 §2.1](https://datatracker.ietf.org/doc/html/rfc7009#section-2.1) ("the
+  invalidation takes place immediately, and the token cannot be used again after the
+  revocation"). With `ROTATE_REFRESH_TOKEN = False` it was additionally re-issued as a new
+  live row carrying the same token value, bringing the repudiated credential back to life
+  in the database. The two are now distinguished by whether the token was ever consumed to
+  mint a successor access token. A genuine rotation retry inside the window is unaffected,
+  and deployments on the default `REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 0` were never
+  exposed.
+
+  This generalizes a test that previously applied only when
+  `REFRESH_TOKEN_REUSE_PROTECTION` was enabled, so it is also a behavior change with reuse
+  protection off: a superseded token whose successor access token has since been deleted is
+  now rejected inside the window rather than accepted.
 * Redirect URIs are now matched exactly, as
   [RFC 9700 §2.1](https://datatracker.ietf.org/doc/html/rfc9700#section-2.1) requires
   ("authorization servers MUST utilize exact string matching except for port numbers in

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -276,10 +276,16 @@ The ``cleartokens`` management command removes revoked refresh tokens once the
 grace period has passed, unless ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled.
 Check :ref:`cleartokens` management command for further info.
 
-When ``REFRESH_TOKEN_REUSE_PROTECTION`` is enabled the grace period applies only to
-the *immediately preceding* refresh token (the token a client retries when it did not
-receive the rotated response). A token that has already been rotated past is rejected
-as a reuse even within the grace window — see ``REFRESH_TOKEN_REUSE_PROTECTION`` below.
+The grace period only ever shields a refresh token that a rotation *superseded* — the
+token a client retries when it did not receive the rotated response. A refresh token that
+was deliberately revoked (through the ``/revoke/`` endpoint, the admin, RP-initiated
+logout, or by revoking its access token) is rejected immediately, whatever the grace
+period: :rfc:`7009#section-2.1` requires that a revoked token "cannot be used again after
+the revocation". The same applies to a token that has already been rotated past — see
+``REFRESH_TOKEN_REUSE_PROTECTION`` below.
+
+With ``ROTATE_REFRESH_TOKEN`` disabled nothing supersedes a refresh token, so the grace
+period has no effect: the same token stays valid until it is revoked or expires.
 
 REFRESH_TOKEN_REUSE_PROTECTION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -1261,18 +1261,21 @@ class OAuth2Validator(RequestValidator):
             grace_expired = rt.revoked <= timezone.now() - timedelta(
                 seconds=oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS
             )
-            # With reuse protection the grace period must only shield the
-            # *immediately preceding* refresh token -- a client that retried
-            # because it did not receive the rotated token. That token still owns
-            # the access token it minted; once the chain rotates again that access
-            # token is revoked (deleted), so its absence marks a stale token being
-            # replayed several generations down the chain. Honoring such a token
-            # within the grace window would defeat reuse protection (#1617).
-            stale_replay = (
-                oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION
-                and not AccessToken.objects.filter(source_refresh_token=rt).exists()
-            )
-            if grace_expired or stale_replay:
+            # The grace window exists only to shield the *immediately preceding* refresh
+            # token -- a client that retried because it did not receive the rotated
+            # response. Rotation records that supersession in the same ``revoked`` column
+            # as a deliberate revocation (the RFC 7009 /revoke/ endpoint, the admin,
+            # RP-initiated logout, ``revoke_access_token``), so the two are told apart by
+            # whether this token was ever consumed to mint a successor access token.
+            #
+            # A token that was repudiated rather than superseded was never consumed, and
+            # must never be honored again: "the invalidation takes place immediately, and
+            # the token cannot be used again after the revocation" (RFC 7009 section 2.1).
+            # The same test also rejects a token replayed several generations down a
+            # rotated chain, whose access token a later rotation has since revoked
+            # (deleted) -- honoring that would defeat reuse protection (#1617).
+            superseded = AccessToken.objects.filter(source_refresh_token=rt).exists()
+            if grace_expired or not superseded:
                 if oauth2_settings.REFRESH_TOKEN_REUSE_PROTECTION and rt.token_family:
                     rt_token_family = RefreshToken.objects.filter(token_family=rt.token_family)
                     for related_rt in rt_token_family.all():

--- a/tests/test_authorization_code.py
+++ b/tests/test_authorization_code.py
@@ -1189,6 +1189,55 @@ class TestAuthorizationCodeTokenView(BaseAuthorizationCodeTokenView):
         self.assertTrue("refresh_token" in content)
         self.assertEqual(content["refresh_token"], first_refresh_token)
 
+    def _issue_token_pair(self, auth_headers):
+        """Run the authorization code flow and return the token endpoint's response body."""
+        authorization_code = self.get_auth()
+        token_request_data = {
+            "grant_type": "authorization_code",
+            "code": authorization_code,
+            "redirect_uri": "http://example.org",
+        }
+        response = self.client.post(reverse("oauth2_provider:token"), data=token_request_data, **auth_headers)
+        self.assertEqual(response.status_code, 200)
+        return json.loads(response.content.decode("utf-8"))
+
+    def _assert_revoked_refresh_token_is_not_honored(self):
+        # A refresh token killed through the RFC 7009 endpoint must stay dead even inside
+        # the grace window: "the token cannot be used again after the revocation"
+        # (RFC 7009 section 2.1). The window exists for a rotation retry, and a revoked
+        # token was never superseded by one (#1816).
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 120
+        self.client.login(username="test_user", password="123456")
+        auth_headers = get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET)
+        content = self._issue_token_pair(auth_headers)
+        refresh_token = content["refresh_token"]
+
+        response = self.client.post(
+            reverse("oauth2_provider:revoke-token"),
+            data={"token": refresh_token, "token_type_hint": "refresh_token"},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post(
+            reverse("oauth2_provider:token"),
+            data={"grant_type": "refresh_token", "refresh_token": refresh_token},
+            **auth_headers,
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(json.loads(response.content.decode("utf-8"))["error"], "invalid_grant")
+        # ...and it was not resurrected as a fresh live row carrying the same value.
+        checksum = hashlib.sha256(refresh_token.encode("utf-8")).hexdigest()
+        self.assertFalse(RefreshToken.objects.filter(token_checksum=checksum, revoked__isnull=True).exists())
+
+    def test_revoked_refresh_token_not_honored_in_grace_period_with_rotation(self):
+        self.oauth2_settings.ROTATE_REFRESH_TOKEN = True
+        self._assert_revoked_refresh_token_is_not_honored()
+
+    def test_revoked_refresh_token_not_honored_in_grace_period_without_rotation(self):
+        self.oauth2_settings.ROTATE_REFRESH_TOKEN = False
+        self._assert_revoked_refresh_token_is_not_honored()
+
     def test_refresh_invalidates_old_tokens(self):
         """
         Ensure existing refresh tokens are cleaned up when issuing new ones

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -442,6 +442,45 @@ class TestOAuth2Validator(TransactionTestCase):
         self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
         self.assertIsNone(request.refresh_token_instance.revoked)
 
+    def test_validate_refresh_token_rejects_revoked_token_that_was_not_superseded(self):
+        # A token revoked deliberately (/revoke/, the admin, RP-initiated logout) was never
+        # consumed to mint a successor access token, so the grace window must not shield it:
+        # "the token cannot be used again after the revocation" (RFC 7009 section 2.1).
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 120
+        token = "repudiated-refresh-token"
+        RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            revoked=timezone.now(),
+        )
+        request = mock.MagicMock(wraps=Request)
+
+        self.assertFalse(self.validator.validate_refresh_token(token, self.application, request))
+
+    def test_validate_refresh_token_accepts_revoked_token_superseded_by_rotation(self):
+        # The counterpart: a token the rotation superseded still owns the access token it
+        # minted, which is what the grace window exists to shield -- a client that retried
+        # because it never received the rotated response.
+        self.oauth2_settings.REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 120
+        token = "superseded-refresh-token"
+        refresh_token = RefreshToken.objects.create(
+            user=self.user,
+            token=token,
+            application=self.application,
+            revoked=timezone.now(),
+        )
+        AccessToken.objects.create(
+            user=self.user,
+            token="superseded-successor-access-token",
+            application=self.application,
+            expires=timezone.now() + datetime.timedelta(days=1),
+            source_refresh_token=refresh_token,
+        )
+        request = mock.MagicMock(wraps=Request)
+
+        self.assertTrue(self.validator.validate_refresh_token(token, self.application, request))
+
     def test_validate_refresh_token_rejects_orphan_without_access_token(self):
         # A non-revoked refresh token whose access token was deleted out of band is an
         # orphan (access_token is SET_NULL). There is nothing left to refresh against, so


### PR DESCRIPTION
Refs #1816

Split out of #1817 so the security fix can ship in 3.4.1 without the schema change. #1817 is now stacked on this branch and carries only the uniqueness work.

## Description of the Change

`RefreshToken.revoked` records two different states, and `validate_refresh_token` could not tell them apart:

1. **superseded by rotation** — `_save_bearer_token` revokes the old token at `oauth2_validators.py:1017` as part of rotating. Replaced, not repudiated. Retrying it is exactly what the grace window is for: a client that never received the rotated response.
2. **repudiated** — the RFC 7009 `/revoke/` endpoint, `AuthorizedTokenDeleteView`, the admin, RP-initiated logout, `revoke_access_token`.

Both land in the same column, so the grace window honored both. A deliberately revoked refresh token was usable for the length of `REFRESH_TOKEN_GRACE_PERIOD_SECONDS`, contrary to RFC 7009 §2.1:

> the authorization server invalidates the token. The invalidation takes place immediately, and the token cannot be used again after the revocation.

With `ROTATE_REFRESH_TOKEN = False` it went further. oauthlib hands back the presented value verbatim on that path, so `_create_refresh_token` re-issued the repudiated token as a new **live** row carrying the same value — the credential came back to life in the database. Note that with rotation off, state (1) cannot arise at all: the reuse branch never revokes, and reaching the `else` with a live row requires a NULL `access_token`, which validation already rejects as an orphan. So every revoked non-rotating refresh token is a repudiated one.

### The fix

Tell the two apart by whether the token was ever consumed to mint a successor access token — a superseded one was, a repudiated one never was. That is the test `stale_replay` already made; it just had a `REFRESH_TOKEN_REUSE_PROTECTION` gate on it, which comes off. How a token came to be revoked has nothing to do with reuse protection, which still decides only whether the family is revoked as well.

```python
superseded = AccessToken.objects.filter(source_refresh_token=rt).exists()
if grace_expired or not superseded:
```

Keeping it as a condition on the existing `if` rather than an early `return False` preserves the family revocation below it.

### Scope of the behavior change

* A genuine rotation retry inside the window is unaffected — the existing grace-period tests cover this and are untouched.
* Deployments on the default `REFRESH_TOKEN_GRACE_PERIOD_SECONDS = 0` were never exposed.
* Dropping the reuse-protection gate widens this slightly: with reuse protection **off**, a superseded token whose successor access token has since been deleted is now rejected inside the window rather than accepted. That deletion only happens through revocation (deliberate) or `clear_expired` on an expired token, so there should be no legitimate case inside a window measured in seconds — but it is a real change and the changelog says so.

### Not rotating is still fine

To be explicit, since this touches the non-rotating path: handing back the same refresh token is in spec. RFC 6749 §6 — *"The authorization server MAY issue a new refresh token"* — and RFC 9700 §4.14.2 requires rotation or sender-constraining only *"for public clients"*, noting confidential clients are already covered by RFC 6749's client binding. Only re-using a **revoked** token is out of spec.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

<sub>No idp/rp demo changes: this removes an unintended behavior rather than adding one to demonstrate.</sub>

---
_Generated by [Claude Code](https://claude.ai/code/session_01QThcriGPwqEruXT85Kag3z)_