### PR TITLE
feat(models): make redirect uri and origin validation pluggable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `AccessToken.expires`, and a misconfigured static value is reported at startup as
   `oauth2_provider.E006`. See "Varying the access token lifetime per request" in the advanced topics
   documentation.
+* #490 Pluggable registration-time URI validation. Two new settings, `REDIRECT_URI_VALIDATOR` and
+  `ALLOWED_ORIGIN_VALIDATOR`, name a factory called with the application that returns the validator
+  `Application.clean()` applies to each `redirect_uris` / `allowed_origins` entry, and the matching
+  `Application.get_redirect_uri_validator()` / `get_allowed_origin_validator()` methods can be
+  overridden on a swapped application model for per-application policy. This makes redirect-uri
+  policy that a static scheme list cannot express -- schemes held in the database, a blacklist, or a
+  scheme accepted only after review, as RFC 8252 native apps tend to need -- possible without
+  swapping the application model. Defaults are unchanged, and the hooks gate only what may be
+  stored: request-time matching remains exact per RFC 9700 section 2.1, and `get_allowed_schemes()`
+  still gates the redirect scheme independently. See `docs/advanced_topics.rst`.
 * #1762 RFC 7523 JWT client authentication (`private_key_jwt` / `client_secret_jwt`) at the token, introspection and
   revocation endpoints. Applications gain `token_endpoint_auth_method`, `client_jwks` and `client_jwks_uri` fields
   (deployments with a swapped/custom Application model must add an equivalent migration); remote JWK Sets are fetched

--- a/docs/advanced_topics.rst
+++ b/docs/advanced_topics.rst
@@ -98,6 +98,93 @@ run::
     Subclass :class:`oauth2_provider.forms.ApplicationForm` to get those errors folded into
     non-field errors instead.
 
+.. _custom-uri-validators:
+
+Custom redirect URI and origin validators
+=========================================
+
+The rules ``clean()`` applies to ``redirect_uris`` and ``allowed_origins`` are not hard-coded.
+``ALLOWED_REDIRECT_URI_SCHEMES`` and ``ALLOWED_SCHEMES`` cover the common case -- a fixed list of
+schemes for the whole server -- but some policies cannot be written as a list: allowed schemes held
+in the database and administered per tenant, a blacklist, or a scheme accepted only after the client
+has been reviewed. Native apps are the usual reason, since :rfc:`8252` section 7.1 gives each app its own
+private-use scheme (``com.example.app:/oauth2redirect``).
+
+For those, replace the validator. There are two layers, and they compose exactly the way
+``SCOPES_BACKEND_CLASS`` and ``Application.get_allowed_schemes()`` already do:
+
+* the ``REDIRECT_URI_VALIDATOR`` and ``ALLOWED_ORIGIN_VALIDATOR`` settings set the default for the
+  whole deployment, and need no custom application model;
+* ``Application.get_redirect_uri_validator()`` and ``Application.get_allowed_origin_validator()``
+  can be overridden on a swapped application model to vary the policy per application.
+
+Each setting names a *factory*: a callable that receives the application and returns a callable
+taking one URI string, which raises :class:`~django.core.exceptions.ValidationError` when the URI is
+not acceptable. ``clean()`` calls the factory once per validation pass and then applies the result to
+each URI, so a factory that queries the database does so once per save rather than once per URI.
+
+A class is a callable, so the simplest custom validator is a subclass of
+``oauth2_provider.validators.AllowedURIValidator`` that takes the application in ``__init__``. It
+inherits all of the :rfc:`3986` and :rfc:`8252` parsing -- private-use schemes, authority rules,
+optional wildcards -- and only replaces the scheme policy::
+
+    # myapp/validators.py
+    from oauth2_provider.validators import AllowedURIValidator
+
+    class DBSchemeValidator(AllowedURIValidator):
+        """Allow the schemes an operator approved for this client."""
+
+        def __init__(self, application):
+            schemes = ["https"]
+            if application.pk:
+                schemes += list(application.approved_schemes.values_list("scheme", flat=True))
+            super().__init__(schemes, name="redirect uri", allow_path=True, allow_query=True)
+
+    OAUTH2_PROVIDER = {
+        "REDIRECT_URI_VALIDATOR": "myapp.validators.DBSchemeValidator",
+    }
+
+A factory can equally be a plain function, which suits policy that is a gate rather than a scheme
+list -- for instance holding a client's custom scheme back until it has been reviewed::
+
+    def review_gated_validator(application):
+        approved = bool(application.pk) and application.review_state == "approved"
+        schemes = ["https", application.custom_scheme] if approved else ["https"]
+        return AllowedURIValidator(schemes, name="redirect uri", allow_path=True, allow_query=True)
+
+Errors raised from a custom validator follow the same convention as the rest of ``clean()``: they are
+collected and keyed to ``redirect_uris`` or ``allowed_origins``, so the admin and the built-in
+application views render each message next to the offending input.
+
+Two constraints are worth knowing before you write one.
+
+**The application may be unsaved.** Registration through Dynamic Client Registration (:rfc:`7591`),
+:doc:`CIMD <cimd>`, the ``createapplication`` command and the admin add form all validate before the
+first save, so
+``application.pk`` can be ``None`` and reverse relations may not exist yet. Guard accordingly, as
+both examples above do.
+
+**A factory may not be ``None``.** Both settings are mandatory, so an empty value raises rather than
+silently disabling validation. If you really want no validation, say so explicitly with a factory
+returning ``lambda uri: None``.
+
+.. warning::
+    These validators decide what may be **stored**. They do not affect request-time matching: an
+    incoming ``redirect_uri`` is matched against the stored values by exact string comparison per
+    :rfc:`9700` section 2.1, and nothing here can relax that. A validator that accepts a sloppy URI
+    only stores a value that will never match.
+
+    They are also not the whole story for schemes. ``Application.get_allowed_schemes()`` is consulted
+    *again* when the redirect is issued, so accepting a new scheme here without adding it to
+    ``ALLOWED_REDIRECT_URI_SCHEMES`` (or overriding ``get_allowed_schemes()``) produces an
+    application that saves cleanly and then fails at redirect time. The same applies to origins:
+    ``ALLOWED_SCHEMES`` is re-checked at request time by ``is_origin_allowed()``.
+
+    On the Dynamic Client Registration and CIMD paths, no other check inspects redirect uri syntax,
+    and a validator's message reaches the registering client verbatim in ``error_description``. Write
+    client-facing messages, and remember that a permissive validator widens the open-redirect and
+    phishing surface just as ``ALLOW_URI_WILDCARDS`` does.
+
 .. _extend_token_models:
 
 Extending the token models

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -363,7 +363,9 @@ configured without explicit port specification, so that the Application accepts 
 assigned ports.
 
 Note that you may override ``Application.get_allowed_schemes()`` to set this on
