### PR TITLE
fix: enforce device grant confirmation ownership

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,7 @@ jobs:
     name: DOT SQLite (Python ${{ matrix.python-version }}, Django ${{ matrix.django-version }})
     runs-on: ubuntu-latest
     permissions:
+      contents: read # An explicit permissions block drops the defaults; checkout on a private repo needs this
       id-token: write # Required for Codecov OIDC token
     strategy:
       fail-fast: false

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -249,4 +249,9 @@ class DeviceGrantStatusView(LoginRequiredMixin, DetailView):
 
     def get_object(self):
         client_id, user_code = self.kwargs.get("client_id"), self.kwargs.get("user_code")
-        return get_object_or_404(self.get_queryset(), client_id=client_id, user_code=user_code)
+        return get_object_or_404(
+            self.get_queryset(),
+            client_id=client_id,
+            user_code=user_code,
+            user=self.request.user,
+        )

--- a/oauth2_provider/views/device.py
+++ b/oauth2_provider/views/device.py
@@ -182,6 +182,7 @@ class DeviceConfirmView(LoginRequiredMixin, FormView):
                 client_id=client_id,
                 user_code=user_code,
                 status=model.AUTHORIZATION_PENDING,
+                user=self.request.user,
             )
         return self._device_grant
 

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -381,7 +381,7 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
         The /token View returning the appropriate message for the "denied" state is covered
         in test_token_view_returns_error_if_device_in_invalid_state.
         """
-        UserModel.objects.create_user(
+        user = UserModel.objects.create_user(
             username="test_user_device_flow",
             email="test_device@example.com",
             password="password123",
@@ -395,6 +395,7 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
             scope="scope",
             expires=datetime.now() + timedelta(days=1),
             status=DeviceModel.AUTHORIZATION_PENDING,
+            user=user,
         )
         device.save()
 
@@ -421,7 +422,7 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
         This test asserts that the confirm view returns 400 if action is not
         "accept" or "deny".
         """
-        UserModel.objects.create_user(
+        user = UserModel.objects.create_user(
             username="test_user_device_flow",
             email="test_device@example.com",
             password="password123",
@@ -435,6 +436,7 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
             scope="scope",
             expires=datetime.now() + timedelta(days=1),
             status=DeviceModel.AUTHORIZATION_PENDING,
+            user=user,
         )
         device.save()
 
@@ -445,6 +447,41 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
         response = self.client.post(device_confirm_url, data={"action": "inccorect_action"})
 
         assert response.status_code == 400
+
+    def test_device_confirm_view_rejects_different_authenticated_user(self):
+        """
+        A user must not be able to approve or deny a device grant that was
+        associated with another user during the user-code step.
+        """
+        UserModel.objects.create_user(
+            username="attacker",
+            email="attacker@example.com",
+            password="password123",
+        )
+        self.client.login(username="attacker", password="password123")
+
+        device = DeviceModel.objects.create(
+            client_id=self.application.client_id,
+            device_code="device_code",
+            user_code="user_code",
+            scope="scope",
+            expires=datetime.now() + timedelta(days=1),
+            status=DeviceModel.AUTHORIZATION_PENDING,
+            user=self.test_user,
+        )
+        device_confirm_url = reverse(
+            "oauth2_provider:device-confirm",
+            kwargs={"user_code": device.user_code, "client_id": device.client_id},
+        )
+
+        get_response = self.client.get(device_confirm_url)
+        assert get_response.status_code == 404
+
+        post_response = self.client.post(device_confirm_url, data={"action": "accept"})
+        assert post_response.status_code == 404
+
+        device.refresh_from_db()
+        assert device.status == DeviceModel.AUTHORIZATION_PENDING
 
     def test_device_flow_authorization_device_invalid_state_returns_form_error(self):
         """

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -451,7 +451,8 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
     def test_device_confirm_view_rejects_different_authenticated_user(self):
         """
         A user must not be able to approve or deny a device grant that was
-        associated with another user during the user-code step.
+        associated with another user during the user-code step, nor view its
+        status.
         """
         UserModel.objects.create_user(
             username="attacker",
@@ -479,6 +480,13 @@ class TestDeviceFlow(DeviceFlowBaseTestCase):
 
         post_response = self.client.post(device_confirm_url, data={"action": "accept"})
         assert post_response.status_code == 404
+
+        device_grant_status_url = reverse(
+            "oauth2_provider:device-grant-status",
+            kwargs={"user_code": device.user_code, "client_id": device.client_id},
+        )
+        status_response = self.client.get(device_grant_status_url)
+        assert status_response.status_code == 404
 
         device.refresh_from_db()
         assert device.status == DeviceModel.AUTHORIZATION_PENDING


### PR DESCRIPTION
Fixes GHSA-cfrv-vfcq-245m

## Description of the Change

Require the authenticated confirmation user to own the pending device grant. This prevents one authenticated account from approving or denying a grant that was associated with another account during the user-code step.

Adds regression coverage for both GET and POST access by a different authenticated user and verifies that the grant remains pending. Existing direct-confirmation fixtures now explicitly model the grant owner used by the documented device flow.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated (existing documentation already describes one user entering and confirming the code)
- [ ] CHANGELOG.md updated (deferred to coordinated security release notes)
- [ ] author name in AUTHORS (not applicable)
- [ ] tests/app/idp updated to demonstrate new features (not applicable to a security regression)
- [ ] tests/app/rp updated to demonstrate new features (not applicable to a security regression)

## Verification

- uv run pytest tests/test_device.py -q (29 passed)
- uv run --extra dev ruff format --check oauth2_provider/views/device.py tests/test_device.py
- uv run --extra dev ruff check oauth2_provider/views/device.py tests/test_device.py

