### PR TITLE
feat(views): reject non form-encoded request bodies behind a setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`RESOURCE_SERVER_INTROSPECTION_JWT_*` settings), Dynamic Client Registration support for both methods with
   `jwks`/`jwks_uri` metadata, and `*_auth_signing_alg_values_supported` advertisement in the discovery documents.
   Note that `client_secret_jwt` requires the client secret to be stored unhashed (it is the HMAC key), like HS256.
+* #657 `REQUIRE_FORM_ENCODED_REQUEST_BODY`, an opt-in setting that makes the endpoints that take the
+  parameters comprising the request in an `application/x-www-form-urlencoded` body -- token
+  (RFC 6749 §4.1.3, §4.3.2, §4.4.2 and §6), revocation (RFC 7009 §2.1), introspection
+  (RFC 7662 §2.1), device authorization (RFC 8628 §3.1) and PAR (RFC 9126 §2.1) -- answer
+  `415 Unsupported Media Type` to a POST sent with any other media type, instead of reaching the
+  view with no parameters at all and reporting a misleading error about a parameter the client did
+  send (a JSON token request is currently rejected as `unsupported_grant_type`). Defaults to
+  `False`, so nothing changes until you opt in; note that turning it on also rejects
+  `multipart/form-data` bodies, which no specification permits here but Django parses into
+  `request.POST` -- including from Django's own test client, whose `client.post(url, data={...})`
+  sends multipart unless a `content_type` is passed. Combining it with the deprecated
+  `JSONOAuthLibCore` backend rejects every request before the backend can parse it, which a new
+  system check (`oauth2_provider.E006`) reports.
 * #1816 A system check (`oauth2_provider.W012`) that warns when
   `REFRESH_TOKEN_REUSE_PROTECTION` is enabled while `ROTATE_REFRESH_TOKEN` is disabled.
   Replay is detected by recognizing a token a previous rotation superseded, so without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conventions are documented in `docs/package_layout.rst` (and summarized for agents in `AGENTS.md`).
 
 ### Deprecated
+* #657 The `False` default of the new `REQUIRE_FORM_ENCODED_REQUEST_BODY` setting, which is scheduled
+  to become `True` in 4.0. Until then a POST body that is not `application/x-www-form-urlencoded` still
+  reaches the token, revocation, introspection, device-authorization and PAR endpoints, but each one
+  emits a `DeprecationWarning` and an `oauth2_provider` logger warning naming the coming HTTP 415.
+  Compliant requests emit nothing, so a deployment whose clients already send form-encoded bodies stays
+  quiet and the default flip will be a no-op for it. Note that Django's test client sends
+  `multipart/form-data` for `client.post(url, data={...})`, so a test suite that posts to these
+  endpoints that way is a likely source of the warnings and will need a `content_type` before 4.0.
 * Several modules moved into role-based subpackages (see Changed below). The old top-level import paths
   still work but now emit a `DeprecationWarning` and will be removed in 4.0. Update imports as follows:
   `oauth2_provider.{compat,exceptions,http,scopes,signals,utils,checks,bcp}` →

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -459,6 +459,14 @@ requirement of `RFC 6750 section 2.2
 the access token *in the body*, not a constraint on the endpoint. Your own protected resources
 are likewise untouched.
 
+.. deprecated:: 3.5
+    The ``False`` default is deprecated and is scheduled to become ``True`` in 4.0. Until then
+    a non-compliant body is still passed through, but every one emits a ``DeprecationWarning``
+    and an ``oauth2_provider`` logger warning naming the change to come. Nothing is emitted for
+    a compliant request, so a deployment whose clients already send form-encoded bodies stays
+    quiet -- and for it the coming default flip is a no-op. Set the setting to ``True`` to adopt
+    the behavior now and silence the warnings.
+
 The default is ``False`` because turning enforcement on rejects two kinds of request that
 previously worked:
 
@@ -468,6 +476,8 @@ previously worked:
 * ``multipart/form-data`` bodies. No specification permits them here, but Django parses them
   into ``request.POST`` so they have always worked -- including from Django's own test client,
   whose ``client.post(url, data={...})`` sends multipart unless a ``content_type`` is passed.
+  If your test suite posts to these endpoints that way, it is the source of the warnings, and
+  it will need a ``content_type`` before 4.0.
 
 While enforcement is off, a request sent with any other media type reaches the view with no
 parameters at all (Django only populates ``request.POST`` for form-encoded and multipart

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -71,6 +71,8 @@ deprecated.)
     ``application/x-www-form-urlencoded`` (RFC 6749, RFC 7662, RFC 7009). The JSON mode is
     non-standard and breaks interoperability with spec-compliant clients; every client can
     send a form-encoded body, so it provides no capability that the default backend lacks.
+    Set `REQUIRE_FORM_ENCODED_REQUEST_BODY`_ to reject the non-standard bodies outright
+    rather than misreporting them as a missing parameter.
 
 EXTRA_SERVER_KWARGS
 ~~~~~~~~~~~~~~~~~~~
@@ -428,6 +430,49 @@ According to `OAuth 2.0 Security Best Current Practice <https://oauth.net/2/oaut
 
 - Public clients MUST use PKCE `RFC7636 <https://datatracker.ietf.org/doc/html/rfc7636>`_
 - For confidential clients, the use of PKCE `RFC7636 <https://datatracker.ietf.org/doc/html/rfc7636>`_ is RECOMMENDED.