-a per-application basis.
+a per-application basis. For policy a static list cannot express -- schemes held in the database,
+a blacklist, or review-gated approval -- replace the validator itself; see
+``REDIRECT_URI_VALIDATOR`` below.
 
 Native apps using an RFC 8252 §7.1 private-use URI scheme should add that scheme here
 (e.g. ``["https", "com.example.app"]``) and register the redirect URI in the single-slash
@@ -382,6 +384,9 @@ Setting this to ``["https"]`` only in production is strongly recommended.
 Adding ``"http"`` to the list is considered to be safe only for local development and testing.
 Note that `OAUTHLIB_INSECURE_TRANSPORT <https://oauthlib.readthedocs.io/en/latest/oauth2/security.html#envvar-OAUTHLIB_INSECURE_TRANSPORT>`_
 environment variable should be also set to allow HTTP origins.
+
+For origin policy a static list cannot express, replace the validator itself; see
+``ALLOWED_ORIGIN_VALIDATOR`` below.
 
 ALLOW_URI_WILDCARDS
 ~~~~~~~~~~~~~~~~~~~
@@ -417,6 +422,82 @@ as ``something-sitename.netlify.app``. Use the double-dash form for Netlify depl
 
 This feature is useful for working with CI service such as cloudflare, netlify, and vercel that offer branch
 deployments for development previews and user acceptance testing.
+
+REDIRECT_URI_VALIDATOR
+~~~~~~~~~~~~~~~~~~~~~~
+Default: ``"oauth2_provider.validators.default_redirect_uri_validator"``
+
+A callable that builds the validator applied to each entry in an application's ``redirect_uris``
+when the application is validated. Use it for redirect-uri policy that a static scheme list cannot
+express -- schemes stored in the database, a blacklist, or a scheme accepted only once the client
+has been reviewed.
+
+The setting names a *factory*, not the validator itself. It is called with the application and
+returns a callable that takes one URI string and raises
+:class:`~django.core.exceptions.ValidationError` when the URI is unacceptable::
+
+    factory(application) -> callable(uri)
+
+``Application.clean()`` calls the factory **once per validation pass**, so a factory backed by the
+database queries once per save rather than once per URI. The application may be unsaved
+(``pk is None``) when it is registered through Dynamic Client Registration (:rfc:`7591`),
+:doc:`CIMD <cimd>` or the admin add form, so a factory must not assume its reverse relations exist.
+
+A class is a callable too, so a validator can subclass ``oauth2_provider.validators.AllowedURIValidator``
+and take the application in ``__init__``, inheriting all of its :rfc:`3986` / :rfc:`8252` parsing::
+
+    from oauth2_provider.validators import AllowedURIValidator
+
+    class DBSchemeValidator(AllowedURIValidator):
+        def __init__(self, application):
+            schemes = list(application.approved_schemes.values_list("scheme", flat=True))
+            super().__init__(schemes, name="redirect uri", allow_path=True, allow_query=True)
+
+    OAUTH2_PROVIDER = {
+        "REDIRECT_URI_VALIDATOR": "myapp.validators.DBSchemeValidator",
+    }
+
+To set the policy per application instead of server-wide, override
+``Application.get_redirect_uri_validator()`` on a :ref:`swapped application model
+<custom-uri-validators>`.
+
+Unlike ``RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR``, this setting may **not** be ``None``: skipping
+redirect-uri validation entirely is an open-redirect risk, so an empty value raises at first access.
+A deliberate no-op is still available, spelled explicitly as a factory returning ``lambda uri: None``.
+
+.. warning::
+    This gates what may be **stored**, not what is accepted at request time. An incoming
+    ``redirect_uri`` is still matched against the stored values by exact string comparison per
+    :rfc:`9700` section 2.1, which no validator here can relax -- a validator that permits a sloppy
+    URI merely stores a value that never matches.
+
+    Conversely, permitting a new **scheme** here is not enough on its own: the scheme is separately
+    gated at request time by ``Application.get_allowed_schemes()`` (see
+    ``ALLOWED_REDIRECT_URI_SCHEMES`` above), so a URI accepted here can still be refused when the
+    redirect is issued. Widen both, and remember that widening the accepted set widens the
+    open-redirect and phishing surface.
+
+    The :rfc:`9700` deploy checks ``W008`` and ``W009`` read ``ALLOWED_REDIRECT_URI_SCHEMES`` and
+    ``ALLOW_URI_WILDCARDS`` statically, so they cannot see through a custom validator and may both
+    false-positive and false-negative. A custom validator owns its own :rfc:`9700` section 2.1 posture.
+
+    On the Dynamic Client Registration and CIMD paths the validator is the *only* check on redirect
+    uri syntax, and its message is surfaced verbatim to the registering client in
+    ``error_description``. Write client-facing messages there.
+
+ALLOWED_ORIGIN_VALIDATOR
+~~~~~~~~~~~~~~~~~~~~~~~~
+Default: ``"oauth2_provider.validators.default_allowed_origin_validator"``
+
+A callable that builds the validator applied to each entry in an application's ``allowed_origins``.
+It follows exactly the same factory contract as ``REDIRECT_URI_VALIDATOR`` above, including the
+prohibition on ``None``, and is overridable per application as
+``Application.get_allowed_origin_validator()``.
+
+.. warning::
+    As above, this gates only what may be stored. An origin whose scheme is outside
+    ``ALLOWED_SCHEMES`` is still rejected at request time by ``is_origin_allowed()``, so a custom
+    validator that permits one must widen ``ALLOWED_SCHEMES`` too.
 
 ALLOW_LOCALHOST_LOOPBACK
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -31,7 +31,10 @@ from .settings import oauth2_settings
 # constructs one itself -- the validator is built by the REDIRECT_URI_VALIDATOR /
 # ALLOWED_ORIGIN_VALIDATOR factories -- but the name has long been importable from here.
 # Import it from oauth2_provider.validators in new code.
