### PR TITLE
Support dynamic access token lifetime via callable ACCESS_TOKEN_EXPIRE_SECONDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+* #483 `ACCESS_TOKEN_EXPIRE_SECONDS` now accepts a `datetime.timedelta`, or a callable taking the
+  oauthlib request and returning a number of seconds or a `timedelta`, in addition to a plain number
+  of seconds. This makes the access token lifetime vary per client, grant type, scope or session
+  without subclassing anything -- the callable may also be given as a dotted import path. The
+  resolved value drives both the `expires_in` in the token response and the stored
+  `AccessToken.expires`, and a misconfigured static value is reported at startup as
+  `oauth2_provider.E006`. See "Varying the access token lifetime per request" in the advanced topics
+  documentation.
 * #1762 RFC 7523 JWT client authentication (`private_key_jwt` / `client_secret_jwt`) at the token, introspection and
   revocation endpoints. Applications gain `token_endpoint_auth_method`, `client_jwks` and `client_jwks_uri` fields
   (deployments with a swapped/custom Application model must add an equivalent migration); remote JWK Sets are fetched
@@ -57,6 +65,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Access-Control-Allow-Credentials` is never sent. Set the new `OIDC_USERINFO_CORS_ENABLED` setting
   to `False` to opt out.
 ### Changed
+* #483 A non-positive or non-numeric `ACCESS_TOKEN_EXPIRE_SECONDS` is now rejected with
+  `ImproperlyConfigured` (and reported by `manage.py check` as `oauth2_provider.E006`) instead of
+  being applied inconsistently: `0` previously meant "expire immediately" for the stored token while
+  oauthlib reported `3600` to the client, and a negative value issued an already-expired token.
 * #1287 RP-Initiated Logout no longer rejects an `id_token_hint` whose ID Token is no longer stored.
   Such a request previously returned HTTP 400; it now takes the prompt-or-logout path, so deployments
   relying on the 400 will see 200 (prompt) or 302 (redirect) instead. "No longer stored" covers an ID

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -334,6 +334,78 @@ keep them if you use those helpers.
 Register the ``Scope`` and ``ApplicationScope`` models with the admin as usual to manage scopes
 through the admin site.
 
+.. _dynamic_access_token_lifetime:
+
+Varying the access token lifetime per request
+=============================================
+
+``ACCESS_TOKEN_EXPIRE_SECONDS`` (see :ref:`settings_access_token_expire_seconds`) may be a
+callable instead of a fixed number of seconds. It is called once per issued token with the
+current ``oauthlib.common.Request`` and must return a number of seconds or a
+``datetime.timedelta``. The value it returns is reported to the client as ``expires_in``
+*and* stored as the token's ``expires``, so the two never drift apart.
+
+The callable can be given directly, or as a dotted import path -- which is usually what you
+want, since a Django settings module often cannot import a callable that touches models::
+
+    OAUTH2_PROVIDER = {
+        "ACCESS_TOKEN_EXPIRE_SECONDS": "myapp.oauth.access_token_expires_in",
+    }
+
+The request carries everything needed to make the decision:
+
+``request.client``
+    The ``Application`` instance the token is being issued to. This is how you give
+    different clients different lifetimes -- add a field to a
+    :ref:`custom Application model <extend_app_model>` and read it here::
+
+        def access_token_expires_in(request):
+            return request.client.access_token_lifetime or 36000
+
+``request.grant_type``
+    The grant being used, e.g. to keep tokens issued to a machine client short because no
+    human is present to notice a leak::
+
+        from datetime import timedelta
+
+        def access_token_expires_in(request):
+            if request.grant_type == "client_credentials":
+                return timedelta(minutes=15)
+            return timedelta(hours=10)
+
+``request.scopes``
+    The granted scopes, so a token that can move money expires sooner than one that can
+    only read::
+
+        def access_token_expires_in(request):
+            if "transfer" in (request.scopes or []):
+                return timedelta(minutes=5)
+            return timedelta(hours=10)
+
+``request.user``
+    The resource owner, where one is involved. It is ``None`` for ``client_credentials``,
+    so guard for that.
+
+``request.headers``
+    A copy of the Django request's ``META``, so an upstream session cookie is reachable and
+    a token can be made not to outlive the session that authorized it.
+
+Notes:
+
+* The callable runs while the token is being issued, inside the token endpoint's
+  transaction. Keep it cheap and side-effect free -- an extra query per token issued is a
+  cost paid on the hot path.
+* Raise nothing: an exception propagates out of the token endpoint. Fall back to a default
+  rather than assuming a field is populated.
+* Return a positive value. A non-positive or non-numeric return raises
+  ``ImproperlyConfigured``.
+* A refresh exchange is a fresh issuance, so the callable is consulted again with
+  ``request.grant_type == "refresh_token"``; the new access token gets the lifetime that
+  applies *then*, not the one the original token got.
+
+``tests/app/idp/idp/oauth.py`` in this repository has a working example wired into the demo
+IdP.
+
 .. _skip-auth-form:
 
 Skip authorization form

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -82,6 +82,11 @@ refresh_token_generator. There's no extra processing so callables (every one
 of those three can be a callable) must be passed here directly and classes
 must be instantiated (callables should accept request as their only argument).
 
+Values given here override the ones django-oauth-toolkit derives from its own
+settings, so ``token_expires_in`` set here takes precedence over
+`ACCESS_TOKEN_EXPIRE_SECONDS`_. Prefer that setting -- it accepts a callable too, is
+validated, and is honored on every code path that computes a token's expiry.
+
 SCOPES_BACKEND_CLASS
 ~~~~~~~~~~~~~~~~~~~~
 **New in 0.12.0**. The import string for the scopes backend class.
@@ -206,13 +211,32 @@ REFRESH_TOKEN_GENERATOR
 See `ACCESS_TOKEN_GENERATOR`_. This is the same but for refresh tokens.
 Defaults to access token generator if not provided.
 
+.. _settings_access_token_expire_seconds:
+
 ACCESS_TOKEN_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Default: ``36000``
 
-The number of seconds an access token remains valid. Requesting a protected
-resource after this duration will fail. Keep this value high enough so clients
-can cache the token for a reasonable amount of time.
+How long an access token remains valid. Requesting a protected resource after this
+duration will fail. Keep this value high enough so clients can cache the token for a
+reasonable amount of time.
+
+Accepted values:
+
+* an ``int`` (or ``float``) number of seconds;
+* a ``datetime.timedelta``;
+* a callable taking the current ``oauthlib.common.Request`` and returning either of
+  the above, so the lifetime can vary per client, grant type, scope or session;
+* a dotted import path to such a callable, e.g. ``"myapp.oauth.access_token_expires_in"``
+  -- useful because a Django settings module often cannot import a callable that touches
+  models at settings-load time.
+
+The resolved value drives both the ``expires_in`` member of the token response and the
+stored ``AccessToken.expires``, so the two always agree. A static value must be
+positive; a misconfigured one is reported at startup as ``oauth2_provider.E006``.
+
+See :ref:`dynamic_access_token_lifetime` for worked examples, and note that
+`EXTRA_SERVER_KWARGS`_ ``["token_expires_in"]``, if set, overrides this setting.
 
 AUTHORIZATION_CODE_EXPIRE_SECONDS
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/core/checks.py
+++ b/oauth2_provider/core/checks.py
@@ -325,10 +325,15 @@ def validate_refresh_token_configuration(app_configs, **kwargs):
     return []
 
 
-@checks.register()
+@checks.register(checks.Tags.security)
 def validate_access_token_expiry_configuration(app_configs, **kwargs):
     """
     Report a misconfigured ``ACCESS_TOKEN_EXPIRE_SECONDS`` at startup.
+
+    Tagged ``security`` (not ``deploy``-only, unlike ``validate_bcp_configuration``) because
+    the access token lifetime is the RFC 9700 §4 exposure window for a leaked token, and an
+    untagged check is skipped entirely by tag-filtered runs such as ``manage.py check --tag
+    security``.
 
     The setting may be a number of seconds, a ``timedelta``, or a callable taking the
     oauthlib request (see ``OAuth2ProviderSettings.access_token_expires_in``). A static

--- a/oauth2_provider/core/checks.py
+++ b/oauth2_provider/core/checks.py
@@ -1,5 +1,6 @@
 from django.apps import apps
 from django.core import checks
+from django.core.exceptions import ImproperlyConfigured
 from django.db import router
 
 from oauth2_provider.core.backends_oauthlib import JSONOAuthLibCore
@@ -318,6 +319,39 @@ def validate_refresh_token_configuration(app_configs, **kwargs):
                     "4.14.2."
                 ),
                 id="oauth2_provider.W012",
+            )
+        ]
+
+    return []
+
+
+@checks.register()
+def validate_access_token_expiry_configuration(app_configs, **kwargs):
+    """
+    Report a misconfigured ``ACCESS_TOKEN_EXPIRE_SECONDS`` at startup.
+
+    The setting may be a number of seconds, a ``timedelta``, or a callable taking the
+    oauthlib request (see ``OAuth2ProviderSettings.access_token_expires_in``). A static
+    value is resolved here so a bad one is reported by ``check`` rather than raising on
+    the first token issued. A callable can only be type-checked -- its return value is
+    validated per call, when there is a request to evaluate it against.
+    """
+    try:
+        if callable(oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS):
+            return []
+        oauth2_settings.access_token_expires_in()
+    # The setting is import-string aware, so a string that is not a dotted path to a
+    # callable raises ImportError; report it here rather than crashing ``manage.py check``.
+    except (ImproperlyConfigured, ImportError) as exc:
+        return [
+            checks.Error(
+                str(exc),
+                hint=(
+                    "Set OAUTH2_PROVIDER['ACCESS_TOKEN_EXPIRE_SECONDS'] to a positive number "
+                    "of seconds, a datetime.timedelta, or a callable taking the oauthlib "
+                    "request and returning either."
+                ),
+                id="oauth2_provider.E006",
             )
         ]
 

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -737,14 +737,15 @@ class OAuth2Validator(ResourceServerValidatorMixin, RequestValidator):
 
         self._check_and_set_request_resource(request)
 
-        # expires_in is passed to Server on initialization
-        # custom server class can have logic to override this
-        expires = timezone.now() + timedelta(
-            seconds=token.get(
-                "expires_in",
-                oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS,
-            )
-        )
+        # The token handler normally puts the lifetime it used in the token dict, so the
+        # stored expiry and the ``expires_in`` the client is told agree. Fall back to
+        # resolving ACCESS_TOKEN_EXPIRE_SECONDS ourselves for token dicts that omit it
+        # (a custom server or token class); resolving it through the settings helper is
+        # what makes a callable setting work on this path too.
+        expires_in = token.get("expires_in")
+        if expires_in is None:
+            expires_in = oauth2_settings.access_token_expires_in(request)
+        expires = timezone.now() + timedelta(seconds=expires_in)
 
         if request.grant_type == "client_credentials":
             request.user = None

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -17,6 +17,7 @@ back to the defaults.
 """
 
 import warnings
+from datetime import timedelta
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -314,6 +315,7 @@ IMPORT_STRINGS = (
     "CLIENT_SECRET_GENERATOR_CLASS",
     "ACCESS_TOKEN_GENERATOR",
     "REFRESH_TOKEN_GENERATOR",
+    "ACCESS_TOKEN_EXPIRE_SECONDS",
     "OAUTH2_SERVER_CLASS",
     "OAUTH2_VALIDATOR_CLASS",
     "OAUTH2_BACKEND_CLASS",
@@ -365,6 +367,31 @@ def import_from_string(val, setting_name):
     except ImportError as e:
         msg = "Could not import %r for setting %r. %s: %s." % (val, setting_name, e.__class__.__name__, e)
         raise ImportError(msg)
+
+
+def coerce_expires_in(value, setting_name):
+    """Normalize a token-lifetime setting to a positive number of seconds.
+
+    Accepts an ``int``/``float`` number of seconds or a ``timedelta`` and returns an
+    ``int``, which is what oauthlib puts in the ``expires_in`` member of the token
+    response and what :class:`datetime.timedelta` needs to compute the stored expiry.
+
+    Raises ``ImproperlyConfigured`` for a non-numeric, non-positive, or out-of-range
+    value (like ``refresh_token_expire_timedelta``) so a misconfiguration fails with a
+    message naming the setting instead of an opaque ``TypeError``/``OverflowError``.
+    """
+    if isinstance(value, timedelta):
+        value = value.total_seconds()
+    # ``bool`` is an ``int`` subclass; ``True`` as a lifetime is always a mistake.
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ImproperlyConfigured("%s must be a number of seconds or a timedelta" % setting_name)
+    try:
+        value = int(value)
+    except (ValueError, OverflowError):
+        raise ImproperlyConfigured("%s is out of range" % setting_name)
+    if value <= 0:
+        raise ImproperlyConfigured("%s must be positive" % setting_name)
+    return value
 
 
 class _PhonyHttpRequest(HttpRequest):
@@ -447,6 +474,24 @@ class OAuth2ProviderSettings:
         if not val and attr in self.mandatory:
             raise AttributeError("OAuth2Provider setting: %s is mandatory" % attr)
 
+    def access_token_expires_in(self, request: Request | None = None) -> int:
+        """Resolve ``ACCESS_TOKEN_EXPIRE_SECONDS`` to a positive number of seconds.
+
+        The setting may be a number of seconds, a ``timedelta``, or a callable taking the
+        current ``oauthlib.common.Request`` and returning either -- which is how a
+        deployment varies the access token lifetime per client, grant type, scope, or
+        session. The signature matches oauthlib's ``token_expires_in`` contract, so this
+        method is handed to the ``Server`` directly when the setting is dynamic.
+
+        :param request: the oauthlib request a dynamic lifetime is computed from. ``None``
+            is only ever passed by callers that have no request in hand, so a callable
+            setting must tolerate it or the deployment must keep a static value.
+        """
+        value = self.ACCESS_TOKEN_EXPIRE_SECONDS
+        if callable(value):
+            value = value(request)
+        return coerce_expires_in(value, "ACCESS_TOKEN_EXPIRE_SECONDS")
+
     @property
     def server_kwargs(self):
         """
@@ -464,7 +509,6 @@ class OAuth2ProviderSettings:
         kwargs = {
             key: getattr(self, value)
             for key, value in [
-                ("token_expires_in", "ACCESS_TOKEN_EXPIRE_SECONDS"),
                 ("refresh_token_expires_in", "REFRESH_TOKEN_EXPIRE_SECONDS"),
                 ("token_generator", "ACCESS_TOKEN_GENERATOR"),
                 ("refresh_token_generator", "REFRESH_TOKEN_GENERATOR"),
@@ -475,6 +519,14 @@ class OAuth2ProviderSettings:
                 ("pre_token", "OAUTH_PRE_TOKEN_VALIDATION"),
             ]
         }
+        # A dynamic lifetime is handed to oauthlib as a callable so it is evaluated per
+        # request (both token handlers call it with the request); a static one is resolved
+        # once, here, so a misconfigured value is reported when the server is built rather
+        # than when the first token is issued.
+        if callable(self.ACCESS_TOKEN_EXPIRE_SECONDS):
+            kwargs["token_expires_in"] = self.access_token_expires_in
+        else:
+            kwargs["token_expires_in"] = self.access_token_expires_in()
         kwargs.update(self.EXTRA_SERVER_KWARGS)
         return kwargs
 

--- a/tests/app/idp/idp/oauth.py
+++ b/tests/app/idp/idp/oauth.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 from django.conf import settings
 from django.contrib.auth.middleware import AuthenticationMiddleware
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -56,3 +58,17 @@ class CustomOAuth2Validator(OAuth2Validator):
             "preferred_username": request.user.get_username(),
             "email": request.user.email,
         }
+
+
+def access_token_expires_in(request):
+    """Demo of a per-request access token lifetime (``ACCESS_TOKEN_EXPIRE_SECONDS``).
+
+    ``request`` is an ``oauthlib.common.Request``, so the lifetime can be keyed on the
+    grant type, the client (``request.client`` is the Application instance), the granted
+    scopes, or the user. Here a client acting on its own behalf gets a short-lived token
+    because no human is present to notice a leak, while an end-user token keeps the
+    default lifetime. Return either a number of seconds or a ``timedelta``.
+    """
+    if request.grant_type == "client_credentials":
+        return timedelta(minutes=15)
+    return 36000

--- a/tests/app/idp/idp/settings.py
+++ b/tests/app/idp/idp/settings.py
@@ -258,6 +258,9 @@ OAUTH2_PROVIDER = {
     "OIDC_RP_INITIATED_LOGOUT_ENABLED": env("OAUTH2_PROVIDER_OIDC_RP_INITIATED_LOGOUT_ENABLED"),
     # this key is just for out test app, you should never store a key like this in a production environment.
     "OIDC_RSA_PRIVATE_KEY": env("OAUTH2_PROVIDER_OIDC_RSA_PRIVATE_KEY"),
+    # A callable (given here as an import string) lets the access token lifetime vary
+    # per request -- see "Varying the access token lifetime per request" in the docs.
+    "ACCESS_TOKEN_EXPIRE_SECONDS": "idp.oauth.access_token_expires_in",
     "SCOPES": env("OAUTH2_PROVIDER_SCOPES"),
     "DEFAULT_SCOPES": env("OAUTH2_PROVIDER_DEFAULT_SCOPES"),
     "PKCE_REQUIRED": pkce_required,

--- a/tests/test_access_token_expiry.py
+++ b/tests/test_access_token_expiry.py
@@ -1,0 +1,171 @@
+"""End-to-end coverage for a dynamic ``ACCESS_TOKEN_EXPIRE_SECONDS``.
+
+The setting may be a number of seconds, a ``timedelta``, or a callable taking the
+oauthlib request, which is how a deployment varies the access token lifetime per
+client, grant type, scope or session (issue #483). What is asserted here is that the
+resolved lifetime reaches *both* the ``expires_in`` the client is told and the
+``AccessToken.expires`` that is stored, and that the two agree.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from django.utils import timezone
+from oauthlib.common import Request
+
+from oauth2_provider.models import get_access_token_model, get_application_model
+from oauth2_provider.oauth2_validators import OAuth2Validator
+
+from . import presets
+from .common_testing import OAuth2ProviderTestCase as TestCase
+from .utils import get_basic_auth_header
+
+
+Application = get_application_model()
+AccessToken = get_access_token_model()
+UserModel = get_user_model()
+
+CLEARTEXT_SECRET = "1234567890abcdefghijklmnopqrstuvwxyz"
+
+PASSWORD_EXPIRES_IN = 111
+CLIENT_CREDENTIALS_EXPIRES_IN = 222
+DEFAULT_EXPIRES_IN = 333
+
+
+def expires_in_by_grant_type(request):
+    """Sample per-grant-type lifetime, wired in as ACCESS_TOKEN_EXPIRE_SECONDS below."""
+    return {
+        "password": PASSWORD_EXPIRES_IN,
+        "client_credentials": CLIENT_CREDENTIALS_EXPIRES_IN,
+    }.get(request.grant_type, DEFAULT_EXPIRES_IN)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(presets.DEFAULT_SCOPES_RW)
+class BaseTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+
+        cls.password_app = Application.objects.create(
+            name="test_password_app",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_PASSWORD,
+            client_secret=CLEARTEXT_SECRET,
+        )
+        cls.client_credentials_app = Application.objects.create(
+            name="test_client_credentials_app",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            client_secret=CLEARTEXT_SECRET,
+        )
+
+    def post_token(self, application, **data):
+        auth_headers = get_basic_auth_header(application.client_id, CLEARTEXT_SECRET)
+        response = self.client.post(reverse("oauth2_provider:token"), data=data, **auth_headers)
+        self.assertEqual(response.status_code, 200, response.content)
+        return json.loads(response.content.decode("utf-8"))
+
+    def assertStoredExpiryMatches(self, content):
+        """The persisted expiry must agree with the ``expires_in`` handed to the client."""
+        access_token = AccessToken.objects.get(token=content["access_token"])
+        remaining = (access_token.expires - timezone.now()).total_seconds()
+        # A second of slack for the time between issuing the token and this assertion.
+        self.assertAlmostEqual(remaining, content["expires_in"], delta=1)
+
+
+class TestCallableAccessTokenExpiry(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = expires_in_by_grant_type
+
+    def test_password_grant_uses_the_callable(self):
+        content = self.post_token(
+            self.password_app, grant_type="password", username="test_user", password="123456"
+        )
+        self.assertEqual(content["expires_in"], PASSWORD_EXPIRES_IN)
+        self.assertStoredExpiryMatches(content)
+
+    def test_client_credentials_grant_uses_the_callable(self):
+        content = self.post_token(self.client_credentials_app, grant_type="client_credentials")
+        self.assertEqual(content["expires_in"], CLIENT_CREDENTIALS_EXPIRES_IN)
+        self.assertStoredExpiryMatches(content)
+
+    def test_one_setting_serves_both_grant_types(self):
+        """The point of a callable: two grant types, two lifetimes, one setting."""
+        password = self.post_token(
+            self.password_app, grant_type="password", username="test_user", password="123456"
+        )
+        client_credentials = self.post_token(self.client_credentials_app, grant_type="client_credentials")
+        self.assertNotEqual(password["expires_in"], client_credentials["expires_in"])
+
+    def test_refresh_re_evaluates_the_callable(self):
+        """A refreshed access token gets the lifetime of the refresh request, not the original."""
+        content = self.post_token(
+            self.password_app, grant_type="password", username="test_user", password="123456"
+        )
+        self.assertEqual(content["expires_in"], PASSWORD_EXPIRES_IN)
+
+        refreshed = self.post_token(
+            self.password_app, grant_type="refresh_token", refresh_token=content["refresh_token"]
+        )
+        self.assertEqual(refreshed["expires_in"], DEFAULT_EXPIRES_IN)
+        self.assertStoredExpiryMatches(refreshed)
+
+
+class TestTimedeltaAccessTokenExpiry(BaseTest):
+    def test_timedelta_setting_is_reported_in_seconds(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = timedelta(minutes=7)
+        content = self.post_token(self.client_credentials_app, grant_type="client_credentials")
+        self.assertEqual(content["expires_in"], 420)
+        self.assertStoredExpiryMatches(content)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(presets.DEFAULT_SCOPES_RW)
+class TestSaveBearerTokenFallback(TestCase):
+    """``_save_bearer_token`` must resolve the setting when the token dict omits ``expires_in``.
+
+    oauthlib's own token handlers always populate ``expires_in``, but a custom server or
+    token class need not, and before #483 that path fed the raw setting straight to
+    ``timedelta(seconds=...)`` -- which raises ``TypeError`` for a callable.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+        cls.application = Application.objects.create(
+            name="test_app",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+            client_secret=CLEARTEXT_SECRET,
+        )
+
+    def _save(self, token):
+        request = Request("/o/token/")
+        request.grant_type = "client_credentials"
+        request.client = self.application
+        request.user = None
+        OAuth2Validator().save_bearer_token(token, request)
+        return AccessToken.objects.get(token=token["access_token"])
+
+    def test_callable_setting_is_resolved_when_token_omits_expires_in(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = expires_in_by_grant_type
+        access_token = self._save({"access_token": "no-expires-in", "scope": "read write"})
+        remaining = (access_token.expires - timezone.now()).total_seconds()
+        self.assertAlmostEqual(remaining, CLIENT_CREDENTIALS_EXPIRES_IN, delta=1)
+
+    def test_token_expires_in_still_wins_over_the_setting(self):
+        self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = expires_in_by_grant_type
+        access_token = self._save(
+            {"access_token": "explicit-expires-in", "scope": "read write", "expires_in": 60}
+        )
+        remaining = (access_token.expires - timezone.now()).total_seconds()
+        self.assertAlmostEqual(remaining, 60, delta=1)

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -132,6 +132,11 @@ class AccessTokenExpiryConfigurationCheckTestCase(TestCase):
         messages = validate_access_token_expiry_configuration(None)
         self.assertEqual([m.id for m in messages], ["oauth2_provider.E006"])
 
+    def test_check_is_tagged(self):
+        # An untagged check is skipped by tag-filtered runs (`manage.py check --tag ...`),
+        # so it must carry a tag like every other check in the module.
+        self.assertIn(checks.Tags.security, validate_access_token_expiry_configuration.tags)
+
     def test_valid_values_pass(self):
         for value in (36000, timedelta(minutes=5), lambda request: 60):
             with self.subTest(value=value):

--- a/tests/test_django_checks.py
+++ b/tests/test_django_checks.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pytest
 from django.core import checks
 from django.core.management import call_command
@@ -5,6 +7,7 @@ from django.core.management.base import SystemCheckError
 from django.test import override_settings
 
 from oauth2_provider.core.checks import (
+    validate_access_token_expiry_configuration,
     validate_refresh_token_configuration,
     validate_swapped_model_consistency,
     validate_token_configuration,
@@ -109,3 +112,38 @@ class RefreshTokenConfigurationCheckTestCase(TestCase):
         messages = validate_refresh_token_configuration(None)
         self.assertEqual([m.id for m in messages], ["oauth2_provider.W012"])
         self.assertIsInstance(messages[0], checks.Warning)
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class AccessTokenExpiryConfigurationCheckTestCase(TestCase):
+    def _ids(self):
+        return [m.id for m in validate_access_token_expiry_configuration(None)]
+
+    def test_check_is_registered(self):
+        from django.core.checks.registry import registry as checks_registry
+
+        self.assertIn(
+            validate_access_token_expiry_configuration,
+            checks_registry.get_checks(include_deployment_checks=True),
+        )
+
+    @override_settings(OAUTH2_PROVIDER={"ACCESS_TOKEN_EXPIRE_SECONDS": "nope.not_importable"})
+    def test_unimportable_string_is_reported_not_raised(self):
+        messages = validate_access_token_expiry_configuration(None)
+        self.assertEqual([m.id for m in messages], ["oauth2_provider.E006"])
+
+    def test_valid_values_pass(self):
+        for value in (36000, timedelta(minutes=5), lambda request: 60):
+            with self.subTest(value=value):
+                self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = value
+                self.assertEqual(self._ids(), [])
+
+    def test_invalid_static_value_errors(self):
+        # A string is treated as a dotted path to the callable, so an unimportable one is
+        # a misconfiguration too -- and must be reported, not raised out of the check.
+        for value in (0, -1, "not a number"):
+            with self.subTest(value=value):
+                self.oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS = value
+                messages = validate_access_token_expiry_configuration(None)
+                self.assertEqual([m.id for m in messages], ["oauth2_provider.E006"])
+                self.assertIsInstance(messages[0], checks.Error)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from django.test.utils import override_settings
@@ -246,3 +248,88 @@ class TestRefreshTokenAdminSelectRelated(TestCase):
         # It must be a dict so the JOIN is scoped to only the declared fields.
         self.assertIsInstance(qs.query.select_related, dict)
         self.assertEqual(set(qs.query.select_related.keys()), {"application", "user"})
+
+
+def _expires_in_by_grant_type(request):
+    """Sample dynamic ACCESS_TOKEN_EXPIRE_SECONDS, referenced by dotted path below."""
+    return 60 if request.grant_type == "client_credentials" else 600
+
+
+class TestAccessTokenExpiresIn(TestCase):
+    """``ACCESS_TOKEN_EXPIRE_SECONDS`` accepts seconds, a timedelta, or a callable."""
+
+    def test_int_is_returned_unchanged(self):
+        settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": 120})
+        assert settings.access_token_expires_in() == 120
+
+    def test_timedelta_is_coerced_to_seconds(self):
+        settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": timedelta(minutes=5)})
+        assert settings.access_token_expires_in() == 300
+
+    def test_callable_is_evaluated_with_the_request(self):
+        settings = OAuth2ProviderSettings(
+            {"ACCESS_TOKEN_EXPIRE_SECONDS": lambda request: 42 if request.grant_type == "password" else 7}
+        )
+        request = Request("/o/token/")
+        request.grant_type = "password"
+        assert settings.access_token_expires_in(request) == 42
+
+    def test_callable_may_return_a_timedelta(self):
+        settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": lambda request: timedelta(hours=2)})
+        assert settings.access_token_expires_in(Request("/o/token/")) == 7200
+
+    def test_import_string_resolves_to_the_callable(self):
+        settings = OAuth2ProviderSettings(
+            {"ACCESS_TOKEN_EXPIRE_SECONDS": "tests.test_settings._expires_in_by_grant_type"}
+        )
+        assert settings.ACCESS_TOKEN_EXPIRE_SECONDS is _expires_in_by_grant_type
+        request = Request("/o/token/")
+        request.grant_type = "client_credentials"
+        assert settings.access_token_expires_in(request) == 60
+
+    def test_invalid_static_value_is_rejected(self):
+        # True is an int subclass, so it would otherwise sneak through as "1 second".
+        for value in (0, -1, True, None, object()):
+            with self.subTest(value=value):
+                settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": value})
+                with pytest.raises(ImproperlyConfigured, match="ACCESS_TOKEN_EXPIRE_SECONDS"):
+                    settings.access_token_expires_in()
+
+    def test_unimportable_string_names_the_setting(self):
+        # The setting is import-string aware, so a string is treated as a dotted path to
+        # the callable rather than as a number of seconds.
+        settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": "3600"})
+        with pytest.raises(ImportError, match="ACCESS_TOKEN_EXPIRE_SECONDS"):
+            settings.access_token_expires_in()
+
+    def test_invalid_callable_return_value_is_rejected(self):
+        settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": lambda request: -5})
+        with pytest.raises(ImproperlyConfigured, match="ACCESS_TOKEN_EXPIRE_SECONDS must be positive"):
+            settings.access_token_expires_in(Request("/o/token/"))
+
+
+class TestServerKwargsTokenExpiresIn(TestCase):
+    """``server_kwargs`` hands oauthlib a number for a static setting, a callable for a dynamic one."""
+
+    def test_static_setting_is_resolved_to_an_int(self):
+        settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": timedelta(minutes=1)})
+        assert settings.server_kwargs["token_expires_in"] == 60
+
+    def test_callable_setting_is_passed_through_for_per_request_evaluation(self):
+        settings = OAuth2ProviderSettings(
+            {"ACCESS_TOKEN_EXPIRE_SECONDS": "tests.test_settings._expires_in_by_grant_type"}
+        )
+        token_expires_in = settings.server_kwargs["token_expires_in"]
+        request = Request("/o/token/")
+        request.grant_type = "authorization_code"
+        assert callable(token_expires_in)
+        assert token_expires_in(request) == 600
+
+    def test_extra_server_kwargs_still_wins(self):
+        settings = OAuth2ProviderSettings(
+            {
+                "ACCESS_TOKEN_EXPIRE_SECONDS": 100,
+                "EXTRA_SERVER_KWARGS": {"token_expires_in": 200},
+            }
+        )
+        assert settings.server_kwargs["token_expires_in"] == 200

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -295,6 +295,16 @@ class TestAccessTokenExpiresIn(TestCase):
                 with pytest.raises(ImproperlyConfigured, match="ACCESS_TOKEN_EXPIRE_SECONDS"):
                     settings.access_token_expires_in()
 
+    def test_non_finite_value_is_rejected(self):
+        # float("inf") raises OverflowError from int() and float("nan") raises ValueError;
+        # both are reachable from a computed setting and must name the setting, not leak
+        # the raw arithmetic error.
+        for value in (float("inf"), float("-inf"), float("nan")):
+            with self.subTest(value=value):
+                settings = OAuth2ProviderSettings({"ACCESS_TOKEN_EXPIRE_SECONDS": value})
+                with pytest.raises(ImproperlyConfigured, match="ACCESS_TOKEN_EXPIRE_SECONDS"):
+                    settings.access_token_expires_in()
+
     def test_unimportable_string_names_the_setting(self):
         # The setting is import-string aware, so a string is treated as a dotted path to
         # the callable rather than as a number of seconds.


### PR DESCRIPTION
Fixes #483

## Description of the Change

This PR adds support for making `ACCESS_TOKEN_EXPIRE_SECONDS` dynamic by accepting:
- A callable that takes the oauthlib `Request` and returns seconds or a `timedelta`
- A dotted import path to such a callable
- Existing static values (int/float seconds or `timedelta`)

This allows deployments to vary token lifetime per client, grant type, scope, or session without subclassing. The resolved lifetime is used consistently for both the `expires_in` response field and the stored `AccessToken.expires`, ensuring they never drift.

### Key Changes

1. **Settings (`oauth2_provider/settings.py`)**:
   - Added `access_token_expires_in(request)` method to resolve the setting to a positive integer
   - Added `coerce_expires_in()` helper to validate and normalize numeric values
   - Updated `server_kwargs` property to pass callables directly to oauthlib for per-request evaluation, while resolving static values once at startup

2. **Token Validation (`oauth2_provider/oauth2_validators.py`)**:
   - Updated `_save_bearer_token()` to resolve `ACCESS_TOKEN_EXPIRE_SECONDS` when the token dict omits `expires_in`, ensuring callable settings work on all code paths

3. **Django Checks (`oauth2_provider/core/checks.py`)**:
   - Added `validate_access_token_expiry_configuration()` check to report misconfigured static values at startup as `oauth2_provider.E006`

4. **Documentation (`docs/advanced_topics.rst`, `docs/settings.rst`)**:
   - Added comprehensive guide on using dynamic lifetimes with examples for per-client, per-grant-type, and per-scope variations
   - Updated settings reference with accepted value types and behavior notes

5. **Tests**:
   - Added `tests/test_access_token_expiry.py` with end-to-end coverage for callable, timedelta, and fallback paths
   - Added `TestAccessTokenExpiresIn` and `TestServerKwargsTokenExpiresIn` to `tests/test_settings.py`
   - Added `AccessTokenExpiryConfigurationCheckTestCase` to `tests/test_django_checks.py`
   - Updated demo IdP (`tests/app/idp/idp/oauth.py`) with working example

## Checklist

- [x] PR only contains one change (single feature: dynamic token lifetime)
- [x] unit-test added (comprehensive test coverage in test_access_token_expiry.py and test_settings.py)
- [x] documentation updated (advanced_topics.rst and settings.rst)
- [x] `CHANGELOG.md` updated
- [x] tests/app/idp updated to demonstrate new features (access_token_expires_in function added)
- [ ] tests/app/rp updated to demonstrate new features (not applicable for this feature)

https://claude.ai/code/session_013kDBBDgW8kop89JLtVLTch