+
+REQUIRE_FORM_ENCODED_REQUEST_BODY
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Default: ``False``
+
+When ``True``, a POST to an endpoint that takes the parameters making up the request in an
+``application/x-www-form-urlencoded`` body is answered with ``415 Unsupported Media Type`` and an
+``invalid_request`` error unless it is sent with that media type. It covers the token
+(:rfc:`4.1.3`, :rfc:`4.3.2`, :rfc:`4.4.2` and :rfc:`6`), revocation (`RFC 7009 section 2.1
+<https://datatracker.ietf.org/doc/html/rfc7009#section-2.1>`_), introspection
+(`RFC 7662 section 2.1 <https://datatracker.ietf.org/doc/html/rfc7662#section-2.1>`_), device
+authorization (`RFC 8628 section 3.1
+<https://datatracker.ietf.org/doc/html/rfc8628#section-3.1>`_) and pushed authorization request
+(`RFC 9126 section 2.1 <https://datatracker.ietf.org/doc/html/rfc9126#section-2.1>`_) endpoints.
+
+Media type parameters are ignored, so ``application/x-www-form-urlencoded; charset=UTF-8`` is
+accepted. ``GET`` requests are never affected: the introspection endpoint, the only covered one
+that accepts a ``GET``, takes its parameters from the query string there.
+
+Some endpoints are deliberately *not* covered. Dynamic Client Registration takes
+``application/json`` bodies per `RFC 7591 <https://datatracker.ietf.org/doc/html/rfc7591>`_. The
+OpenID Connect UserInfo endpoint accepts a POST whose only credential is the ``Authorization``
+header (`OpenID Connect Core section 5.3.1
+<https://openid.net/specs/openid-connect-core-1_0.html#UserInfo>`_); the form-encoding
+requirement of `RFC 6750 section 2.2
+<https://datatracker.ietf.org/doc/html/rfc6750#section-2.2>`_ is a condition on a client putting
+the access token *in the body*, not a constraint on the endpoint. Your own protected resources
+are likewise untouched.
+
+The default is ``False`` because turning enforcement on rejects two kinds of request that
+previously worked:
+
+* ``application/json`` bodies, read by the deprecated ``JSONOAuthLibCore`` value of
+  `OAUTH2_BACKEND_CLASS`_. Combining that backend with this setting rejects every request
+  before the backend can parse it, so ``manage.py check`` raises ``oauth2_provider.E006``.
+* ``multipart/form-data`` bodies. No specification permits them here, but Django parses them
+  into ``request.POST`` so they have always worked -- including from Django's own test client,
+  whose ``client.post(url, data={...})`` sends multipart unless a ``content_type`` is passed.
+
+While enforcement is off, a request sent with any other media type reaches the view with no
+parameters at all (Django only populates ``request.POST`` for form-encoded and multipart
+bodies), which surfaces as a misleading error about a parameter the client did send -- a JSON
+token request, for instance, is rejected as ``unsupported_grant_type``.
 
 PAR_ENABLED
 ~~~~~~~~~~~

--- a/oauth2_provider/authorization_server/views/base.py
+++ b/oauth2_provider/authorization_server/views/base.py
@@ -26,6 +26,7 @@ from oauth2_provider.core.exceptions import FatalClientError, OAuthToolkitError
 from oauth2_provider.core.http import OAuth2ResponseRedirect
 from oauth2_provider.core.scopes import get_scopes_backend
 from oauth2_provider.core.signals import app_authorized
+from oauth2_provider.core.views import FormEncodedRequestMixin
 from oauth2_provider.models import get_access_token_model, get_application_model, get_device_grant_model
 from oauth2_provider.resource_server.validators import is_valid_resource_uri
 from oauth2_provider.settings import oauth2_settings
@@ -536,7 +537,7 @@ class AuthorizationView(BaseAuthorizationView, FormView):
 
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
-class TokenView(AuthorizationServerViewMixin, View):
+class TokenView(FormEncodedRequestMixin, AuthorizationServerViewMixin, View):
     """
     Implements an endpoint to provide access tokens
 
@@ -546,6 +547,8 @@ class TokenView(AuthorizationServerViewMixin, View):
     * Client credentials
     * Device code flow (specifically for the device polling stage)
     """