-from .validators import AllowedURIValidator  # noqa: F401
+#
+# Spelled as a redundant alias: that is the standard marker for a deliberate re-export
+# (PEP 484), so linters read the intent from the code rather than from this comment.
+from .validators import AllowedURIValidator as AllowedURIValidator  # noqa: F401
 
 
 logger = logging.getLogger(__name__)

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -27,6 +27,12 @@ from .core.utils import jwk_allows_verification, jwk_from_pem
 from .generators import generate_client_id, generate_client_secret
 from .settings import oauth2_settings
 
+# AllowedURIValidator is re-exported for backwards compatibility. clean() no longer
+# constructs one itself -- the validator is built by the REDIRECT_URI_VALIDATOR /
+# ALLOWED_ORIGIN_VALIDATOR factories -- but the name has long been importable from here.
+# Import it from oauth2_provider.validators in new code.
+from .validators import AllowedURIValidator  # noqa: F401
+
 
 logger = logging.getLogger(__name__)
 

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -395,7 +395,11 @@ class AbstractApplication(models.Model):
         return self.allowed_origins and is_origin_allowed(origin, self.allowed_origins.split())
 
     @staticmethod
-    def _collect_uri_validation_error(field_errors, field, exc):
+    def _collect_uri_validation_error(
+        field_errors: defaultdict[str, list[ValidationError]],
+        field: str,
+        exc: ValidationError,
+    ) -> None:
         """Fold a URI validator's ValidationError into the per-field error map.
 
         The built-in validators always raise a message-and-params error, whose parts are
@@ -609,7 +613,7 @@ class AbstractApplication(models.Model):
         """
         return oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES
 
-    def get_redirect_uri_validator(self):
+    def get_redirect_uri_validator(self) -> Callable[[str], None]:
         """
         Returns the validator ``clean()`` applies to each entry in ``redirect_uris``.
         By default, builds one from the `REDIRECT_URI_VALIDATOR` setting.
@@ -627,7 +631,7 @@ class AbstractApplication(models.Model):
         """
         return oauth2_settings.REDIRECT_URI_VALIDATOR(self)
 
-    def get_allowed_origin_validator(self):
+    def get_allowed_origin_validator(self) -> Callable[[str], None]:
         """
         Returns the validator ``clean()`` applies to each entry in ``allowed_origins``.
         By default, builds one from the `ALLOWED_ORIGIN_VALIDATOR` setting.

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -26,7 +26,6 @@ from .core.scopes import get_scopes_backend
 from .core.utils import jwk_allows_verification, jwk_from_pem
 from .generators import generate_client_id, generate_client_secret
 from .settings import oauth2_settings
-from .validators import AllowedURIValidator
 
 
 logger = logging.getLogger(__name__)
@@ -415,19 +414,12 @@ class AbstractApplication(models.Model):
         field_errors = defaultdict(list)
 
         redirect_uris = self.redirect_uris.strip().split()
-        allowed_schemes = set(s.lower() for s in self.get_allowed_schemes())
 
         if redirect_uris:
-            validator = AllowedURIValidator(
-                allowed_schemes,
-                name="redirect uri",
-                allow_path=True,
-                allow_query=True,
-                allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
-            )
+            redirect_uri_validator = self.get_redirect_uri_validator()
             for uri in redirect_uris:
                 try:
-                    validator(uri)
+                    redirect_uri_validator(uri)
                 except ValidationError as exc:
                     field_errors["redirect_uris"].extend(exc.error_list)
 
@@ -441,15 +433,10 @@ class AbstractApplication(models.Model):
             )
         allowed_origins = self.allowed_origins.strip().split()
         if allowed_origins:
-            # oauthlib allows only https scheme for CORS
-            validator = AllowedURIValidator(
-                oauth2_settings.ALLOWED_SCHEMES,
-                "allowed origin",
-                allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
-            )
+            allowed_origin_validator = self.get_allowed_origin_validator()
             for uri in allowed_origins:
                 try:
-                    validator(uri)
+                    allowed_origin_validator(uri)
                 except ValidationError as exc:
                     field_errors["allowed_origins"].extend(exc.error_list)
 
@@ -594,6 +581,35 @@ class AbstractApplication(models.Model):
         By default, returns `ALLOWED_REDIRECT_URI_SCHEMES`.
         """
         return oauth2_settings.ALLOWED_REDIRECT_URI_SCHEMES
+
+    def get_redirect_uri_validator(self):
+        """
+        Returns the validator ``clean()`` applies to each entry in ``redirect_uris``.
+        By default, builds one from the `REDIRECT_URI_VALIDATOR` setting.
+
+        The setting names a factory called with this application; the object it returns is
+        called once per URI and raises ``ValidationError`` for anything unacceptable.
+        Because the factory runs once per ``clean()`` rather than once per URI, a policy
+        backed by the database queries once per save. Note this application may be unsaved
+        (``pk is None``) when registration goes through Dynamic Client Registration, CIMD
+        or the admin add form, so an override must not assume reverse relations exist.
+
+        This gates what may be *stored*. At request time a redirect uri is still matched by
+        exact string comparison (see ``check_redirect_to_uri_allowed()``), and the scheme is
+        separately gated by ``get_allowed_schemes()``, which no validator here can relax.
+        """
+        return oauth2_settings.REDIRECT_URI_VALIDATOR(self)
+
+    def get_allowed_origin_validator(self):
+        """
+        Returns the validator ``clean()`` applies to each entry in ``allowed_origins``.
+        By default, builds one from the `ALLOWED_ORIGIN_VALIDATOR` setting.
+
+        Follows the same factory contract as ``get_redirect_uri_validator()``. An origin
+        whose scheme is outside ``ALLOWED_SCHEMES`` is still rejected at request time by
+        ``is_origin_allowed()`` even if a custom validator lets it be stored.
+        """
+        return oauth2_settings.ALLOWED_ORIGIN_VALIDATOR(self)
 
     def allows_grant_type(self, *grant_types):
         return self.authorization_grant_type in grant_types

