### PR TITLE
fix: correct log levels in two resource-server paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is unchanged in every case, only subclassing and patching are affected.
 
 ### Fixed
+* #1828 Two resource-server paths no longer log at the wrong level. A non-200 introspection
+  response is an ordinary response, not an exception, so it is logged with `log.warning` instead
+  of `log.exception` — the latter appended a meaningless `NoneType: None` line to every such
+  record, and attached an unrelated traceback whenever the call happened to be made from inside
+  some outer `except`. And `OAuth2ExtraTokenMiddleware` logged a full traceback for every request
+  carrying a bearer token that does not resolve, which is the normal outcome for an expired,
+  revoked or bogus token; it is now a single `log.debug` line. Operators filtering these records
+  at `ERROR` level will stop seeing them.
 * #1827 The remote introspection POST is now time-bounded by a new
   `RESOURCE_SERVER_INTROSPECTION_TIMEOUT_SECONDS` setting (default `5`, matching the other outbound
   fetch timeouts). `requests` applies no timeout of its own, so an authorization server that accepted

--- a/oauth2_provider/resource_server/middleware.py
+++ b/oauth2_provider/resource_server/middleware.py
@@ -59,7 +59,7 @@ class OAuth2ExtraTokenMiddleware:
                 token_checksum = hashlib.sha256(tokenstring.encode("utf-8")).hexdigest()
                 token = AccessToken.objects.get(token_checksum=token_checksum)
                 request.access_token = token
-            except AccessToken.DoesNotExist as e:
-                log.exception(e)
+            except AccessToken.DoesNotExist:
+                log.debug("Bearer token not found in the database")
         response = self.get_response(request)
         return response

--- a/oauth2_provider/resource_server/validators.py
+++ b/oauth2_provider/resource_server/validators.py
@@ -215,12 +215,12 @@ class ResourceServerValidatorMixin:
             log.exception("Introspection: Failed POST to %r in token lookup", introspection_url)
             return None
 
-        # Log an exception when response from auth server is not successful
         if response.status_code != http.client.OK:
-            log.exception(
-                "Introspection: Failed to get a valid response "
-                "from authentication server. Status code: {}, "
-                "Reason: {}.".format(response.status_code, response.reason)
+            log.warning(
+                "Introspection: Failed to get a valid response from authentication server. "
+                "Status code: %s, Reason: %s.",
+                response.status_code,
+                response.reason,
             )
             return None
 
@@ -286,6 +286,9 @@ class ResourceServerValidatorMixin:
             )
 
             return access_token
+
+        log.debug("Introspection: token is not active")
+        return None
 
     @staticmethod
     def _build_introspection_client_assertion():

--- a/tests/test_oauth2_provider_middleware.py
+++ b/tests/test_oauth2_provider_middleware.py
@@ -81,6 +81,20 @@ class TestOAuth2ExtraTokenMiddleware(TestCase):
         # Should not have access_token attribute
         self.assertFalse(hasattr(request, "access_token"))
 
+    def test_invalid_bearer_token_logs_at_debug_level(self):
+        """A token that does not resolve is the normal outcome for an expired, revoked or
+        bogus token, so it is logged at DEBUG and without a traceback rather than as an error.
+        """
+        request = self.factory.get("/", HTTP_AUTHORIZATION="Bearer invalid-token-xyz")
+
+        with self.assertLogs(logger="oauth2_provider.resource_server.middleware", level="DEBUG") as logs:
+            _ = self.middleware(request)
+
+        self.assertEqual(
+            ["DEBUG:oauth2_provider.resource_server.middleware:Bearer token not found in the database"],
+            logs.output,
+        )
+
     def test_no_authorization_header(self):
         """Test that request without Authorization header works normally"""
         request = self.factory.get("/")

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -1028,7 +1028,9 @@ class TestOAuth2ValidatorErrorResourceToken(TestCase):
 
     def test_response_when_auth_server_response_not_200(self):
         """
-        Ensure we log the error when the authentication server returns a non-200 response.
+        A non-200 introspection response is an ordinary response, not an exception: it is
+        logged as a warning, without the ``NoneType: None`` tail ``log.exception()`` appends
+        when there is no active exception to attach.
         """
         mock_response = requests.Response()
         mock_response.status_code = 404
@@ -1039,13 +1041,61 @@ class TestOAuth2ValidatorErrorResourceToken(TestCase):
                 self.validator._get_token_from_authentication_server(
                     self.token, self.introspection_url, self.introspection_token, None
                 )