+
+    form_encoded_endpoint = "The OAuth 2.0 token endpoint (RFC 6749 section 3.2)"
 
     @method_decorator(sensitive_post_parameters("password", "client_secret"))
     def authorization_flow_token_response(
@@ -630,10 +633,12 @@ class TokenView(AuthorizationServerViewMixin, View):
 
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
-class RevokeTokenView(AuthorizationServerViewMixin, View):
+class RevokeTokenView(FormEncodedRequestMixin, AuthorizationServerViewMixin, View):
     """
     Implements an endpoint to revoke access or refresh tokens
     """
+
+    form_encoded_endpoint = "The OAuth 2.0 token revocation endpoint (RFC 7009 section 2.1)"
 
     def post(self, request, *args, **kwargs):
         url, headers, body, status = self.create_revocation_response(request)

--- a/oauth2_provider/authorization_server/views/device.py
+++ b/oauth2_provider/authorization_server/views/device.py
@@ -15,6 +15,7 @@ from oauthlib.oauth2 import DeviceApplicationServer
 from oauth2_provider.authorization_server.views.mixins import AuthorizationServerViewMixin
 from oauth2_provider.core.compat import login_not_required
 from oauth2_provider.core.scopes import get_scopes_backend
+from oauth2_provider.core.views import FormEncodedRequestMixin
 from oauth2_provider.models import (
     AbstractDeviceGrant,
     DeviceCodeResponse,
@@ -27,8 +28,9 @@ from oauth2_provider.models import (
 
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
-class DeviceAuthorizationView(AuthorizationServerViewMixin, View):
+class DeviceAuthorizationView(FormEncodedRequestMixin, AuthorizationServerViewMixin, View):
     server_class = DeviceApplicationServer
+    form_encoded_endpoint = "The OAuth 2.0 device authorization endpoint (RFC 8628 section 3.1)"
 
     def post(self, request, *args, **kwargs):
         headers, response, status = self.create_device_authorization_response(request)

--- a/oauth2_provider/authorization_server/views/introspect.py
+++ b/oauth2_provider/authorization_server/views/introspect.py
@@ -7,13 +7,14 @@ from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
 
 from oauth2_provider.core.compat import login_not_required
+from oauth2_provider.core.views import FormEncodedRequestMixin
 from oauth2_provider.models import get_access_token_model
 from oauth2_provider.resource_server.views.generic import ClientProtectedScopedResourceView
 
 
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
-class IntrospectTokenView(ClientProtectedScopedResourceView):
+class IntrospectTokenView(FormEncodedRequestMixin, ClientProtectedScopedResourceView):
     """
     Implements an endpoint for token introspection based
     on RFC 7662 https://rfc-editor.org/rfc/rfc7662.html
@@ -23,6 +24,7 @@ class IntrospectTokenView(ClientProtectedScopedResourceView):
     """
 
     required_scopes = ["introspection"]
+    form_encoded_endpoint = "The OAuth 2.0 token introspection endpoint (RFC 7662 section 2.1)"
 
     @staticmethod
     def get_token_response(token_value=None):

--- a/oauth2_provider/authorization_server/views/par.py
+++ b/oauth2_provider/authorization_server/views/par.py
@@ -8,12 +8,13 @@ from oauth2_provider.authorization_server import par
 from oauth2_provider.authorization_server.views.mixins import AuthorizationServerViewMixin
 from oauth2_provider.core.compat import login_not_required
 from oauth2_provider.core.exceptions import OAuthToolkitError
+from oauth2_provider.core.views import FormEncodedRequestMixin
 from oauth2_provider.settings import oauth2_settings
 
 
 @method_decorator(csrf_exempt, name="dispatch")
 @method_decorator(login_not_required, name="dispatch")
-class PushedAuthorizationRequestView(AuthorizationServerViewMixin, View):
+class PushedAuthorizationRequestView(FormEncodedRequestMixin, AuthorizationServerViewMixin, View):
     """
     Implements the Pushed Authorization Request (PAR) endpoint as defined in
     :rfc:`9126`.
@@ -29,6 +30,7 @@ class PushedAuthorizationRequestView(AuthorizationServerViewMixin, View):
 
     # POST-only: the base View returns 405 for any other method (RFC 9126 §2.3).
     http_method_names = ["post"]
+    form_encoded_endpoint = "The OAuth 2.0 pushed authorization request endpoint (RFC 9126 section 2.1)"
 
     def dispatch(self, request, *args, **kwargs):
         if not oauth2_settings.PAR_ENABLED:

--- a/oauth2_provider/core/checks.py
+++ b/oauth2_provider/core/checks.py
@@ -2,6 +2,7 @@ from django.apps import apps
 from django.core import checks
 from django.db import router
 
+from oauth2_provider.core.backends_oauthlib import JSONOAuthLibCore
 from oauth2_provider.settings import oauth2_settings
 
 
@@ -176,6 +177,44 @@ def validate_bcp_configuration(app_configs, **kwargs):
         )
 
     return messages
+
+
+@checks.register(checks.Tags.security)
+def validate_request_body_configuration(app_configs, **kwargs):
+    """
+    Flag a request-body configuration that rejects every request it is set up to parse.
+
+    ``REQUIRE_FORM_ENCODED_REQUEST_BODY`` makes the token, revocation, introspection,
+    device-authorization and PAR endpoints answer 415 to any POST that is not
+    ``application/x-www-form-urlencoded``, while the deprecated ``JSONOAuthLibCore``
+    backend exists solely to read ``application/json`` bodies on those same endpoints.
+    Combined, the gate rejects the request before the backend ever sees it, so *every*
+    JSON request fails and the backend parses nothing -- always a misconfiguration
+    rather than a deliberate posture.
+
+    Unlike the RFC 9700 gates this is an internal-consistency check, so it is always on
+    rather than ``--deploy``-only.
+    """
+    if not oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY:
+        return []
+    # OAUTH2_BACKEND_CLASS is an import-string setting, so this is the resolved class.
+    if not issubclass(oauth2_settings.OAUTH2_BACKEND_CLASS, JSONOAuthLibCore):
+        return []
+    return [
+        checks.Error(
+            "OAUTH2_PROVIDER['REQUIRE_FORM_ENCODED_REQUEST_BODY'] is True while "
+            "OAUTH2_PROVIDER['OAUTH2_BACKEND_CLASS'] reads application/json request "
+            "bodies, so every request the backend is configured to parse is rejected "
+            "with HTTP 415 before it reaches the backend.",
+            hint=(
+                "Remove the OAUTH2_BACKEND_CLASS override (the default "
+                "'oauth2_provider.core.backends_oauthlib.OAuthLibCore' reads form-encoded "
+                "bodies) and have clients send application/x-www-form-urlencoded request "
+                "bodies, or set REQUIRE_FORM_ENCODED_REQUEST_BODY = False."
+            ),
+            id="oauth2_provider.E006",
+        )
+    ]
 
 
 # Registered under the ``models`` tag rather than ``database``: this check only asks the

--- a/oauth2_provider/core/views.py
+++ b/oauth2_provider/core/views.py
@@ -1,4 +1,4 @@
-"""Shared view mixin.
+"""Shared view mixins.
 
 ``OAuthLibCoreMixin`` holds the oauthlib configuration and core-construction
 machinery common to the authorization-server and resource-server view layers.
@@ -7,9 +7,87 @@ The role-specific behavior lives in
 (building authorization/token/revocation/userinfo responses) and
 :class:`oauth2_provider.resource_server.mixins.ResourceServerViewMixin`
 (verifying protected-resource requests).
+
+``FormEncodedRequestMixin`` implements the ``REQUIRE_FORM_ENCODED_REQUEST_BODY``
+gate for the endpoints whose request bodies the specifications define as
+``application/x-www-form-urlencoded``.
 """
 
+from django.http import HttpRequest, HttpResponse, JsonResponse
+
 from oauth2_provider.settings import oauth2_settings
+
+
+FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
+
+
+class FormEncodedRequestMixin:
+    """
+    Reject POST bodies that are not ``application/x-www-form-urlencoded``.
+
+    The OAuth 2.0 endpoints this library serves take the parameters that make up the
+    request in a form-encoded request body: the token endpoint
+    (:rfc:`6749#section-4.1.3`, :rfc:`6749#section-4.3.2`, :rfc:`6749#section-4.4.2`
+    and :rfc:`6749#section-6`), revocation (:rfc:`7009#section-2.1`), introspection
+    (:rfc:`7662#section-2.1`), device authorization (:rfc:`8628#section-3.1`) and
+    pushed authorization requests (:rfc:`9126#section-2.1`). Django only populates
+    ``request.POST`` for form-encoded (and multipart) bodies, so a client that sends,
+    say, JSON reaches the view with no parameters at all and gets a confusing error
+    about a parameter it did supply -- a JSON token request is rejected as
+    ``unsupported_grant_type``.
+
+    Not applied to the OpenID Connect UserInfo endpoint: OpenID Connect Core
+    section 5.3.1 allows a POST whose only credential is the ``Authorization`` header,
+    and the form-encoding requirement of :rfc:`6750#section-2.2` is a condition on the
+    client putting the access token *in the body*, not on the endpoint. Nor to Dynamic
+    Client Registration, whose bodies :rfc:`7591` defines as ``application/json``.
+
+    Enforcement is opt-in via ``REQUIRE_FORM_ENCODED_REQUEST_BODY`` because rejecting
+    the bodies previously accepted (JSON via the deprecated ``JSONOAuthLibCore``
+    backend, and multipart, which Django parses into ``request.POST`` but no
+    specification permits here) is a breaking change for clients that rely on them.
+    While the gate is off the legacy handling is unchanged.
+
+    Only requests carrying a body are checked: the endpoints that also answer ``GET``
+    (introspection) take their parameters from the query string there, where no media
+    type applies.
+
+    Subclasses set :attr:`form_encoded_endpoint` to the endpoint description named in
+    the error, which is also where the spec citation lives.
+    """
+
+    #: Description of the endpoint, with the citation defining it, used in the error.
+    form_encoded_endpoint = "The OAuth 2.0 token endpoint (RFC 6749 section 3.2)"
+
+    def dispatch(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        response = self.form_encoded_body_error(request)
+        if response is not None:
+            return response
+        return super().dispatch(request, *args, **kwargs)
+
+    def form_encoded_body_error(self, request: HttpRequest) -> JsonResponse | None:
+        """
+        Return a ``415 Unsupported Media Type`` response for a request whose body
+        is not form-encoded, or ``None`` when the request may proceed.
+        """
+        if not oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY or request.method != "POST":
+            return None
+        # ``HttpRequest.content_type`` is the media type alone, lower-cased and with
+        # any parameters stripped, so "Application/X-WWW-Form-Urlencoded; charset=UTF-8"
+        # compares equal here. A request with no Content-Type header gives "".
+        if request.content_type == FORM_URLENCODED_MEDIA_TYPE:
+            return None
+        return JsonResponse(
+            {
+                "error": "invalid_request",
+                "error_description": (
+                    f"{self.form_encoded_endpoint} takes its parameters in a "
+                    f"{FORM_URLENCODED_MEDIA_TYPE} request body; got "
+                    f"{request.content_type or 'no Content-Type header'}."
+                ),
+            },
+            status=415,
+        )
 
 
 class OAuthLibCoreMixin:

--- a/oauth2_provider/core/views.py
+++ b/oauth2_provider/core/views.py
@@ -13,10 +13,15 @@ gate for the endpoints whose request bodies the specifications define as
 ``application/x-www-form-urlencoded``.
 """
 
+import logging
+import warnings
+
 from django.http import HttpRequest, HttpResponse, JsonResponse
 
 from oauth2_provider.settings import oauth2_settings
 
+
+log = logging.getLogger("oauth2_provider")
 
 FORM_URLENCODED_MEDIA_TYPE = "application/x-www-form-urlencoded"
 
@@ -42,11 +47,16 @@ class FormEncodedRequestMixin:
     client putting the access token *in the body*, not on the endpoint. Nor to Dynamic
     Client Registration, whose bodies :rfc:`7591` defines as ``application/json``.
 
-    Enforcement is opt-in via ``REQUIRE_FORM_ENCODED_REQUEST_BODY`` because rejecting
+    Enforcement is gated on ``REQUIRE_FORM_ENCODED_REQUEST_BODY`` because rejecting
     the bodies previously accepted (JSON via the deprecated ``JSONOAuthLibCore``
     backend, and multipart, which Django parses into ``request.POST`` but no
     specification permits here) is a breaking change for clients that rely on them.
-    While the gate is off the legacy handling is unchanged.
+    The ``False`` default is deprecated and scheduled to become ``True`` in 4.0: while
+    it is off a non-compliant body is still passed through, but each one emits a
+    ``DeprecationWarning`` (and a log line) naming the client-visible change to come.
+    Nothing is emitted for a compliant request, so a deployment whose clients already
+    send form-encoded bodies stays quiet -- and for it the coming default flip is a
+    no-op.
 
     Only requests carrying a body are checked: the endpoints that also answer ``GET``
     (introspection) take their parameters from the query string there, where no media
@@ -67,27 +77,43 @@ class FormEncodedRequestMixin:
 
     def form_encoded_body_error(self, request: HttpRequest) -> JsonResponse | None:
         """
-        Return a ``415 Unsupported Media Type`` response for a request whose body
-        is not form-encoded, or ``None`` when the request may proceed.
+        Return a ``415 Unsupported Media Type`` response for a request whose body is not
+        form-encoded, or ``None`` when the request may proceed.
+
+        While ``REQUIRE_FORM_ENCODED_REQUEST_BODY`` is ``False`` a non-compliant body
+        proceeds, but warns that it will not once the default flips in 4.0.
         """
-        if not oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY or request.method != "POST":
+        if request.method != "POST":
             return None
         # ``HttpRequest.content_type`` is the media type alone, lower-cased and with
         # any parameters stripped, so "Application/X-WWW-Form-Urlencoded; charset=UTF-8"
         # compares equal here. A request with no Content-Type header gives "".
         if request.content_type == FORM_URLENCODED_MEDIA_TYPE:
             return None
-        return JsonResponse(
-            {
-                "error": "invalid_request",
-                "error_description": (
-                    f"{self.form_encoded_endpoint} takes its parameters in a "
-                    f"{FORM_URLENCODED_MEDIA_TYPE} request body; got "
-                    f"{request.content_type or 'no Content-Type header'}."
-                ),
-            },
-            status=415,
+
+        received = request.content_type or "no Content-Type header"
+        detail = (
+            f"{self.form_encoded_endpoint} takes its parameters in a "
+            f"{FORM_URLENCODED_MEDIA_TYPE} request body; got {received}."
         )
+        if not oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY:
+            # Warn only on the non-compliant path, so a deployment whose clients already
+            # comply never sees this. Mirrors the RFC 9700 request-time gates in
+            # :mod:`oauth2_provider.core.bcp`, which is RFC 9700-specific and so not
+            # reused here.
+            message = (
+                f"{detail} The request is currently allowed to proceed because "
+                'OAUTH2_PROVIDER["REQUIRE_FORM_ENCODED_REQUEST_BODY"] is False; this '
+                "default is scheduled to change to True in django-oauth-toolkit 4.0, "
+                "after which such a request is rejected with HTTP 415. Set "
+                'OAUTH2_PROVIDER["REQUIRE_FORM_ENCODED_REQUEST_BODY"] to True to adopt '
+                "the compliant behavior now."
+            )
+            warnings.warn(message, DeprecationWarning, stacklevel=2)
+            log.warning(message)
+            return None
+
+        return JsonResponse({"error": "invalid_request", "error_description": detail}, status=415)
 
 
 class OAuthLibCoreMixin:

--- a/oauth2_provider/core/views.py
+++ b/oauth2_provider/core/views.py
@@ -93,7 +93,7 @@ class FormEncodedRequestMixin:
 
         received = request.content_type or "no Content-Type header"
         detail = (
-            f"{self.form_encoded_endpoint} takes its parameters in a "
+            f"{self.form_encoded_endpoint} takes its parameters in an "
             f"{FORM_URLENCODED_MEDIA_TYPE} request body; got {received}."
         )
         if not oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY:

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -133,7 +133,9 @@ DEFAULTS = {
     # device authorization and PAR) reject a POST sent with any other media type, with
     # HTTP 415. Defaults to ``False`` so upgrading does not break clients sending the
     # bodies previously accepted (multipart, or JSON via the deprecated
-    # JSONOAuthLibCore backend). See oauth2_provider.core.views.FormEncodedRequestMixin.
+    # JSONOAuthLibCore backend). That default is deprecated and scheduled to become
+    # ``True`` in 4.0; while it is ``False`` each non-compliant body warns.
+    # See oauth2_provider.core.views.FormEncodedRequestMixin.
     "REQUIRE_FORM_ENCODED_REQUEST_BODY": False,
     # RFC 9700 (OAuth 2.0 Security Best Current Practice) gates.
     #

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -128,6 +128,13 @@ DEFAULTS = {
     "DEVICE_FLOW_INTERVAL": 5,
     # Whether or not PKCE is required
     "PKCE_REQUIRED": True,
+    # Whether the endpoints that take the parameters comprising the request in an
+    # ``application/x-www-form-urlencoded`` body (token, revocation, introspection,
+    # device authorization and PAR) reject a POST sent with any other media type, with
+    # HTTP 415. Defaults to ``False`` so upgrading does not break clients sending the
+    # bodies previously accepted (multipart, or JSON via the deprecated
+    # JSONOAuthLibCore backend). See oauth2_provider.core.views.FormEncodedRequestMixin.
+    "REQUIRE_FORM_ENCODED_REQUEST_BODY": False,
     # RFC 9700 (OAuth 2.0 Security Best Current Practice) gates.
     #
     # Each ``COMPLIANT_BCP_RFC9700_*`` flag covers one RFC 9700 recommendation. ``False``

--- a/tests/test_form_encoded_requests.py
+++ b/tests/test_form_encoded_requests.py
@@ -1,0 +1,240 @@
+"""
+Tests for ``REQUIRE_FORM_ENCODED_REQUEST_BODY`` (issue #657).
+
+The OAuth 2.0 endpoints this library serves take the parameters comprising the request
+in an ``application/x-www-form-urlencoded`` body. Enforcement is opt-in: with the setting
+at its ``False`` default every endpoint keeps its previous behavior, and with it ``True``
+a POST sent with any other media type is answered with HTTP 415.
+"""
+
+import json
+from urllib.parse import urlencode
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.core import checks
+from django.urls import reverse
+
+from oauth2_provider.core.backends_oauthlib import JSONOAuthLibCore
+from oauth2_provider.core.checks import validate_request_body_configuration
+from oauth2_provider.models import get_application_model
+
+from . import presets
+from .common_testing import OAuth2ProviderTestCase as TestCase
+from .utils import get_basic_auth_header
+
+
+Application = get_application_model()
+UserModel = get_user_model()
+
+CLEARTEXT_SECRET = "1234567890abcdefghijklmnopqrstuvwxyz"
+FORM_ENCODED = "application/x-www-form-urlencoded"
+
+# The endpoints whose request bodies the specifications define as form-encoded. Each is
+# probed with a body that is valid for the endpoint had it been form-encoded, so the
+# legacy (gate off) status is the endpoint's own error rather than an artifact of the
+# probe.
+FORM_ENCODED_ENDPOINTS = [
+    ("oauth2_provider:token", {"grant_type": "client_credentials"}),
+    ("oauth2_provider:revoke-token", {"token": "no-such-token"}),
+    ("oauth2_provider:introspect", {"token": "no-such-token"}),
+    ("oauth2_provider:device-authorization", {"client_id": "no-such-client"}),
+    ("oauth2_provider:pushed-authorization-request", {"client_id": "no-such-client"}),
+]
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(presets.DEFAULT_SCOPES_RW)
+class BaseTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+        cls.application = Application.objects.create(
+            name="test_form_encoding_app",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            client_secret=CLEARTEXT_SECRET,
+        )
+
+    def token_request(self, **kwargs):
+        kwargs.update(get_basic_auth_header(self.application.client_id, CLEARTEXT_SECRET))
+        return self.client.post(reverse("oauth2_provider:token"), **kwargs)
+
+
+class TestFormEncodingNotEnforced(BaseTest):
+    """With the gate at its default the previously accepted bodies still work."""
+
+    def test_json_body_keeps_legacy_error(self):
+        """
+        The behavior issue #657 reports: a JSON body leaves the view with no parameters,
+        so the grant type the client did send is reported as unsupported. Preserved
+        while the gate is off.
+        """
+        response = self.token_request(
+            data=json.dumps({"grant_type": "client_credentials"}), content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "unsupported_grant_type")
+
+    def test_multipart_body_is_accepted(self):
+        """Django parses multipart into request.POST, so it works even though no spec allows it."""
+        response = self.token_request(data={"grant_type": "client_credentials"})
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_no_endpoint_answers_415(self):
+        for url_name, data in FORM_ENCODED_ENDPOINTS:
+            with self.subTest(url_name=url_name):
+                response = self.client.post(
+                    reverse(url_name), data=json.dumps(data), content_type="application/json"
+                )
+
+                self.assertNotEqual(response.status_code, 415)
+
+
+class TestFormEncodingEnforced(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = True
+
+    def test_form_encoded_body_is_accepted(self):
+        response = self.token_request(
+            data=urlencode({"grant_type": "client_credentials"}), content_type=FORM_ENCODED
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_charset_parameter_is_accepted(self):
+        """The media type is compared without its parameters, per RFC 9110 section 8.3."""
+        response = self.token_request(
+            data=urlencode({"grant_type": "client_credentials"}),
+            content_type=f"{FORM_ENCODED}; charset=UTF-8",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_json_body_is_rejected(self):
+        response = self.token_request(
+            data=json.dumps({"grant_type": "client_credentials"}), content_type="application/json"
+        )
+
+        self.assertEqual(response.status_code, 415)
+        body = response.json()
+        self.assertEqual(body["error"], "invalid_request")
+        self.assertIn(FORM_ENCODED, body["error_description"])
+        self.assertIn("RFC 6749 section 3.2", body["error_description"])
+        self.assertIn("application/json", body["error_description"])
+
+    def test_multipart_body_is_rejected(self):
+        response = self.token_request(data={"grant_type": "client_credentials"})
+
+        self.assertEqual(response.status_code, 415)
+        self.assertIn("multipart/form-data", response.json()["error_description"])
+
+    def test_missing_content_type_is_rejected(self):
+        response = self.token_request(data=b"", content_type="")
+
+        self.assertEqual(response.status_code, 415)
+        self.assertIn("no Content-Type header", response.json()["error_description"])
+
+    def test_every_form_encoded_endpoint_is_covered(self):
+        for url_name, data in FORM_ENCODED_ENDPOINTS:
+            with self.subTest(url_name=url_name):
+                response = self.client.post(
+                    reverse(url_name), data=json.dumps(data), content_type="application/json"
+                )
+
+                self.assertEqual(response.status_code, 415)
+                self.assertEqual(response.json()["error"], "invalid_request")
+
+    def test_get_requests_are_unaffected(self):
+        """A GET carries its parameters in the query string, where no media type applies."""
+        url = reverse("oauth2_provider:introspect")
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = False
+        enforced_off = self.client.get(url, data={"token": "no-such-token"}).status_code
+
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = True
+        response = self.client.get(url, data={"token": "no-such-token"})
+
+        self.assertNotEqual(response.status_code, 415)
+        self.assertEqual(response.status_code, enforced_off)
+
+    def test_disabled_endpoint_still_reports_not_found(self):
+        """The endpoint-enabled gate runs first: a disabled endpoint stays absent."""
+        self.oauth2_settings.PAR_ENABLED = False
+
+        response = self.client.post(
+            reverse("oauth2_provider:pushed-authorization-request"),
+            data=json.dumps({"client_id": "no-such-client"}),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 404)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(presets.DCR_SETTINGS)
+class TestDynamicClientRegistrationIsNotCovered(TestCase):
+    """RFC 7591 defines the registration request body as ``application/json``."""
+
+    def test_json_registration_still_succeeds(self):
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = True
+        user = UserModel.objects.create_user("dcr_user", "dcr@example.com", "pass")
+        self.client.force_login(user)
+
+        response = self.client.post(
+            reverse("oauth2_provider:dcr-register"),
+            data=json.dumps(
+                {"redirect_uris": ["https://example.com/cb"], "grant_types": ["authorization_code"]}
+            ),
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 201)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+class TestUserInfoIsNotCovered(TestCase):
+    """
+    OpenID Connect Core section 5.3.1 allows a UserInfo POST whose only credential is the
+    ``Authorization`` header, and RFC 6750 section 2.2 constrains a client that puts the
+    access token in the body rather than the endpoint, so UserInfo is left alone.
+    """
+
+    def test_userinfo_post_is_not_rejected(self):
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = True
+
+        response = self.client.post(
+            reverse("oauth2_provider:user-info"), data="{}", content_type="application/json"
+        )
+
+        self.assertNotEqual(response.status_code, 415)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class TestRequestBodyConfigurationCheck(TestCase):
+    def test_no_error_by_default(self):
+        self.assertEqual(validate_request_body_configuration(None), [])
+
+    def test_no_error_when_only_the_gate_is_set(self):
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = True
+
+        self.assertEqual(validate_request_body_configuration(None), [])
+
+    def test_no_error_when_only_the_json_backend_is_set(self):
+        self.oauth2_settings.OAUTH2_BACKEND_CLASS = JSONOAuthLibCore
+
+        self.assertEqual(validate_request_body_configuration(None), [])
+
+    def test_error_when_the_json_backend_can_never_be_reached(self):
+        self.oauth2_settings.REQUIRE_FORM_ENCODED_REQUEST_BODY = True
+        self.oauth2_settings.OAUTH2_BACKEND_CLASS = JSONOAuthLibCore
+
+        errors = validate_request_body_configuration(None)
+
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], checks.Error)
+        self.assertEqual(errors[0].id, "oauth2_provider.E006")

--- a/tests/test_form_encoded_requests.py
+++ b/tests/test_form_encoded_requests.py
@@ -8,6 +8,7 @@ a POST sent with any other media type is answered with HTTP 415.
 """
 
 import json
+import warnings
 from urllib.parse import urlencode
 
 import pytest
@@ -83,6 +84,37 @@ class TestFormEncodingNotEnforced(BaseTest):
         response = self.token_request(data={"grant_type": "client_credentials"})
 
         self.assertEqual(response.status_code, 200)
+
+    def test_non_compliant_body_warns_about_the_coming_default(self):
+        """The ``False`` default is deprecated, so each non-compliant body nags."""
+        with self.assertWarns(DeprecationWarning) as caught:
+            self.token_request(
+                data=json.dumps({"grant_type": "client_credentials"}),
+                content_type="application/json",
+            )
+
+        message = str(caught.warning)
+        self.assertIn("REQUIRE_FORM_ENCODED_REQUEST_BODY", message)
+        self.assertIn("django-oauth-toolkit 4.0", message)
+        self.assertIn("application/json", message)
+
+    def test_compliant_body_does_not_warn(self):
+        """A deployment whose clients already comply sees nothing."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            response = self.token_request(
+                data=urlencode({"grant_type": "client_credentials"}), content_type=FORM_ENCODED
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual([w for w in caught if "REQUIRE_FORM_ENCODED_REQUEST_BODY" in str(w.message)], [])
+
+    def test_get_request_does_not_warn(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            self.client.get(reverse("oauth2_provider:introspect"), data={"token": "no-such-token"})
+
+        self.assertEqual([w for w in caught if "REQUIRE_FORM_ENCODED_REQUEST_BODY" in str(w.message)], [])
 
     def test_no_endpoint_answers_415(self):
         for url_name, data in FORM_ENCODED_ENDPOINTS:


### PR DESCRIPTION
Fixes #657

## Description of the Change

The token, revocation, introspection, device-authorization and PAR endpoints take the parameters comprising the request in an `application/x-www-form-urlencoded` body (RFC 6749 §4.1.3/§4.3.2/§4.4.2/§6, RFC 7009 §2.1, RFC 7662 §2.1, RFC 8628 §3.1, RFC 9126 §2.1). Django only populates `request.POST` for form-encoded and multipart bodies, so a client that sends anything else reaches the view with no parameters at all and gets an error about a parameter it *did* send — the confusing `400 {"error": "unsupported_grant_type"}` for a JSON token request that this issue and its comments report.

This adds **`REQUIRE_FORM_ENCODED_REQUEST_BODY`**, which makes those endpoints answer `415 Unsupported Media Type` with an `invalid_request` error naming the endpoint, the spec section and the media type actually received:

```json
{
  "error": "invalid_request",
  "error_description": "The OAuth 2.0 token endpoint (RFC 6749 section 3.2) takes its parameters in an application/x-www-form-urlencoded request body; got application/json."
}
```

Per @n2ygk's [comment on the issue](https://github.com/django-oauth/django-oauth-toolkit/issues/657#issuecomment-2146103339) it is selectable via a setting and **defaults to `False`, so nothing changes on upgrade.**

### Deprecation path

The `False` default is itself marked deprecated, scheduled to become `True` in 4.0. While it is off a non-compliant body still proceeds, but each one emits a `DeprecationWarning` and an `oauth2_provider` logger warning naming the HTTP 415 to come and how to adopt it now — the same request-time gate shape the RFC 9700 gates use.

The warning fires **only on the non-compliant path**, so a deployment whose clients already send form-encoded bodies stays completely silent — and for it the coming default flip is a no-op. `GET` requests never warn.

### Design notes

- **Why opt-in.** Enforcement rejects two body types that work today: `application/json` (via the already-deprecated `JSONOAuthLibCore` backend) and `multipart/form-data` — which no specification permits here, but Django parses into `request.POST` so it has always worked. That includes Django's own test client, whose `client.post(url, data={...})` sends multipart unless a `content_type` is passed, so a default flip would break many downstream test suites. Those suites are exactly what the new warning surfaces, giving them a release to add a `content_type`. (This repo's own suite is one of them: pytest collapses the result to 9 warning summary blocks.)
- **Media type parameters are ignored.** `application/x-www-form-urlencoded; charset=UTF-8` is accepted (`HttpRequest.content_type` is already the bare, lower-cased media type).
- **`GET` is never affected.** Introspection — the only covered endpoint that answers a `GET` — takes its parameters from the query string there, where no media type applies.
- **Endpoint-disabled gates still win.** `PAR_ENABLED = False` keeps returning 404 rather than 415, because `PushedAuthorizationRequestView.dispatch` runs before the mixin.
- **UserInfo is deliberately *not* covered.** OpenID Connect Core §5.3.1 allows a POST whose only credential is the `Authorization` header, and the form-encoding requirement of RFC 6750 §2.2 (quoted in the issue) is a condition on a client putting the access token *in the body*, not a constraint on the endpoint. Enforcing there would be stricter than the specs.
- **Dynamic Client Registration is not covered** either — RFC 7591 defines *those* bodies as `application/json`.
- **New system check `oauth2_provider.E006`** flags enabling this alongside the deprecated `JSONOAuthLibCore` backend: the gate would reject every request before the backend could parse it, so the combination is always a misconfiguration.

Implementation is a small `FormEncodedRequestMixin` in `oauth2_provider/core/views.py`; each view sets `form_encoded_endpoint` to its own description and citation.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

<sub>The idp/rp demo apps are unchanged: this feature has no UI surface — it is a server-side setting that changes an error status code, covered by `tests/test_form_encoded_requests.py` (20 tests, including that each covered endpoint answers 415, that DCR and UserInfo do not, that the deprecation warning fires only for non-compliant bodies, and that the legacy `unsupported_grant_type` behavior is preserved while the gate is off).</sub>