--- a/oauth2_provider/models.py
+++ b/oauth2_provider/models.py
@@ -385,6 +385,24 @@ class AbstractApplication(models.Model):
         """
         return self.allowed_origins and is_origin_allowed(origin, self.allowed_origins.split())
 
+    @staticmethod
+    def _collect_uri_validation_error(field_errors, field, exc):
+        """Fold a URI validator's ValidationError into the per-field error map.
+
+        The built-in validators always raise a message-and-params error, whose parts are
+        reachable as ``error_list``. A validator supplied through REDIRECT_URI_VALIDATOR /
+        ALLOWED_ORIGIN_VALIDATOR may instead raise one built from a dict, which has no
+        ``error_list`` at all -- reading it would raise ``AttributeError`` out of
+        ``clean()``. Honor the dict form by keying each of its messages to the field the
+        validator named, which also lets a custom validator report on a field of a swapped
+        application model.
+        """
+        if hasattr(exc, "error_dict"):
+            for error_field, messages in exc.error_dict.items():
+                field_errors[error_field].extend(messages)
+        else:
+            field_errors[field].extend(exc.error_list)
+
     def clean(self) -> None:
         """Validate the application, reporting each problem on the field it belongs to.
 
@@ -421,7 +439,7 @@ class AbstractApplication(models.Model):
                 try:
                     redirect_uri_validator(uri)
                 except ValidationError as exc:
-                    field_errors["redirect_uris"].extend(exc.error_list)
+                    self._collect_uri_validation_error(field_errors, "redirect_uris", exc)
 
         elif self.authorization_grant_type in grant_types:
             field_errors["redirect_uris"].append(
@@ -438,7 +456,7 @@ class AbstractApplication(models.Model):
                 try:
                     allowed_origin_validator(uri)
                 except ValidationError as exc:
-                    field_errors["allowed_origins"].extend(exc.error_list)
+                    self._collect_uri_validation_error(field_errors, "allowed_origins", exc)
 
         if self.algorithm == AbstractApplication.RS256_ALGORITHM:
             if not oauth2_settings.OIDC_RSA_PRIVATE_KEY:

--- a/oauth2_provider/settings.py
+++ b/oauth2_provider/settings.py
@@ -121,6 +121,13 @@ DEFAULTS = {
     "ALLOWED_SCHEMES": ["https"],
     "ALLOW_URI_WILDCARDS": False,
     "ALLOW_LOCALHOST_LOOPBACK": False,
+    # Factories building the validators Application.clean() applies to each redirect uri
+    # and each allowed origin. Each is called with the application and returns a callable
+    # taking one URI string. Keep these as import strings rather than direct references:
+    # oauth2_provider.validators imports this module lazily, and a direct reference here
+    # would make that a cycle.
+    "REDIRECT_URI_VALIDATOR": "oauth2_provider.validators.default_redirect_uri_validator",
+    "ALLOWED_ORIGIN_VALIDATOR": "oauth2_provider.validators.default_allowed_origin_validator",
     # Device Authorization Grant (RFC 8628)
     "OAUTH_DEVICE_VERIFICATION_URI": None,
     "OAUTH_DEVICE_VERIFICATION_URI_COMPLETE": None,
@@ -304,6 +311,11 @@ MANDATORY = (
     "OAUTH2_BACKEND_CLASS",
     "SCOPES",
     "ALLOWED_REDIRECT_URI_SCHEMES",
+    # Mandatory so that a None here fails loudly on first access instead of silently
+    # skipping registration-time URI validation. A deliberate no-op is still available as
+    # a factory returning ``lambda uri: None``.
+    "REDIRECT_URI_VALIDATOR",
+    "ALLOWED_ORIGIN_VALIDATOR",
     "OIDC_RESPONSE_TYPES_SUPPORTED",
     "OIDC_SUBJECT_TYPES_SUPPORTED",
     "OIDC_TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED",
@@ -327,6 +339,8 @@ IMPORT_STRINGS = (
     "REFRESH_TOKEN_ADMIN_CLASS",
     "DCR_REGISTRATION_PERMISSION_CLASSES",
     "RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR",
+    "REDIRECT_URI_VALIDATOR",
+    "ALLOWED_ORIGIN_VALIDATOR",
     "CIMD_METADATA_FETCHER",
     "CIMD_REGISTRATION_PERMISSION_CLASSES",
 )

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -226,10 +226,13 @@ def default_allowed_origin_validator(application):
     """
     from oauth2_provider.settings import oauth2_settings
 
-    # Unlike the redirect schemes above, ALLOWED_SCHEMES is passed through as configured.
-    # Origins are compared against it verbatim at request time by is_origin_allowed(), so
-    # lowercasing here would let clean() accept an origin the request-time check rejects.
-    # oauthlib allows only https scheme for CORS.
+    # The gate is ALLOWED_SCHEMES, whose default is https-only because oauthlib permits only
+    # https for CORS; adding "http" is supported for local development, and needs
+    # OAUTHLIB_INSECURE_TRANSPORT set as well.
+    #
+    # Unlike the redirect schemes above, it is passed through exactly as configured. Origins
+    # are compared against it verbatim at request time by is_origin_allowed(), so lowercasing
+    # here would let clean() accept an origin the request-time check then rejects.
     return AllowedURIValidator(
         oauth2_settings.ALLOWED_SCHEMES,
         "allowed origin",

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -1,9 +1,16 @@
 import re
+from typing import TYPE_CHECKING
 from urllib.parse import urlsplit
 
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
 from django.utils.encoding import force_str
+
+
+if TYPE_CHECKING:
+    # Only for annotations: models.py imports this module at runtime, so importing it
+    # back unguarded would be a cycle.
+    from .models import AbstractApplication
 
 
 class URIValidator(URLValidator):
@@ -183,7 +190,7 @@ class AllowedURIValidator(URIValidator):
             )
 
 
-def default_redirect_uri_validator(application):
+def default_redirect_uri_validator(application: "AbstractApplication") -> AllowedURIValidator:
     """Build the validator applied to each entry in ``Application.redirect_uris``.
 
     This is the default for the ``REDIRECT_URI_VALIDATOR`` setting, which names a
@@ -218,7 +225,7 @@ def default_redirect_uri_validator(application):
     )
 
 
-def default_allowed_origin_validator(application):
+def default_allowed_origin_validator(application: "AbstractApplication") -> AllowedURIValidator:
     """Build the validator applied to each entry in ``Application.allowed_origins``.
 
     This is the default for the ``ALLOWED_ORIGIN_VALIDATOR`` setting. It follows the same

--- a/oauth2_provider/validators.py
+++ b/oauth2_provider/validators.py
@@ -181,3 +181,57 @@ class AllowedURIValidator(URIValidator):
                 "%(name)s URI validation error. %(cause)s: %(value)s",
                 params={"name": self.name, "value": value, "cause": e},
             )
+
+
+def default_redirect_uri_validator(application):
+    """Build the validator applied to each entry in ``Application.redirect_uris``.
+
+    This is the default for the ``REDIRECT_URI_VALIDATOR`` setting, which names a
+    *factory*: a callable taking the application and returning a callable that takes a
+    single URI string and raises :class:`~django.core.exceptions.ValidationError` when it
+    is not acceptable. ``AbstractApplication.clean()`` calls the factory once per
+    validation pass, so a policy backed by the database queries once per save rather than
+    once per URI. The application may be unsaved (``pk is None``) on the registration
+    paths -- Dynamic Client Registration, CIMD and the admin add form -- so a custom
+    factory must not assume reverse relations exist.
+
+    A class is a callable too, so a custom validator can subclass
+    :class:`AllowedURIValidator` and take the application in ``__init__``, keeping all of
+    the RFC 3986 / RFC 8252 parsing above.
+    """
+    # Imported here rather than at module scope: this module is referenced from migration
+    # 0001 and must stay importable before Django settings are configured, and settings.py
+    # holds direct references to some defaults (e.g. OAUTH_DEVICE_USER_CODE_GENERATOR), so
+    # a module-level import would risk a cycle the moment a default here became one.
+    from oauth2_provider.settings import oauth2_settings
+
+    # urlsplit() lowercases the scheme, so the allowed schemes have to be lowercased for
+    # AllowedURIValidator's membership test to match. A swapped application model's
+    # get_allowed_schemes() may legitimately return e.g. "HTTPS".
+    schemes = set(s.lower() for s in application.get_allowed_schemes())
+    return AllowedURIValidator(
+        schemes,
+        name="redirect uri",
+        allow_path=True,
+        allow_query=True,
+        allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
+    )
+
+
+def default_allowed_origin_validator(application):
+    """Build the validator applied to each entry in ``Application.allowed_origins``.
+
+    This is the default for the ``ALLOWED_ORIGIN_VALIDATOR`` setting. It follows the same
+    factory contract as :func:`default_redirect_uri_validator`.
+    """
+    from oauth2_provider.settings import oauth2_settings
+
+    # Unlike the redirect schemes above, ALLOWED_SCHEMES is passed through as configured.
+    # Origins are compared against it verbatim at request time by is_origin_allowed(), so
+    # lowercasing here would let clean() accept an origin the request-time check rejects.
+    # oauthlib allows only https scheme for CORS.
+    return AllowedURIValidator(
+        oauth2_settings.ALLOWED_SCHEMES,
+        "allowed origin",
+        allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
+    )

--- a/tests/test_import_compat.py
+++ b/tests/test_import_compat.py
@@ -261,6 +261,19 @@ def test_oauth2_validator_composition_and_reexports():
     assert is_valid_resource_uri is rs_is_valid
 
 
+def test_models_reexports_allowed_uri_validator():
+    """``AllowedURIValidator`` stays importable from ``oauth2_provider.models``.
+
+    ``Application.clean()`` no longer constructs one -- the validator now comes from the
+    REDIRECT_URI_VALIDATOR / ALLOWED_ORIGIN_VALIDATOR factories (see #490) -- but the name
+    has long been importable from ``models``, so it is kept as an explicit re-export.
+    """
+    from oauth2_provider.models import AllowedURIValidator
+    from oauth2_provider.validators import AllowedURIValidator as canonical
+
+    assert AllowedURIValidator is canonical
+
+
 def test_client_package_is_standalone():
     """``oauth2_provider.client`` is the client side and must stay independent.
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1458,11 +1458,9 @@ def test_application_model_hook_overrides_the_setting(oauth2_settings, applicati
     with pytest.raises(ValidationError):
         application.clean()
 
-    with mock.patch.object(
-        type(application),
-        "get_redirect_uri_validator",
-        lambda self: private_use_scheme_factory(self),
-    ):
+    # The factory's signature already matches an unbound method's, so it can be patched in
+    # directly: as a class attribute it binds and receives the application as ``self``.
+    with mock.patch.object(type(application), "get_redirect_uri_validator", private_use_scheme_factory):
         application.clean()
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -29,6 +29,7 @@ from oauth2_provider.models import (
     redirect_to_uri_allowed,
     refresh_token_expire_timedelta,
 )
+from oauth2_provider.validators import AllowedURIValidator
 
 from . import presets
 from .common_testing import OAuth2ProviderTestCase as TestCase
@@ -1300,6 +1301,176 @@ def test_application_clean_reports_every_invalid_uri(oauth2_settings, applicatio
     assert len(messages) == 2
     assert "invalid-one" in messages[0]
     assert "invalid-two" in messages[1]
+
+
+# --- Pluggable redirect uri / allowed origin validators (see #490) -------------------
+#
+# Module-level so the settings can name them by import string, which is what exercises
+# the IMPORT_STRINGS wiring.
+
+
+def private_use_scheme_factory(application):
+    """Accepts one RFC 8252 private-use scheme, ignoring ALLOWED_REDIRECT_URI_SCHEMES."""
+    return AllowedURIValidator(["com.example.app"], name="redirect uri", allow_path=True, allow_query=True)
+
+
+def deny_all_redirect_uri_factory(application):
+    def validate(uri):
+        raise ValidationError("nope: %(value)s", params={"value": uri})
+
+    return validate
+
+
+def http_origin_factory(application):
+    """Allows a plain-http origin, which the default ALLOWED_SCHEMES rejects."""
+    return AllowedURIValidator(["http", "https"], "allowed origin")
+
+
+class ApplicationSchemeValidator(AllowedURIValidator):
+    """A class used directly as a factory: ``Cls(application)`` is the factory call."""
+
+    def __init__(self, application):
+        schemes = [s.lower() for s in application.get_allowed_schemes()] + ["com.example.app"]
+        super().__init__(schemes, name="redirect uri", allow_path=True, allow_query=True)
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_clean_builds_the_redirect_uri_validator_once(oauth2_settings, application):
+    """The factory runs once per clean(), not once per uri.
+
+    This is what lets a database-backed policy query once per save.
+    """
+    seen = []
+    hook = mock.Mock(side_effect=lambda: seen.append)
+    application.redirect_uris = "https://a.example/cb https://b.example/cb"
+    with mock.patch.object(type(application), "get_redirect_uri_validator", hook):
+        application.clean()
+
+    assert hook.call_count == 1
+    assert seen == ["https://a.example/cb", "https://b.example/cb"]
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_clean_builds_the_allowed_origin_validator_once(oauth2_settings, application):
+    seen = []
+    hook = mock.Mock(side_effect=lambda: seen.append)
+    application.allowed_origins = "https://a.example https://b.example"
+    with mock.patch.object(type(application), "get_allowed_origin_validator", hook):
+        application.clean()
+
+    assert hook.call_count == 1
+    assert seen == ["https://a.example", "https://b.example"]
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_clean_uses_the_default_validators(oauth2_settings, application):
+    """Out of the box the hooks build exactly what clean() used to construct inline."""
+    redirect_uri_validator = application.get_redirect_uri_validator()
+    assert isinstance(redirect_uri_validator, AllowedURIValidator)
+    assert redirect_uri_validator.name == "redirect uri"
+    assert redirect_uri_validator.allow_path
+    assert redirect_uri_validator.allow_query
+    assert redirect_uri_validator.schemes == {s.lower() for s in application.get_allowed_schemes()}
+
+    allowed_origin_validator = application.get_allowed_origin_validator()
+    assert isinstance(allowed_origin_validator, AllowedURIValidator)
+    assert allowed_origin_validator.name == "allowed origin"
+    assert not allowed_origin_validator.allow_path
+    assert allowed_origin_validator.schemes == oauth2_settings.ALLOWED_SCHEMES
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(
+    {
+        **presets.OIDC_SETTINGS_RW,
+        "REDIRECT_URI_VALIDATOR": "tests.test_models.private_use_scheme_factory",
+    }
+)
+def test_redirect_uri_validator_setting_accepts_a_custom_scheme(oauth2_settings, application):
+    """#490: a custom scheme without swapping the Application model."""
+    # The scheme is not in ALLOWED_REDIRECT_URI_SCHEMES, so the default would reject it.
+    assert "com.example.app" not in application.get_allowed_schemes()
+
+    application.redirect_uris = "com.example.app:/oauth2redirect"
+    application.clean()
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(
+    {
+        **presets.OIDC_SETTINGS_RW,
+        "REDIRECT_URI_VALIDATOR": "tests.test_models.deny_all_redirect_uri_factory",
+    }
+)
+def test_redirect_uri_validator_setting_can_reject(oauth2_settings, application):
+    """A rejection from a custom validator is still keyed to redirect_uris."""
+    application.redirect_uris = "https://example.org/cb"
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["redirect_uris"]
+    assert "nope: https://example.org/cb" in exc.value.message_dict["redirect_uris"][0]
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(
+    {
+        **presets.OIDC_SETTINGS_RW,
+        "ALLOWED_ORIGIN_VALIDATOR": "tests.test_models.http_origin_factory",
+    }
+)
+def test_allowed_origin_validator_setting_overrides_allowed_schemes(oauth2_settings, application):
+    # http origins are rejected by default; the custom validator permits them.
+    assert "http" not in oauth2_settings.ALLOWED_SCHEMES
+    application.allowed_origins = "http://example.com"
+    application.clean()
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(
+    {
+        **presets.OIDC_SETTINGS_RW,
+        "REDIRECT_URI_VALIDATOR": "tests.test_models.ApplicationSchemeValidator",
+    }
+)
+def test_redirect_uri_validator_setting_accepts_a_class(oauth2_settings, application):
+    """A class is a callable, so an AllowedURIValidator subclass works as the factory."""
+    application.redirect_uris = "https://example.org/cb com.example.app:/oauth2redirect"
+    application.clean()
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(presets.OIDC_SETTINGS_RW)
+def test_application_model_hook_overrides_the_setting(oauth2_settings, application):
+    """What a swapped model overrides -- the hook wins over the configured default."""
+    application.redirect_uris = "com.example.app:/oauth2redirect"
+    with pytest.raises(ValidationError):
+        application.clean()
+
+    with mock.patch.object(
+        type(application),
+        "get_redirect_uri_validator",
+        lambda self: private_use_scheme_factory(self),
+    ):
+        application.clean()
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.parametrize(
+    "setting,field,value",
+    [
+        ("REDIRECT_URI_VALIDATOR", "redirect_uris", "https://example.org/cb"),
+        ("ALLOWED_ORIGIN_VALIDATOR", "allowed_origins", "https://example.com"),
+    ],
+)
+def test_uri_validator_settings_may_not_be_none(oauth2_settings, application, setting, field, value):
+    """None would silently skip validation, so it is refused rather than tolerated."""
+    oauth2_settings.update({**presets.OIDC_SETTINGS_RW, setting: None})
+    setattr(application, field, value)
+    with pytest.raises(AttributeError, match="is mandatory"):
+        application.clean()
 
 
 def _client_assertion_application(**kwargs):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1321,6 +1321,15 @@ def deny_all_redirect_uri_factory(application):
     return validate
 
 
+def field_keyed_error_factory(application):
+    """Raises a dict-built ValidationError, which has no ``error_list``."""
+
+    def validate(uri):
+        raise ValidationError({"allowed_origins": ["reported on another field"]})
+
+    return validate
+
+
 def http_origin_factory(application):
     """Allows a plain-http origin, which the default ALLOWED_SCHEMES rejects."""
     return AllowedURIValidator(["http", "https"], "allowed origin")
@@ -1471,6 +1480,22 @@ def test_uri_validator_settings_may_not_be_none(oauth2_settings, application, se
     setattr(application, field, value)
     with pytest.raises(AttributeError, match="is mandatory"):
         application.clean()
+
+
+@pytest.mark.django_db(databases="__all__")
+@pytest.mark.oauth2_settings(
+    {
+        **presets.OIDC_SETTINGS_RW,
+        "REDIRECT_URI_VALIDATOR": "tests.test_models.field_keyed_error_factory",
+    }
+)
+def test_custom_validator_may_raise_a_field_keyed_error(oauth2_settings, application):
+    """A dict-built ValidationError is honored rather than crashing on error_list."""
+    application.redirect_uris = "https://example.org/cb"
+    with pytest.raises(ValidationError) as exc:
+        application.clean()
+    assert list(exc.value.message_dict) == ["allowed_origins"]
+    assert exc.value.message_dict["allowed_origins"] == ["reported on another field"]
 
 
 def _client_assertion_application(**kwargs):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -314,7 +314,13 @@ class TestPrivateUseURISchemeValidator(TestCase):
 
 
 class _FakeApplication:
-    """Stands in for an Application: the factories only touch get_allowed_schemes()."""
+    """Stands in for an Application.
+
+    ``default_redirect_uri_validator`` reads ``get_allowed_schemes()`` off the application;
+    ``default_allowed_origin_validator`` does not consult the application at all and takes
+    its schemes from ``ALLOWED_SCHEMES``. This stub therefore only has to answer the former,
+    and is passed to the latter purely to satisfy the shared factory signature.
+    """
 
     def __init__(self, allowed_schemes):
         self._allowed_schemes = allowed_schemes

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,7 +1,11 @@
 import pytest
 from django.core.validators import ValidationError
 
-from oauth2_provider.validators import AllowedURIValidator
+from oauth2_provider.validators import (
+    AllowedURIValidator,
+    default_allowed_origin_validator,
+    default_redirect_uri_validator,
+)
 
 from .common_testing import OAuth2ProviderTestCase as TestCase
 
@@ -307,3 +311,66 @@ class TestPrivateUseURISchemeValidator(TestCase):
         validator = AllowedURIValidator(["com.example.app"], "test")
         with self.assertRaises(ValidationError):
             validator("com.example.app:/oauth2redirect")
+
+
+class _FakeApplication:
+    """Stands in for an Application: the factories only touch get_allowed_schemes()."""
+
+    def __init__(self, allowed_schemes):
+        self._allowed_schemes = allowed_schemes
+
+    def get_allowed_schemes(self):
+        return self._allowed_schemes
+
+
+@pytest.mark.usefixtures("oauth2_settings")
+class TestDefaultValidatorFactories(TestCase):
+    """The factories behind REDIRECT_URI_VALIDATOR / ALLOWED_ORIGIN_VALIDATOR."""
+
+    def test_redirect_uri_validator_configuration(self):
+        validator = default_redirect_uri_validator(_FakeApplication(["https", "http"]))
+        self.assertIsInstance(validator, AllowedURIValidator)
+        self.assertEqual(validator.name, "redirect uri")
+        self.assertTrue(validator.allow_path)
+        self.assertTrue(validator.allow_query)
+        self.assertFalse(validator.allow_fragments)
+        self.assertEqual(validator.schemes, {"https", "http"})
+
+    def test_allowed_origin_validator_configuration(self):
+        validator = default_allowed_origin_validator(_FakeApplication(["https"]))
+        self.assertIsInstance(validator, AllowedURIValidator)
+        self.assertEqual(validator.name, "allowed origin")
+        self.assertFalse(validator.allow_path)
+        self.assertFalse(validator.allow_query)
+        self.assertFalse(validator.allow_fragments)
+        # Passed through verbatim, and taken from the setting rather than the application.
+        self.assertEqual(validator.schemes, self.oauth2_settings.ALLOWED_SCHEMES)
+
+    def test_redirect_uri_validator_lowercases_application_schemes(self):
+        # urlsplit() lowercases the scheme, so an application returning "HTTPS" from
+        # get_allowed_schemes() must still accept an https redirect uri.
+        validator = default_redirect_uri_validator(_FakeApplication(["HTTPS", "Com.Example.App"]))
+        self.assertEqual(validator.schemes, {"https", "com.example.app"})
+        validator("https://example.com/cb")
+        validator("com.example.app:/oauth2redirect")
+
+    def test_allowed_origin_validator_does_not_lowercase_schemes(self):
+        # ALLOWED_SCHEMES is compared verbatim at request time by is_origin_allowed(), so
+        # lowercasing it here would let clean() accept an origin that is rejected later.
+        self.oauth2_settings.ALLOWED_SCHEMES = ["HTTPS"]
+        validator = default_allowed_origin_validator(_FakeApplication(["https"]))
+        self.assertEqual(validator.schemes, ["HTTPS"])
+        with self.assertRaises(ValidationError):
+            validator("https://example.com")
+
+    def test_factories_read_wildcard_setting_at_call_time(self):
+        # Settings are imported inside the factory bodies, so a change is picked up
+        # without reimporting the module.
+        application = _FakeApplication(["https"])
+        self.oauth2_settings.ALLOW_URI_WILDCARDS = False
+        self.assertFalse(default_redirect_uri_validator(application).allow_hostname_wildcard)
+        self.assertFalse(default_allowed_origin_validator(application).allow_hostname_wildcard)
+
+        self.oauth2_settings.ALLOW_URI_WILDCARDS = True
+        self.assertTrue(default_redirect_uri_validator(application).allow_hostname_wildcard)
+        self.assertTrue(default_allowed_origin_validator(application).allow_hostname_wildcard)


### PR DESCRIPTION
Fixes #490

## Description of the Change

`Application.clean()` hard-coded the `AllowedURIValidator` it applied to `redirect_uris` and `allowed_origins`. Redirect-uri policy that a static scheme list cannot express — schemes held in the database, a blacklist, or a scheme accepted only once the client has been reviewed, which RFC 8252 native apps tend to need — could therefore only be had by swapping the Application model and reimplementing `clean()`'s error-keying contract by hand. #490 asks for a settings-level hook instead.

This adds two layers, composing the way `SCOPES_BACKEND_CLASS` and `get_allowed_schemes()` already do:

- **`REDIRECT_URI_VALIDATOR` / `ALLOWED_ORIGIN_VALIDATOR`** settings (both in `IMPORT_STRINGS`), setting the default for a whole deployment with no custom model.
- **`Application.get_redirect_uri_validator()` / `get_allowed_origin_validator()`**, overridable on a swapped model for per-application policy.

### The contract

Each setting names a *factory*, not a validator: `factory(application) -> callable(uri)`, raising `ValidationError`. `clean()` calls the factory once per validation pass and applies the result to each URI, so a policy backed by the database queries **once per save** rather than once per URI. Since a class is a callable, a custom validator can subclass `AllowedURIValidator` and take the application in `__init__`, inheriting all of its RFC 3986 / RFC 8252 parsing:

```python
class DBSchemeValidator(AllowedURIValidator):
    def __init__(self, application):
        schemes = list(application.approved_schemes.values_list("scheme", flat=True))
        super().__init__(schemes, name="redirect uri", allow_path=True, allow_query=True)
```

Both settings are in `MANDATORY`: a `None` would be skipped by `perform_import` and only surface later as `TypeError: 'NoneType' object is not callable`, silently disabling a security-relevant gate. A deliberate no-op is still available, spelled explicitly as a factory returning `lambda uri: None`. This deliberately differs from `RESOURCE_SERVER_TOKEN_RESOURCE_VALIDATOR`, which is nullable because RFC 8707 audience binding is opt-in; the divergence is noted in the docs.

### Notes for review

- **Defaults are unchanged.** The two default factories reproduce the previous construction exactly. Two asymmetries in the old code are preserved deliberately and each has a dedicated test: redirect schemes are lowercased (`urlsplit()` lowercases the scheme, and a swapped model may return `"HTTPS"`), origin schemes are **not** (`is_origin_allowed()` compares `ALLOWED_SCHEMES` verbatim at request time, so lowercasing here would accept an origin that is later rejected).
- **No migration.** No field carried a `validators=` kwarg; `makemigrations --check` is clean under both `tests.settings` and `tests.settings_swapped`.
- **No import-path break.** `AllowedURIValidator` stays importable from `oauth2_provider.models` as an explicit re-export, with a `test_import_compat` case asserting object identity against `oauth2_provider.validators`.
- **Every registration path is covered for free**, since admin, the built-in forms, DCR, CIMD and `createapplication` all route through `full_clean()`. DCR already wraps the resulting `ValidationError` as `invalid_client_metadata`, so no changes were needed there.
- **Methods, not properties.** The issue thread suggested `redirect_uri_validator` / `allowed_origin_validator` properties. `get_*()` matches `get_allowed_schemes()` and `get_absolute_url()` on the same class, and leaves room to add a `field=` argument later without a deprecation — relevant to the follow-up below. Happy to flip this if preferred.
- **Second commit** (`fix(models): honor field-keyed errors…`) is separable. `clean()` collected failures with `exc.error_list`, which does not exist on a `ValidationError` built from a dict — unreachable while only the library's own validator ran there, reachable from third-party code now. It also lets a custom validator report onto a field of a swapped model, which review-gated policy wants.

### Security framing

The docs state this in both new sections, because the natural misreading is "I can now customize redirect-uri *matching*":

- These hooks gate what may be **stored**. Request-time matching stays exact per RFC 9700 §2.1 and no hook can relax it — a validator accepting a sloppy URI merely stores a value that never matches.
- `get_allowed_schemes()` is *also* a request-time gate, so permitting a new scheme here without widening `ALLOWED_REDIRECT_URI_SCHEMES` yields an application that saves cleanly and then fails at redirect time. Same for origins and `ALLOWED_SCHEMES`.
- The RFC 9700 deploy checks `W008`/`W009` read those settings statically and cannot see through a custom validator, so they may both false-positive and false-negative.
- On the DCR/CIMD paths the validator is the *only* check on redirect-uri syntax, and its message reaches the registering client verbatim in `error_description`.

Per that last point, no new system check ships here — one that could see through an arbitrary callable does not exist.

### Follow-up, not in this PR

`post_logout_redirect_uris` is never validated in `clean()` at all, despite being matched at request time by `post_logout_redirect_uri_allowed()`. Validating it now would reject existing stored rows on the next save, so it wants its own issue.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

<sub>The last two are N/A: this changes a validation seam whose defaults are unchanged, so the demo IdP/RP apps exercise it identically either way.</sub>

Testing: 1499 passed, 1 skipped. New tests fail on `master` and pass here. `ruff check` / `ruff format --check` clean; `makemigrations --check` clean under both settings modules; docs build adds no new warnings and `sphinx-lint` is clean on both changed files.

Rebased onto `master` at 2ac136a (#1836); the only conflict was two additive `## [unreleased]` changelog entries, both kept.