-                self.assertIn(
-                    "ERROR:oauth2_provider:Introspection: Failed to "
-                    "get a valid response from authentication server. "
-                    "Status code: 404, Reason: "
-                    "Not Found.\nNoneType: None",
+                self.assertEqual(
+                    [
+                        "WARNING:oauth2_provider:Introspection: Failed to get a valid response "
+                        "from authentication server. Status code: 404, Reason: Not Found."
+                    ],
                     mock_log.output,
                 )
+
+    def test_response_when_auth_server_response_not_200_inside_except_block(self):
+        """
+        The non-200 branch must not borrow the traceback of an unrelated exception the caller
+        happens to be handling further up the stack.
+        """
+        mock_response = requests.Response()
+        mock_response.status_code = 503
+        mock_response.reason = "Service Unavailable"
+        with mock.patch("requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            try:
+                raise ValueError("unrelated caller failure")
+            except ValueError:
+                with self.assertLogs(logger="oauth2_provider") as mock_log:
+                    self.validator._get_token_from_authentication_server(
+                        self.token, self.introspection_url, self.introspection_token, None
+                    )
+        self.assertNotIn("unrelated caller failure", "\n".join(mock_log.output))
+        self.assertNotIn("Traceback", "\n".join(mock_log.output))
+
+    def test_inactive_token_returns_none(self):
+        """
+        An introspection response reporting an inactive token yields no access token.
+        """
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = b'{"active": false}'
+        with mock.patch("requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            access_token = self.validator._get_token_from_authentication_server(
+                self.token, self.introspection_url, self.introspection_token, None
+            )
+        self.assertIsNone(access_token)
+
+    def test_response_without_active_claim_returns_none(self):
+        """
+        An introspection response with no ``active`` member at all yields no access token.
+        """
+        mock_response = requests.Response()
+        mock_response.status_code = 200
+        mock_response._content = b'{"scope": "read write"}'
+        with mock.patch("requests.post") as mock_post:
+            mock_post.return_value = mock_response
+            access_token = self.validator._get_token_from_authentication_server(
+                self.token, self.introspection_url, self.introspection_token, None
+            )
+        self.assertIsNone(access_token)
 
 
 @pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)

--- a/tests/test_oauth2_validators.py
+++ b/tests/test_oauth2_validators.py
@@ -1066,6 +1066,13 @@ class TestOAuth2ValidatorErrorResourceToken(TestCase):
                     self.validator._get_token_from_authentication_server(
                         self.token, self.introspection_url, self.introspection_token, None
                     )
+        self.assertEqual(
+            [
+                "WARNING:oauth2_provider:Introspection: Failed to get a valid response from "
+                "authentication server. Status code: 503, Reason: Service Unavailable."
+            ],
+            mock_log.output,
+        )
         self.assertNotIn("unrelated caller failure", "\n".join(mock_log.output))
         self.assertNotIn("Traceback", "\n".join(mock_log.output))
 


### PR DESCRIPTION
Fixes #1828

## Description of the Change

Three one-line corrections in the resource server, all behavior-neutral.

**1. Non-200 introspection response is not an exception (`resource_server/validators.py`).** The branch is reached on a perfectly ordinary HTTP response, never from an `except` block, but used `log.exception()`. With no active exception the handler appends a bare `NoneType: None` line to every one of these records — and when `_get_token_from_authentication_server()` is called from inside some unrelated outer `except`, `exc_info=True` attaches *that* exception's traceback and makes the log actively misleading. Now `log.warning`, with `%`-style deferred formatting instead of eager `.format()`.

**2. `AccessToken.DoesNotExist` in `OAuth2ExtraTokenMiddleware` (`resource_server/middleware.py`).** `exc_info` is legitimate here — it *is* an exception handler — but `ERROR` is the wrong level. A bearer token that does not resolve is the normal outcome for an expired, revoked or simply bogus token, and this middleware runs on every request carrying an `Authorization` header: a full traceback per unauthenticated request is noisy, costs real formatting work on a hot path, and gives an unauthenticated caller a trivially cheap way to inflate log volume. `log.exception(e)` also logged only the exception's `str()`, which for `DoesNotExist` is empty — so these records carried no message at all, just a traceback. Now a single `log.debug("Bearer token not found in the database")`.

**3. Implicit fall-through return in `_get_token_from_authentication_server()`.** An introspection response with `"active": false`, or with no `active` member, returned `None` by falling off the end of the function, while every other failure path returns it explicitly. The behavior is correct — the caller does `if access_token and access_token.is_valid(scopes)`, so `None` means "token invalid", the right fail-closed outcome — but in a security decision this central the most common rejection path should not be the invisible one. Now an explicit terminal `return None` with a debug line. Purely readability; included here because it is inside the function (1) already modifies.

Every path keeps its existing control flow. The changelog notes (1) and (2) because operators filtering these records at `ERROR` level will stop seeing them.

### Relationship to other PRs

#1830 covers this issue together with #1827, but #1827 has since landed on its own in #1832, leaving that PR conflicted against master. This PR is scoped to #1828 alone and applies on current master.

### Testing

Three tests fail before this change and pass after:

- `test_response_when_auth_server_response_not_200` — tightened from `assertIn` to `assertEqual` on the full log output; it previously pinned the buggy `ERROR:...Not Found.\nNoneType: None` record;
- `test_response_when_auth_server_response_not_200_inside_except_block` — new; calls the introspection path from inside an unrelated `except ValueError` and asserts neither that exception nor any traceback reaches the log;
- `test_invalid_bearer_token_logs_at_debug_level` — new; the middleware emits exactly one DEBUG record for an unknown bearer token.

Two further tests (`test_inactive_token_returns_none`, `test_response_without_active_claim_returns_none`) pass both before and after — they pin the fail-closed behavior that (3) makes explicit, so that a future edit to that terminal return cannot silently change it.

`tests/test_oauth2_validators.py` + `tests/test_oauth2_provider_middleware.py`: 84 passed, 6 subtests. `ruff check` and `ruff format --check` clean.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [ ] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [ ] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPnKm9SDd1TQHAuaD7NTU2)_