### PR TITLE
Add cross-site third-party cookie browser tests for silent login

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -554,6 +554,16 @@ jobs:
       - name: Install tox
         run: python -m pip install --upgrade tox
 
+      - name: Map the cross-site e2e hostnames to loopback
+        # The third-party-cookie layer needs the IdP and the RP on two genuinely
+        # distinct registrable domains; .test is absent from the Public Suffix
+        # List, so idp.test and rp.test are different sites. Without this the
+        # layer fails hard (E2E_REQUIRE_BROWSER is set below) rather than
+        # silently skipping.
+        run: |
+          echo "127.0.0.1 idp.test rp.test" | sudo tee -a /etc/hosts
+          getent hosts idp.test rp.test
+
       - name: Run end-to-end compliance suite
         # Require the browser layer on CI: a missing/broken Chromium fails the
         # job rather than silently skipping the browser RP coverage.

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ venv/
 /.e2e-venv/
 /compliance-matrix.md
 /compliance-matrix.json
-/.rp-server.log
+# The e2e RP dev-server log, one per port (see tests/e2e/helpers/rp_process.py).
+/.rp-server-*.log
 /tests/e2e/reports/
 /.venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ markers = [
     "spec_oidc_discovery: OpenID Connect Discovery 1.0",
     "spec_oidc_rp_logout: OpenID Connect RP-Initiated Logout 1.0",
     "spec_browser_rp: Browser RP (SvelteKit) end-to-end",
+    "spec_browser_cross_site: Browser RP third-party-cookie behaviour across distinct sites (idp.test/rp.test)",
 ]
 
 [tool.ruff]

--- a/tests/app/idp/fixtures/seed.json
+++ b/tests/app/idp/fixtures/seed.json
@@ -21,8 +21,8 @@
   "fields": {
     "client_id": "2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm",
     "user": null,
-    "redirect_uris": "http://localhost:5173\r\nhttp://127.0.0.1:5173",
-    "post_logout_redirect_uris": "http://localhost:5173\r\nhttp://127.0.0.1:5173",
+    "redirect_uris": "http://localhost:5173\r\nhttp://127.0.0.1:5173\r\nhttps://rp.test:5443\r\nhttps://rp.test:5443/silent-callback.html",
+    "post_logout_redirect_uris": "http://localhost:5173\r\nhttp://127.0.0.1:5173\r\nhttps://rp.test:5443",
     "client_type": "public",
     "authorization_grant_type": "authorization-code",
     "client_secret": "pbkdf2_sha256$600000$HEYByn6WXiQUI1D6ezTnAf$qPLekt0t3ZssnzEOvQkeOSfxx7tbs/gcC3O0CthtP2A=",
@@ -32,7 +32,7 @@
     "created": "2023-05-01T20:27:46.167Z",
     "updated": "2023-11-11T17:23:44.643Z",
     "algorithm": "RS256",
-    "allowed_origins": "http://localhost:5173\r\nhttp://127.0.0.1:5173"
+    "allowed_origins": "http://localhost:5173\r\nhttp://127.0.0.1:5173\r\nhttps://rp.test:5443"
   }
 },
 {

--- a/tests/app/idp/idp/oauth.py
+++ b/tests/app/idp/idp/oauth.py
@@ -14,7 +14,7 @@ def get_response():
 
 
 class CustomOAuth2Validator(OAuth2Validator):
-    def validate_silent_login(self, request) -> None:
+    def validate_silent_login(self, request) -> bool:
         # request is an OAuthLib.common.Request and doesn't have the session
         # or user of the django request. We will emulate the session and auth
         # middleware here, since that is what the idp is using for auth. You
@@ -22,14 +22,26 @@ class CustomOAuth2Validator(OAuth2Validator):
         # middleware or auth backend.
 
         session_cookie_name = settings.SESSION_COOKIE_NAME
-        HTTP_COOKIE = request.headers.get("HTTP_COOKIE")
-        COOKIES = HTTP_COOKIE.split("; ")
-        for cookie in COOKIES:
-            cookie_name, cookie_value = cookie.split("=")
-            if cookie.startswith(session_cookie_name):
+        # HTTP_COOKIE is missing from request.headers entirely when the user
+        # agent sends no Cookie header at all. That is the normal case for a
+        # prompt=none request in a hidden third-party iframe under a browser
+        # that partitions or blocks third-party cookies (Firefox's Total Cookie
+        # Protection): there is no OP session to authenticate against, so the
+        # request must resolve to login_required rather than raising.
+        cookie_header = request.headers.get("HTTP_COOKIE") or ""
+        session_key = None
+        for cookie in cookie_header.split(";"):
+            # partition() rather than split("="): a cookie value may itself
+            # contain "=" (base64 padding, for one), which unpacking rejects.
+            name, _, value = cookie.strip().partition("=")
+            if name == session_cookie_name:
+                session_key = value
                 break
+        if not session_key:
+            return False
+
         session_middleware = SessionMiddleware(get_response)
-        session = session_middleware.SessionStore(cookie_value)
+        session = session_middleware.SessionStore(session_key)
         # add session to request for compatibility with django.contrib.auth
         request.session = session
 
@@ -38,7 +50,7 @@ class CustomOAuth2Validator(OAuth2Validator):
         auth_middleware.process_request(request)
         return request.user.is_authenticated
 
-    def validate_silent_authorization(self, request) -> None:
+    def validate_silent_authorization(self, request) -> bool:
         return True
 
     def get_additional_claims(self, request):

--- a/tests/app/idp/idp/settings.py
+++ b/tests/app/idp/idp/settings.py
@@ -100,6 +100,16 @@ ipUMvb4Se0LDJnmFuv8v6gM6V4vyXkP855mNOiRHUOHOSKdQ3SeKrLlnR6I=
     OAUTH2_PROVIDER_PKCE_REQUIRED=(bool, True),
     OAUTH2_PROVIDER_PKCE_REQUIRED_CLIENT_IDS=(list, []),
     OAUTH2_PROVIDER_ALLOWED_SCHEMES=(list, ["https", "http"]),
+    # Cookie/CSRF posture is env-driven so the cross-site end-to-end layer can
+    # serve this IdP over TLS with SESSION_COOKIE_SAMESITE=None -- required for
+    # the OP session cookie to reach a third-party iframe at all, and only
+    # honoured by browsers alongside Secure. The defaults reproduce Django's own
+    # defaults, so plain-HTTP local runs are unaffected.
+    SESSION_COOKIE_SAMESITE=(str, "Lax"),
+    SESSION_COOKIE_SECURE=(bool, False),
+    CSRF_COOKIE_SAMESITE=(str, "Lax"),
+    CSRF_COOKIE_SECURE=(bool, False),
+    CSRF_TRUSTED_ORIGINS=(list, []),
     # RFC 9700 compliance gates, env-driven so the e2e suite and the Docker
     # image can exercise both the legacy (False, the library default) and the
     # enforced (True) position of every gate without a code change.
@@ -133,6 +143,12 @@ SECRET_KEY = env("SECRET_KEY")
 DEBUG = env("DEBUG")
 
 ALLOWED_HOSTS = env("ALLOWED_HOSTS")
+
+SESSION_COOKIE_SAMESITE = env("SESSION_COOKIE_SAMESITE")
+SESSION_COOKIE_SECURE = env("SESSION_COOKIE_SECURE")
+CSRF_COOKIE_SAMESITE = env("CSRF_COOKIE_SAMESITE")
+CSRF_COOKIE_SECURE = env("CSRF_COOKIE_SECURE")
+CSRF_TRUSTED_ORIGINS = env("CSRF_TRUSTED_ORIGINS")
 
 
 # Application definition

--- a/tests/app/rp/.gitignore
+++ b/tests/app/rp/.gitignore
@@ -6,6 +6,9 @@ node_modules
 /.svelte-kit-*
 /.vite-*
 /package
+# The repo-root .gitignore excludes a bare `lib` (a Python build artifact) at
+# any depth, which silently swallows SvelteKit's src/lib. Re-include it here.
+!src/lib/
 .env
 .env.*
 !.env.example

--- a/tests/app/rp/.gitignore
+++ b/tests/app/rp/.gitignore
@@ -2,6 +2,9 @@
 node_modules
 /build
 /.svelte-kit
+# Per-server build/cache dirs for the cross-site e2e layer (RP_OUT_DIR/RP_CACHE_DIR).
+/.svelte-kit-*
+/.vite-*
 /package
 .env
 .env.*

--- a/tests/app/rp/README.md
+++ b/tests/app/rp/README.md
@@ -31,6 +31,8 @@ reproduce the historical hard-coded values.
 | `RP_TLS_CERT` / `RP_TLS_KEY` | unset                     | Serve the dev server over HTTPS with this certificate.                     |
 | `RP_ALLOWED_HOSTS`           | unset                     | Comma-separated hostnames Vite will answer for, beyond localhost.          |
 
+These are read once in `src/lib/oidc-config.js`, which both pages import.
+
 The `/device` and `/par` demos remain pinned to `localhost` / `127.0.0.1`; only
 the pages above honour `PUBLIC_RP_*`.
 

--- a/tests/app/rp/README.md
+++ b/tests/app/rp/README.md
@@ -16,6 +16,28 @@ npm create svelte@latest
 npm create svelte@latest my-app
 ```
 
+## Configuration
+
+The OIDC code-flow page (`/`) and the silent-login probe (`/silent`) read their
+configuration at runtime, so the same app can be pointed at a different
+authorization server without a rebuild. Every variable is optional; the defaults
+reproduce the historical hard-coded values.
+
+| Variable                     | Default                   | Purpose                                                                    |
+| ---------------------------- | ------------------------- | -------------------------------------------------------------------------- |
+| `PUBLIC_RP_ISSUER`           | `http://localhost:8000/o` | The OP's issuer URL.                                                       |
+| `PUBLIC_RP_CLIENT_ID`        | the seed OIDC client      | The client to authenticate as.                                             |
+| `PUBLIC_RP_ORIGIN`           | `http://localhost:5173`   | This RP's own origin, used for the redirect and post-logout redirect URIs. |
+| `RP_TLS_CERT` / `RP_TLS_KEY` | unset                     | Serve the dev server over HTTPS with this certificate.                     |
+| `RP_ALLOWED_HOSTS`           | unset                     | Comma-separated hostnames Vite will answer for, beyond localhost.          |
+
+The `/device` and `/par` demos remain pinned to `localhost` / `127.0.0.1`; only
+the pages above honour `PUBLIC_RP_*`.
+
+The end-to-end suite's cross-site layer
+(`tests/e2e/browser_cross_site`) uses all of these to run this app on
+`https://rp.test:5443` against an IdP on `https://idp.test:8443`.
+
 ## Developing
 
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:

--- a/tests/app/rp/src/lib/oidc-config.js
+++ b/tests/app/rp/src/lib/oidc-config.js
@@ -1,0 +1,15 @@
+import { env } from '$env/dynamic/public';
+
+// Runtime configuration shared by every page that talks to the OP.
+//
+// $env/dynamic/public is read from process.env on each request by the dev
+// server and by adapter-node, so this needs no build step and no committed
+// .env file. The defaults are the historical hard-coded values, so `npm run
+// dev` still talks to a local IdP on :8000 with this RP on :5173; the
+// cross-site end-to-end layer (tests/e2e/browser_cross_site) overrides them to
+// put the IdP and the RP on two genuinely different registrable domains.
+//
+// The client id is the one seeded in tests/app/idp/fixtures/seed.json.
+export const issuer = env.PUBLIC_RP_ISSUER || 'http://localhost:8000/o';
+export const clientId = env.PUBLIC_RP_CLIENT_ID || '2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm';
+export const rpOrigin = env.PUBLIC_RP_ORIGIN || 'http://localhost:5173';

--- a/tests/app/rp/src/routes/+page.svelte
+++ b/tests/app/rp/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script>
 	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
+	import { clientId, issuer, rpOrigin } from '$lib/oidc-config';
 	import {
 		EventLog,
 		LoginButton,
@@ -14,16 +14,6 @@
 		isLoading,
 		userInfo
 	} from '@dopry/svelte-oidc';
-
-	// Runtime configuration. $env/dynamic/public is read from process.env on
-	// every request by the dev server and by adapter-node, so it needs no build
-	// step and no committed .env file. The defaults are the historical
-	// hard-coded values, so `npm run dev` still talks to a local IdP on :8000
-	// with this RP on :5173; the cross-site end-to-end layer overrides them to
-	// put the IdP and the RP on two genuinely different registrable domains.
-	const issuer = env.PUBLIC_RP_ISSUER || 'http://localhost:8000/o';
-	const clientId = env.PUBLIC_RP_CLIENT_ID || '2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm';
-	const rpOrigin = env.PUBLIC_RP_ORIGIN || 'http://localhost:5173';
 
 	const metadata = {};
 </script>

--- a/tests/app/rp/src/routes/+page.svelte
+++ b/tests/app/rp/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import { browser } from '$app/environment';
+	import { env } from '$env/dynamic/public';
 	import {
 		EventLog,
 		LoginButton,
@@ -14,15 +15,25 @@
 		userInfo
 	} from '@dopry/svelte-oidc';
 
+	// Runtime configuration. $env/dynamic/public is read from process.env on
+	// every request by the dev server and by adapter-node, so it needs no build
+	// step and no committed .env file. The defaults are the historical
+	// hard-coded values, so `npm run dev` still talks to a local IdP on :8000
+	// with this RP on :5173; the cross-site end-to-end layer overrides them to
+	// put the IdP and the RP on two genuinely different registrable domains.
+	const issuer = env.PUBLIC_RP_ISSUER || 'http://localhost:8000/o';
+	const clientId = env.PUBLIC_RP_CLIENT_ID || '2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm';
+	const rpOrigin = env.PUBLIC_RP_ORIGIN || 'http://localhost:5173';
+
 	const metadata = {};
 </script>
 
 {#if browser}
 	<OidcContext
-		issuer="http://localhost:8000/o"
-		client_id="2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm"
-		redirect_uri="http://localhost:5173"
-		post_logout_redirect_uri="http://localhost:5173"
+		{issuer}
+		client_id={clientId}
+		redirect_uri={rpOrigin}
+		post_logout_redirect_uri={rpOrigin}
 		{metadata}
 		scope="openid"
 		extraOptions={{

--- a/tests/app/rp/src/routes/silent/+page.svelte
+++ b/tests/app/rp/src/routes/silent/+page.svelte
@@ -1,0 +1,87 @@
+<script>
+	import { browser } from '$app/environment';
+	import { env } from '$env/dynamic/public';
+	import { onMount } from 'svelte';
+
+	const issuer = env.PUBLIC_RP_ISSUER || 'http://localhost:8000/o';
+	const clientId = env.PUBLIC_RP_CLIENT_ID || '2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm';
+	const rpOrigin = env.PUBLIC_RP_ORIGIN || 'http://localhost:5173';
+	const redirectUri = `${rpOrigin}/silent-callback.html`;
+
+	// How long to wait for the iframe to report back before calling it a
+	// timeout. A hidden iframe that never resolves would otherwise look
+	// indistinguishable from one that is merely slow.
+	const TIMEOUT_MS = 15000;
+
+	let outcome = 'pending';
+	let detail = '';
+	let src = '';
+
+	function handleMessage(event) {
+		if (event.origin !== window.location.origin) return;
+		if (!event.data || event.data.type !== 'silent-login-result') return;
+		const params = new URLSearchParams(event.data.search);
+		if (params.get('code')) {
+			outcome = 'code';
+		} else if (params.get('error')) {
+			outcome = params.get('error');
+		} else {
+			outcome = 'no-parameters';
+		}
+		detail = event.data.search;
+	}
+
+	onMount(() => {
+		window.addEventListener('message', handleMessage);
+		const params = new URLSearchParams({
+			client_id: clientId,
+			response_type: 'code',
+			redirect_uri: redirectUri,
+			scope: 'openid',
+			state: 'silent-login-probe',
+			prompt: 'none'
+		});
+		src = `${issuer}/authorize/?${params.toString()}`;
+		const timer = setTimeout(() => {
+			if (outcome === 'pending') outcome = 'timeout';
+		}, TIMEOUT_MS);
+		return () => {
+			clearTimeout(timer);
+			window.removeEventListener('message', handleMessage);
+		};
+	});
+</script>
+
+<div class="row">
+	<div class="col s12">
+		<h5>Silent login probe</h5>
+		<p>
+			This page frames the OP's authorization endpoint with <code>prompt=none</code>. If the
+			OP's session cookie reaches the third-party iframe, the OP recognises the session and
+			answers with an authorization <code>code</code>. If the browser blocks or partitions
+			that cookie — as Firefox's Total Cookie Protection does by default — the OP sees an
+			unauthenticated request and answers <code>login_required</code> instead. Nothing about the
+			OP differs between the two; only the user agent's cookie policy does.
+		</p>
+		<table>
+			<tbody>
+				<tr>
+					<td style="width: 20%;">outcome</td>
+					<td><strong data-testid="silent-outcome">{outcome}</strong></td>
+				</tr>
+				<tr>
+					<td>authorization response</td>
+					<td data-testid="silent-detail" style="word-break: break-all;">{detail}</td>
+				</tr>
+				<tr>
+					<td>iframe src</td>
+					<td data-testid="silent-src" style="word-break: break-all;">{src}</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</div>
+
+{#if browser && src}
+	<iframe title="silent-login" {src} style="width: 1px; height: 1px; border: 0;"></iframe>
+{/if}

--- a/tests/app/rp/src/routes/silent/+page.svelte
+++ b/tests/app/rp/src/routes/silent/+page.svelte
@@ -1,11 +1,8 @@
 <script>
 	import { browser } from '$app/environment';
-	import { env } from '$env/dynamic/public';
+	import { clientId, issuer, rpOrigin } from '$lib/oidc-config';
 	import { onMount } from 'svelte';
 
-	const issuer = env.PUBLIC_RP_ISSUER || 'http://localhost:8000/o';
-	const clientId = env.PUBLIC_RP_CLIENT_ID || '2EIxgjlyy5VgCp2fjhEpKLyRtSMMPK0hZ0gBpNdm';
-	const rpOrigin = env.PUBLIC_RP_ORIGIN || 'http://localhost:5173';
 	const redirectUri = `${rpOrigin}/silent-callback.html`;
 
 	// How long to wait for the iframe to report back before calling it a

--- a/tests/app/rp/static/silent-callback.html
+++ b/tests/app/rp/static/silent-callback.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<title>Silent login callback</title>
+	</head>
+	<body>
+		<script>
+			// The OP redirected the hidden iframe here. This document is same-origin
+			// with the page that framed it, so hand the raw query string back and let
+			// the parent decide whether it is an authorization code or an error.
+			// A static file rather than a SvelteKit route: it fires on parse, with no
+			// hydration to wait for and no layout wrapper around it.
+			window.parent.postMessage(
+				{ type: 'silent-login-result', search: window.location.search },
+				window.location.origin
+			);
+		</script>
+	</body>
+</html>

--- a/tests/app/rp/svelte.config.js
+++ b/tests/app/rp/svelte.config.js
@@ -9,7 +9,12 @@ const config = {
 
 	kit: {
 		// build to run in containerized node.js environment
-		adapter: adapter()
+		adapter: adapter(),
+		// Two dev servers running out of this one project directory would
+		// otherwise share .svelte-kit/ and invalidate each other's module graph
+		// mid-request. The cross-site end-to-end layer sets RP_OUT_DIR so its
+		// server gets its own; everything else keeps the default.
+		outDir: process.env.RP_OUT_DIR || '.svelte-kit'
 	}
 };
 

--- a/tests/app/rp/vite.config.ts
+++ b/tests/app/rp/vite.config.ts
@@ -1,6 +1,28 @@
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
+import fs from 'node:fs';
+
+// Optional TLS and Host allow-list, used only by the cross-site end-to-end
+// layer (tests/e2e/browser_cross_site). Both are unset in normal development,
+// so `npm run dev` keeps serving plain http on localhost exactly as before.
+const certPath = process.env.RP_TLS_CERT;
+const keyPath = process.env.RP_TLS_KEY;
+const https =
+	certPath && keyPath
+		? { cert: fs.readFileSync(certPath), key: fs.readFileSync(keyPath) }
+		: undefined;
+const allowedHosts = process.env.RP_ALLOWED_HOSTS?.split(',').map((host) => host.trim());
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	// Paired with RP_OUT_DIR (see svelte.config.js): a second dev server in this
+	// same project directory needs its own dependency cache too.
+	cacheDir: process.env.RP_CACHE_DIR || undefined,
+	server: {
+		// HMR runs over wss:// once the server is TLS, and the throwaway
+		// certificate makes that socket retry noisily. The e2e suite never edits
+		// files mid-run, so drop it.
+		...(https ? { https, hmr: false } : {}),
+		...(allowedHosts ? { allowedHosts } : {})
+	}
 });

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -5,10 +5,11 @@ django-oauth-toolkit supports**, end-to-end and black-box, against the real
 demo apps in `tests/app/`:
 
 * **`tests/app/idp`** — the toolkit configured as a live OAuth2/OIDC provider.
-  It is booted as an actual `runserver` process (not imported in-process), so
-  the tests talk to it purely over HTTP/HTML the way a real client would.
-* **`tests/app/rp`** — the SvelteKit relying party, driven through Chromium with
-  Playwright for the browser layer.
+  It is booted as an actual server process (`runserver`, or uvicorn where the
+  cross-site layer needs TLS) rather than imported in-process, so the tests talk
+  to it purely over HTTP/HTML the way a real client would.
+* **`tests/app/rp`** — the SvelteKit relying party, driven through Chromium (and,
+  for the cross-site layer, Firefox) with Playwright for the browser layer.
 
 Tests are **organized by specification** (one package per RFC / OIDC spec) and
 every check is tagged with a `@pytest.mark.compliance(spec, section, requirement)`
@@ -40,8 +41,35 @@ in-process unit suite's `tests/conftest.py` (which configures Django).
 
 The browser tests self-skip when Node or Playwright is unavailable, so the
 protocol suite still runs in minimal environments. Set `E2E_REQUIRE_BROWSER=1`
-(as the CI job does) to make a missing/broken Chromium a hard failure instead of
-a skip, so the browser RP coverage cannot be silently dropped.
+(as the CI job does) to make a missing/broken browser a hard failure instead of
+a skip, so the browser RP coverage cannot be silently dropped. A pre-installed
+browser can be pointed at with `E2E_CHROMIUM_PATH` / `E2E_FIREFOX_PATH`.
+
+### The cross-site (third-party cookie) layer
+
+`browser_cross_site/` runs a **second** IdP + RP pair, on `idp.test` and
+`rp.test`, over HTTPS with a self-signed certificate generated per session. Two
+things about that setup are load-bearing rather than incidental:
+
+* **Distinct registrable domains.** On `localhost:8000` / `localhost:5173` ports
+  do not count toward "site", so a browser treats the OP iframe the RP embeds as
+  first-party and third-party-cookie policy never engages. `.test` is absent
+  from the Public Suffix List, so `idp.test` and `rp.test` are different sites.
+* **HTTPS.** The OP session cookie has to be `SameSite=None`; browsers only
+  honour that alongside `Secure`; and `Secure` needs a secure context. Over
+  plain HTTP the cookie would be withheld from the iframe in *every* engine and
+  the comparison would prove nothing.
+
+To run it locally:
+
+```bash
+echo "127.0.0.1 idp.test rp.test" | sudo tee -a /etc/hosts
+python -m playwright install firefox
+tox -e e2e -- -m spec_browser_cross_site
+```
+
+Without the hosts entries the layer skips — or fails, under
+`E2E_REQUIRE_BROWSER`, so CI cannot silently drop it.
 
 ## Layout
 
@@ -51,8 +79,10 @@ tests/e2e/
   compliance.py        # compliance-matrix reporting plugin
   constants.py         # client ids / secrets / users (mirror the fixtures)
   helpers/
-    idp_process.py     # launch/teardown the real idp project
-    rp_process.py      # launch/teardown the SvelteKit rp + Chromium resolution
+    idp_process.py     # launch/teardown the real idp project (runserver, or uvicorn for TLS)
+    rp_process.py      # launch/teardown the SvelteKit rp + browser resolution
+    tls.py             # throwaway self-signed cert for the cross-site layer
+    local_http.py      # readiness polling for the local servers
     oauth_client.py    # Python relying-party (login/consent forms, token, ...)
     http_forms.py      # stdlib HTML form parsing
     jwt_tools.py       # ID Token / JWKS validation (OIDC Core 3.1.3.7)
@@ -63,7 +93,8 @@ tests/e2e/
   rfc7591_dynamic_client_registration/
   cimd_client_id_metadata_document/   # CIMD-enabled IdP + loopback document server
   oidc_core/  oidc_discovery/  oidc_rp_initiated_logout/
-  browser_rp/          # Playwright over the real SvelteKit RP
+  browser_rp/          # Playwright over the real SvelteKit RP (localhost, Chromium)
+  browser_cross_site/  # Chromium + Firefox over idp.test / rp.test (HTTPS)
 ```
 
 ## Test clients

--- a/tests/e2e/browser_cross_site/conftest.py
+++ b/tests/e2e/browser_cross_site/conftest.py
@@ -1,0 +1,204 @@
+"""
+Fixtures for the cross-site browser layer.
+
+Everything the ``browser_rp`` package does happens on one registrable domain
+(``localhost:8000`` / ``localhost:5173``): ports do not count toward "site", so
+a browser treats an OP iframe embedded by the RP as *first-party* and
+third-party-cookie policy never engages. This package therefore runs a second
+IdP + RP pair on two genuinely distinct registrable domains, ``idp.test`` and
+``rp.test``. ``.test`` is an IANA special-use TLD that is absent from the Public
+Suffix List, so the whole two-label host is the registrable domain and the two
+are different sites.
+
+The pair is served over TLS with a throwaway self-signed certificate. That is
+not incidental: the OP session cookie has to be ``SameSite=None``, browsers only
+honour ``SameSite=None`` alongside ``Secure``, and ``Secure`` requires a secure
+context. Over plain HTTP the cookie would be withheld from the iframe in *every*
+engine and the two-engine comparison would prove nothing.
+
+Both hosts must resolve to loopback (CI adds them to ``/etc/hosts``); when they
+do not, the layer skips, or fails under ``E2E_REQUIRE_BROWSER``.
+"""
+
+import os
+import socket
+
+import pytest
+
+from tests.e2e import constants as c
+
+
+pytest.importorskip("playwright")
+pytest.importorskip("pytest_playwright")
+
+from tests.e2e.helpers.browser import skip_or_fail  # noqa: E402
+from tests.e2e.helpers.idp_process import IdpServer  # noqa: E402
+from tests.e2e.helpers.rp_process import (  # noqa: E402
+    RpServer,
+    chromium_executable,
+    firefox_executable,
+)
+from tests.e2e.helpers.tls import generate_self_signed_cert  # noqa: E402
+
+
+IDP_HOST = "idp.test"
+RP_HOST = "rp.test"
+# Fixed ports: they appear verbatim in the client's registered redirect_uris,
+# and they are deliberately distinct from browser_rp's 8000/5173 so both
+# session-scoped server pairs can be alive at once in a single pytest session.
+IDP_PORT = 8443
+RP_PORT = 5443
+
+IDP_ORIGIN = f"https://{IDP_HOST}:{IDP_PORT}"
+RP_ORIGIN = f"https://{RP_HOST}:{RP_PORT}"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _require_cross_site_hosts():
+    """Require idp.test and rp.test to resolve to the loopback interface.
+
+    CI adds them to /etc/hosts. Locally they usually are not present, so the
+    layer skips — unless E2E_REQUIRE_BROWSER is set, where a missing entry is a
+    hard failure: silently dropping this coverage is the exact failure mode that
+    flag exists to prevent.
+    """
+    for host in (IDP_HOST, RP_HOST):
+        try:
+            resolved = socket.gethostbyname(host)
+        except OSError as exc:
+            skip_or_fail(
+                f'{host} does not resolve ({exc}); add "127.0.0.1 {IDP_HOST} {RP_HOST}" to /etc/hosts'
+            )
+        else:
+            if not resolved.startswith("127."):
+                skip_or_fail(f"{host} resolves to {resolved}, not the loopback interface")
+
+
+@pytest.fixture(scope="session")
+def cross_site_tls(tmp_path_factory):
+    return generate_self_signed_cert(
+        tmp_path_factory.mktemp("e2e-tls"),
+        hostnames=[IDP_HOST, RP_HOST, "localhost"],
+    )
+
+
+@pytest.fixture(scope="session")
+def cross_site_idp(cross_site_tls):
+    certfile, keyfile = cross_site_tls
+    server = IdpServer(
+        host=IDP_HOST,
+        bind_host="127.0.0.1",
+        port=IDP_PORT,
+        scopes=c.E2E_SCOPES,
+        default_scopes=c.E2E_DEFAULT_SCOPES,
+        pkce_required=False,
+        pkce_required_client_ids=c.PKCE_REQUIRED_CLIENT_IDS,
+        allowed_hosts=[IDP_HOST, "127.0.0.1", "localhost"],
+        ssl_certfile=certfile,
+        ssl_keyfile=keyfile,
+        # The whole point of this layer: without SameSite=None the OP session
+        # cookie never reaches a third-party iframe in any engine.
+        session_cookie_samesite="None",
+        secure_cookies=True,
+        csrf_trusted_origins=[IDP_ORIGIN],
+    )
+    try:
+        server.start()
+    except Exception as exc:  # pragma: no cover - environment guard
+        skip_or_fail(f"Could not start the cross-site IdP: {exc}")
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+@pytest.fixture(scope="session")
+def cross_site_rp(cross_site_idp, cross_site_tls):
+    certfile, keyfile = cross_site_tls
+    server = RpServer(
+        host=RP_HOST,
+        bind_host="127.0.0.1",
+        port=RP_PORT,
+        tls_cert=certfile,
+        tls_key=keyfile,
+        # browser_rp's dev server is alive at the same time, out of the same
+        # project directory; without this they clobber each other's build state.
+        isolate_build=True,
+        env={
+            "PUBLIC_RP_ISSUER": cross_site_idp.issuer,
+            "PUBLIC_RP_CLIENT_ID": c.RP_OIDC_CLIENT_ID,
+            "PUBLIC_RP_ORIGIN": RP_ORIGIN,
+        },
+    )
+    try:
+        server.start()
+    except Exception as exc:  # pragma: no cover - environment guard
+        skip_or_fail(f"Could not start the cross-site SvelteKit RP: {exc}")
+    try:
+        yield server
+    finally:
+        server.stop()
+
+
+# idp.test and rp.test are /etc/hosts aliases for loopback, but they do not
+# *look* local, so an ambient HTTP(S)_PROXY in the environment would have the
+# browser try to reach them through it. Hand the browser process an environment
+# with those variables removed.
+_PROXY_ENV_VARS = ("http_proxy", "https_proxy", "all_proxy", "no_proxy")
+
+
+def _browser_env():
+    return {key: value for key, value in os.environ.items() if key.lower() not in _PROXY_ENV_VARS}
+
+
+def _launch(browser_type, executable, **kwargs):
+    if executable:
+        kwargs["executable_path"] = executable
+    try:
+        return browser_type.launch(env=_browser_env(), **kwargs)
+    except Exception as exc:  # pragma: no cover - environment guard
+        skip_or_fail(f"No usable {browser_type.name} for Playwright ({exc})")
+
+
+# The engines are launched explicitly rather than through pytest-playwright's
+# ``browser``/``page`` fixtures: this layer is a *comparison* between engines
+# within one session, and ``firefox_user_prefs`` is Firefox-only (passing it to
+# ``chromium.launch()`` is an error).
+@pytest.fixture(scope="session")
+def chromium(playwright):
+    browser = _launch(playwright.chromium, chromium_executable())
+    yield browser
+    browser.close()
+
+
+@pytest.fixture(scope="session")
+def firefox_partitioning(playwright):
+    """Firefox with Total Cookie Protection pinned on (its shipped default)."""
+    browser = _launch(
+        playwright.firefox,
+        firefox_executable(),
+        # 5 == BEHAVIOR_REJECT_TRACKER_AND_PARTITION_FOREIGN. Pinned rather than
+        # inherited so the assertion cannot quietly change meaning when the
+        # bundled Firefox changes its default.
+        firefox_user_prefs={"network.cookie.cookieBehavior": 5},
+    )
+    yield browser
+    browser.close()
+
+
+@pytest.fixture(scope="session")
+def firefox_permissive(playwright):
+    """Control engine: the same Firefox with third-party cookies accepted.
+
+    A broken setup — bad certificate, unregistered redirect_uri, a 500 in the OP
+    — also yields "not a code", which is exactly what the partitioning test
+    expects to see. This control fails in that case and passes only when the
+    difference really is the cookie policy.
+    """
+    browser = _launch(
+        playwright.firefox,
+        firefox_executable(),
+        firefox_user_prefs={"network.cookie.cookieBehavior": 0},
+    )
+    yield browser
+    browser.close()

--- a/tests/e2e/browser_cross_site/test_silent_login_cross_site.py
+++ b/tests/e2e/browser_cross_site/test_silent_login_cross_site.py
@@ -1,0 +1,133 @@
+"""
+Third-party-cookie behaviour of OIDC silent login (``prompt=none``), driven
+through two real engines against genuinely cross-site hosts.
+
+The authorization server behaves identically in every run here; what differs is
+the user agent. Whether a relying party can refresh a session behind the scenes
+depends entirely on whether the browser lets the OP's cookie into a third-party
+iframe: Chromium (today, with third-party cookies allowed) does, and the RP gets
+an authorization ``code``; Firefox with Total Cookie Protection does not, and
+the RP gets ``login_required``.
+
+This is the coverage that OIDC Session Management and Front-Channel Logout will
+need when they land — both depend on the same cookie reaching the same kind of
+frame — so the harness is in place ahead of them.
+"""
+
+import pytest
+
+from tests.e2e import constants as c
+
+
+pytestmark = pytest.mark.browser
+
+
+def _probe(browser, idp, rp, login=True):
+    """Read the cross-site iframe's outcome, optionally after an OP login."""
+    context = browser.new_context(ignore_https_errors=True)
+    try:
+        page = context.new_page()
+
+        if login:
+            # First-party, top-level login at the OP. This leg is identical in
+            # both engines: the session cookie is set during a top-level
+            # navigation to idp.test, so it lands in the unpartitioned jar
+            # either way.
+            page.goto(f"{idp.base_url}/accounts/login/?next=/")
+            page.wait_for_selector("#id_username", timeout=20000)
+            page.fill("#id_username", c.SUPERUSER_USERNAME)
+            page.fill("#id_password", c.SUPERUSER_PASSWORD)
+            page.click("button[type=submit]")
+            page.wait_for_url(f"{idp.base_url}/", timeout=20000)
+
+            # Fail loudly when it is the *setup* that broke rather than the
+            # cookie policy. Without a Secure, SameSite=None session cookie
+            # every engine would answer login_required, and the Firefox
+            # assertion below would pass for entirely the wrong reason.
+            session = [cookie for cookie in context.cookies() if cookie["name"] == "sessionid"]
+            assert session, f"the OP set no session cookie on login:\n{idp.read_log()[-2000:]}"
+            assert session[0]["secure"], "the OP session cookie is not Secure"
+            assert session[0]["sameSite"] == "None", (
+                f"the OP session cookie is SameSite={session[0]['sameSite']}; it can never "
+                "reach a third-party iframe"
+            )
+
+        # Cross-site leg: rp.test frames idp.test's authorization endpoint.
+        page.goto(f"{rp.base_url}/silent")
+        # Guard against the RP silently falling back to its localhost defaults,
+        # which would make the iframe same-site and the whole comparison moot.
+        # The URL is built on mount, so wait for hydration rather than reading
+        # the server-rendered placeholder.
+        page.wait_for_function(
+            "document.querySelector('[data-testid=silent-src]')?.textContent.trim() !== ''",
+            timeout=20000,
+        )
+        assert idp.base_url in page.locator("[data-testid=silent-src]").inner_text(), (
+            "the RP is not framing the cross-site IdP; PUBLIC_RP_ISSUER did not reach the app"
+        )
+        try:
+            page.wait_for_function(
+                "document.querySelector('[data-testid=silent-outcome]')?.textContent.trim() !== 'pending'",
+                timeout=20000,
+            )
+        except Exception as exc:
+            raise AssertionError(
+                "the silent-login iframe never reported a result — the OP probably "
+                "rendered an error page (which X-Frame-Options: DENY keeps blank) "
+                f"instead of redirecting:\n{idp.read_log()[-4000:]}"
+            ) from exc
+        return page.locator("[data-testid=silent-outcome]").inner_text().strip()
+    finally:
+        context.close()
+
+
+@pytest.mark.compliance(
+    "OpenID Connect Core 1.0",
+    "3.1.2.1",
+    "prompt=none silent login returns a code in a cross-site iframe (third-party cookies allowed)",
+)
+def test_chromium_silent_login_returns_code(chromium, cross_site_idp, cross_site_rp):
+    assert _probe(chromium, cross_site_idp, cross_site_rp) == "code"
+
+
+@pytest.mark.compliance(
+    "OpenID Connect Core 1.0",
+    "3.1.2.6",
+    "prompt=none returns login_required when the iframe carries no OP cookie",
+)
+def test_silent_login_without_an_op_session_yields_login_required(chromium, cross_site_idp, cross_site_rp):
+    """The no-cookie-at-all case, reachable without Firefox.
+
+    A partitioned iframe and an iframe belonging to a user who never logged in
+    look identical to the OP: the authorization request simply arrives with no
+    Cookie header. That is the shape the OP has to answer with login_required
+    rather than an error page — which, carrying X-Frame-Options: DENY, would
+    leave the frame blank and give the RP nothing at all.
+    """
+    assert _probe(chromium, cross_site_idp, cross_site_rp, login=False) == "login_required"
+
+
+@pytest.mark.compliance(
+    "OpenID Connect Core 1.0",
+    "3.1.2.6",
+    "prompt=none returns login_required when the OP cookie is partitioned away",
+)
+def test_firefox_total_cookie_protection_yields_login_required(
+    firefox_partitioning, cross_site_idp, cross_site_rp
+):
+    # Exactly login_required, not merely "an error": a misconfigured client or
+    # an unregistered redirect_uri would surface as invalid_request or
+    # no-parameters, and a dead iframe as timeout.
+    assert _probe(firefox_partitioning, cross_site_idp, cross_site_rp) == "login_required"
+
+
+@pytest.mark.compliance(
+    "OpenID Connect Core 1.0",
+    "3.1.2.1",
+    "prompt=none silent login returns a code in Firefox when third-party cookies are allowed",
+)
+def test_firefox_without_partitioning_returns_code(firefox_permissive, cross_site_idp, cross_site_rp):
+    # Control for the test above: same engine, same URLs, same certificate,
+    # same OP — only the cookie policy differs. If this fails, the
+    # login_required result above is a broken setup, not a partitioning result.
+    assert _probe(firefox_permissive, cross_site_idp, cross_site_rp) == "code"

--- a/tests/e2e/browser_rp/conftest.py
+++ b/tests/e2e/browser_rp/conftest.py
@@ -7,8 +7,6 @@ working Node toolchain is not available, so the rest of the compliance suite
 still runs in minimal environments.
 """
 
-import os
-
 import pytest
 
 from tests.e2e import constants as c
@@ -17,21 +15,9 @@ from tests.e2e import constants as c
 pytest.importorskip("playwright")
 pytest.importorskip("pytest_playwright")
 
-from tests.e2e.helpers.browser import click_until  # noqa: E402
+from tests.e2e.helpers.browser import click_until, skip_or_fail  # noqa: E402
 from tests.e2e.helpers.idp_process import IdpServer  # noqa: E402
 from tests.e2e.helpers.rp_process import RpServer, chromium_executable  # noqa: E402
-
-
-def _skip_or_fail(message):
-    """Skip the browser layer, or fail it when E2E_REQUIRE_BROWSER is set.
-
-    CI sets E2E_REQUIRE_BROWSER so that a missing browser or an IdP/RP that
-    won't start is a hard failure rather than silently dropped coverage; local
-    and protocol-only runs keep skipping.
-    """
-    if os.environ.get("E2E_REQUIRE_BROWSER"):
-        pytest.fail(f"{message}; E2E_REQUIRE_BROWSER is set so the browser layer must run")
-    pytest.skip(f"{message}; skipping browser layer")
 
 
 @pytest.fixture(scope="session")
@@ -57,7 +43,7 @@ def _require_browser(browser_type, browser_type_launch_args):
     try:
         browser = browser_type.launch(**browser_type_launch_args)
     except Exception as exc:  # pragma: no cover - environment guard
-        _skip_or_fail(f"No usable Chromium for Playwright ({exc})")
+        skip_or_fail(f"No usable Chromium for Playwright ({exc})")
     else:
         browser.close()
 
@@ -79,7 +65,7 @@ def browser_idp():
     try:
         server.start()
     except Exception as exc:  # pragma: no cover - environment guard
-        _skip_or_fail(f"Could not start IdP for browser tests: {exc}")
+        skip_or_fail(f"Could not start IdP for browser tests: {exc}")
     try:
         yield server
     finally:
@@ -92,7 +78,7 @@ def rp_server(browser_idp):
     try:
         server.start()
     except Exception as exc:  # pragma: no cover - environment guard
-        _skip_or_fail(f"Could not start SvelteKit RP (Node/npm required): {exc}")
+        skip_or_fail(f"Could not start SvelteKit RP (Node/npm required): {exc}")
     try:
         yield server
     finally:

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -38,6 +38,10 @@ SPEC_BY_PACKAGE = {
     "oidc_discovery": ("OpenID Connect Discovery 1.0", "spec_oidc_discovery"),
     "oidc_rp_initiated_logout": ("OpenID Connect RP-Initiated Logout 1.0", "spec_oidc_rp_logout"),
     "browser_rp": ("Browser RP (SvelteKit)", "spec_browser_rp"),
+    "browser_cross_site": (
+        "Browser RP cross-site (third-party cookies)",
+        "spec_browser_cross_site",
+    ),
 }
 
 # Map a ``compliance()`` spec label (and a few close variants) to a family

--- a/tests/e2e/helpers/browser.py
+++ b/tests/e2e/helpers/browser.py
@@ -6,6 +6,22 @@ browser package without breaking protocol-only environments; the Playwright
 error type surfaces as an ordinary exception that ``click_until`` catches.
 """
 
+import os
+
+import pytest
+
+
+def skip_or_fail(message):
+    """Skip the browser layer, or fail it when ``E2E_REQUIRE_BROWSER`` is set.
+
+    CI sets ``E2E_REQUIRE_BROWSER`` so that a missing browser, an unresolvable
+    test hostname, or an IdP/RP that will not start is a hard failure rather
+    than silently dropped coverage; local and protocol-only runs keep skipping.
+    """
+    if os.environ.get("E2E_REQUIRE_BROWSER"):
+        pytest.fail(f"{message}; E2E_REQUIRE_BROWSER is set so the browser layer must run")
+    pytest.skip(f"{message}; skipping browser layer")
+
 
 def click_until(locator, check, attempts=20):
     """Click ``locator`` repeatedly until ``check()`` succeeds.

--- a/tests/e2e/helpers/browser.py
+++ b/tests/e2e/helpers/browser.py
@@ -7,11 +7,12 @@ error type surfaces as an ordinary exception that ``click_until`` catches.
 """
 
 import os
+from typing import NoReturn
 
 import pytest
 
 
-def skip_or_fail(message):
+def skip_or_fail(message: str) -> NoReturn:
     """Skip the browser layer, or fail it when ``E2E_REQUIRE_BROWSER`` is set.
 
     CI sets ``E2E_REQUIRE_BROWSER`` so that a missing browser, an unresolvable
@@ -21,6 +22,9 @@ def skip_or_fail(message):
     if os.environ.get("E2E_REQUIRE_BROWSER"):
         pytest.fail(f"{message}; E2E_REQUIRE_BROWSER is set so the browser layer must run")
     pytest.skip(f"{message}; skipping browser layer")
+    # Both pytest.fail and pytest.skip raise, so this is unreachable; the
+    # NoReturn annotation is what tells a reader (and a static analyzer) that
+    # callers never fall through to an implicit None.
 
 
 def click_until(locator, check, attempts=20):

--- a/tests/e2e/helpers/idp_process.py
+++ b/tests/e2e/helpers/idp_process.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import requests
 
+from .local_http import poll
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 IDP_DIR = REPO_ROOT / "tests" / "app" / "idp"
@@ -52,6 +54,14 @@ class IdpServer:
       Document support and (optionally) swap the metadata fetcher import string
       (the CIMD package uses ``idp.cimd.LoopbackMetadataFetcher`` so the IdP
       can fetch documents from a local test server).
+    * ``ssl_certfile`` / ``ssl_keyfile`` — serve over TLS. ``runserver`` has no
+      TLS support, so the same project is served through uvicorn against
+      ``idp.asgi:application`` instead. Only the cross-site browser layer needs
+      this; every other caller keeps ``runserver``.
+    * ``session_cookie_samesite`` / ``secure_cookies`` / ``csrf_trusted_origins``
+      — cookie posture, needed by the cross-site layer (``SameSite=None`` plus
+      ``Secure``, without which the OP session cookie can never reach a
+      third-party iframe).
     """
 
     def __init__(
@@ -66,8 +76,18 @@ class IdpServer:
         cimd_metadata_fetcher=None,
         fixtures=("fixtures/seed.json", "fixtures/e2e_seed.json"),
         allowed_hosts=None,
+        bind_host=None,
+        ssl_certfile=None,
+        ssl_keyfile=None,
+        session_cookie_samesite=None,
+        secure_cookies=False,
+        csrf_trusted_origins=None,
     ):
         self.host = host
+        # ``host`` is the name clients address the server by; ``bind_host`` is
+        # the interface it listens on. They differ for the cross-site layer,
+        # where idp.test is an /etc/hosts alias for the loopback interface.
+        self.bind_host = bind_host or host
         self.port = port or find_free_port()
         # The browser RP addresses the IdP as both localhost and 127.0.0.1
         # (the SPA uses localhost for OIDC and 127.0.0.1 for the device page),
@@ -80,13 +100,22 @@ class IdpServer:
         self.cimd_enabled = cimd_enabled
         self.cimd_metadata_fetcher = cimd_metadata_fetcher
         self.fixtures = fixtures
+        self.ssl_certfile = ssl_certfile
+        self.ssl_keyfile = ssl_keyfile
+        self.session_cookie_samesite = session_cookie_samesite
+        self.secure_cookies = secure_cookies
+        self.csrf_trusted_origins = csrf_trusted_origins or []
         self._proc = None
         self._tmpdir = None
         self._log = None
 
     @property
+    def scheme(self):
+        return "https" if self.ssl_certfile else "http"
+
+    @property
     def base_url(self):
-        return f"http://{self.host}:{self.port}"
+        return f"{self.scheme}://{self.host}:{self.port}"
 
     @property
     def issuer(self):
@@ -107,6 +136,13 @@ class IdpServer:
         env["OAUTH2_PROVIDER_PKCE_REQUIRED"] = "True" if self.pkce_required else "False"
         if self.pkce_required_client_ids:
             env["OAUTH2_PROVIDER_PKCE_REQUIRED_CLIENT_IDS"] = ",".join(self.pkce_required_client_ids)
+        if self.session_cookie_samesite:
+            env["SESSION_COOKIE_SAMESITE"] = self.session_cookie_samesite
+        if self.secure_cookies:
+            env["SESSION_COOKIE_SECURE"] = "True"
+            env["CSRF_COOKIE_SECURE"] = "True"
+        if self.csrf_trusted_origins:
+            env["CSRF_TRUSTED_ORIGINS"] = ",".join(self.csrf_trusted_origins)
         env["OAUTH2_PROVIDER_CIMD_ENABLED"] = "True" if self.cimd_enabled else "False"
         if self.cimd_metadata_fetcher:
             env["OAUTH2_PROVIDER_CIMD_METADATA_FETCHER"] = self.cimd_metadata_fetcher
@@ -137,7 +173,7 @@ class IdpServer:
 
             self._log = open(os.path.join(self._tmpdir, "server.log"), "w+")
             self._proc = subprocess.Popen(
-                [sys.executable, "manage.py", "runserver", f"{self.host}:{self.port}", "--noreload"],
+                self._server_command(),
                 cwd=IDP_DIR,
                 env=env,
                 stdout=self._log,
@@ -150,6 +186,35 @@ class IdpServer:
             raise
         return self
 
+    def _server_command(self):
+        """The command that serves the project, with or without TLS."""
+        if not self.ssl_certfile:
+            return [
+                sys.executable,
+                "manage.py",
+                "runserver",
+                f"{self.bind_host}:{self.port}",
+                "--noreload",
+            ]
+        # runserver cannot terminate TLS, so serve the same project through
+        # uvicorn. uvicorn terminates TLS itself and reports scheme=https in the
+        # ASGI scope, so request.is_secure() is True and no SECURE_PROXY_SSL_HEADER
+        # is involved -- there is no proxy in front of it.
+        return [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "idp.asgi:application",
+            "--host",
+            self.bind_host,
+            "--port",
+            str(self.port),
+            "--ssl-certfile",
+            str(self.ssl_certfile),
+            "--ssl-keyfile",
+            str(self.ssl_keyfile),
+        ]
+
     def _wait_until_ready(self, timeout):
         deadline = time.monotonic() + timeout
         url = self.url(DISCOVERY_PATH)
@@ -157,7 +222,7 @@ class IdpServer:
             if self._proc.poll() is not None:
                 raise RuntimeError(f"IdP process exited early:\n{self.read_log()}")
             try:
-                if requests.get(url, timeout=2).status_code == 200:
+                if poll(url).status_code == 200:
                     return
             except requests.RequestException:
                 # Connection refused / timeouts are expected while the server is

--- a/tests/e2e/helpers/local_http.py
+++ b/tests/e2e/helpers/local_http.py
@@ -1,0 +1,26 @@
+"""
+A readiness-poll GET for the servers this suite launches.
+
+The IdP and RP are always local processes, but the cross-site layer addresses
+them by hostnames that do not look local (``idp.test`` / ``rp.test``) and serves
+them with a throwaway self-signed certificate. Both facts have to be spelled out
+per request, so they live here rather than being repeated at each call site.
+"""
+
+import warnings
+
+import requests
+import urllib3
+
+
+# Never route a poll for a local process through an ambient HTTP(S)_PROXY.
+_NO_PROXY = {"http": None, "https": None}
+
+
+def poll(url, timeout=2):
+    """GET ``url`` as a liveness check: no proxy, no certificate verification."""
+    with warnings.catch_warnings():
+        # Verifying the throwaway certificate is not the point of a liveness
+        # check, and pytest re-enables this warning per test.
+        warnings.simplefilter("ignore", urllib3.exceptions.InsecureRequestWarning)
+        return requests.get(url, timeout=timeout, verify=False, proxies=_NO_PROXY)

--- a/tests/e2e/helpers/rp_process.py
+++ b/tests/e2e/helpers/rp_process.py
@@ -2,18 +2,23 @@
 Launch the real SvelteKit relying party (``tests/app/rp``) for the browser
 layer of the compliance suite.
 
-The RP is hard-configured (in ``src/routes/+page.svelte``) to talk to an IdP at
-``http://localhost:8000`` using the seed OIDC client, and to use
+The RP defaults (in ``src/routes/+page.svelte``) to an IdP at
+``http://localhost:8000`` using the seed OIDC client, and to
 ``http://localhost:5173`` as its redirect URI — so the browser tests pin the IdP
-to port 8000 and serve the RP on 5173.
+to port 8000 and serve the RP on 5173. Those defaults are overridable through
+``PUBLIC_RP_*`` environment variables, which is how the cross-site layer points
+the same app at ``https://idp.test:8443`` / ``https://rp.test:5443``.
 """
 
 import os
+import signal
 import subprocess
 import time
 from pathlib import Path
 
 import requests
+
+from .local_http import poll
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -28,38 +33,85 @@ def chromium_executable():
     Playwright's own build may not match); otherwise ``None`` so Playwright uses
     its bundled browser.
     """
-    explicit = os.environ.get("E2E_CHROMIUM_PATH")
+    return _playwright_executable("E2E_CHROMIUM_PATH", "chromium-*/chrome-linux/chrome", "chromium-")
+
+
+def firefox_executable():
+    """Resolve a usable Firefox for Playwright, the same way as Chromium.
+
+    Prefers ``E2E_FIREFOX_PATH``; then a pre-installed build under
+    ``PLAYWRIGHT_BROWSERS_PATH``; otherwise ``None`` so Playwright uses its
+    bundled browser.
+    """
+    return _playwright_executable("E2E_FIREFOX_PATH", "firefox-*/firefox/firefox", "firefox-")
+
+
+def _playwright_executable(env_var, glob_pattern, directory_prefix):
+    explicit = os.environ.get(env_var)
     if explicit and os.path.exists(explicit):
         return explicit
     browsers_root = os.environ.get("PLAYWRIGHT_BROWSERS_PATH")
     if browsers_root:
-        matches = list(Path(browsers_root).glob("chromium-*/chrome-linux/chrome"))
+        matches = list(Path(browsers_root).glob(glob_pattern))
         if matches:
             # Pick the highest build revision by numeric value, not lexicographic
             # order (so chromium-1234 beats chromium-999).
-            return str(max(matches, key=_chromium_revision))
+            return str(max(matches, key=lambda path: _revision(path, directory_prefix)))
     return None
 
 
-def _chromium_revision(chrome_path):
-    """Extract the numeric build revision from a ``chromium-<rev>/...`` path."""
-    for part in chrome_path.parts:
-        if part.startswith("chromium-"):
-            rev = part[len("chromium-") :]
+def _revision(browser_path, directory_prefix):
+    """Extract the numeric build revision from a ``<prefix><rev>/...`` path."""
+    for part in browser_path.parts:
+        if part.startswith(directory_prefix):
+            rev = part[len(directory_prefix) :]
             return int(rev) if rev.isdigit() else -1
     return -1
 
 
 class RpServer:
-    def __init__(self, host="localhost", port=5173):
+    """Manage the lifecycle of the SvelteKit dev server.
+
+    ``host`` is the name the browser addresses the RP by; ``bind_host`` is the
+    interface Vite listens on (they differ for the cross-site layer, where
+    rp.test is an /etc/hosts alias for loopback). ``env`` is merged over the
+    inherited environment, which is how the ``PUBLIC_RP_*`` configuration
+    reaches the app. Passing ``tls_cert``/``tls_key`` serves it over HTTPS.
+
+    ``isolate_build`` gives this instance its own SvelteKit output and Vite
+    cache directories. Two dev servers running out of the one project directory
+    otherwise share ``.svelte-kit/`` and invalidate each other's module graph
+    mid-request, which surfaces as unrelated browser tests failing whenever both
+    happen to be alive at once.
+    """
+
+    def __init__(
+        self,
+        host="localhost",
+        port=5173,
+        bind_host=None,
+        env=None,
+        tls_cert=None,
+        tls_key=None,
+        isolate_build=False,
+    ):
         self.host = host
+        self.bind_host = bind_host or host
         self.port = port
+        self.extra_env = env or {}
+        self.tls_cert = tls_cert
+        self.tls_key = tls_key
+        self.isolate_build = isolate_build
         self._proc = None
         self._log = None
 
     @property
+    def scheme(self):
+        return "https" if self.tls_cert else "http"
+
+    @property
     def base_url(self):
-        return f"http://{self.host}:{self.port}"
+        return f"{self.scheme}://{self.host}:{self.port}"
 
     def _ensure_dependencies(self):
         if not (RP_DIR / "node_modules").is_dir():
@@ -68,12 +120,28 @@ class RpServer:
     def start(self, timeout=90):
         self._ensure_dependencies()
         try:
-            self._log = open(os.path.join(os.getcwd(), ".rp-server.log"), "w+")
+            # Per-port log name so two RP instances can run side by side.
+            self._log = open(os.path.join(os.getcwd(), f".rp-server-{self.port}.log"), "w+")
             self._proc = subprocess.Popen(
-                ["npm", "run", "dev", "--", "--port", str(self.port), "--strictPort", "--host", self.host],
+                [
+                    "npm",
+                    "run",
+                    "dev",
+                    "--",
+                    "--port",
+                    str(self.port),
+                    "--strictPort",
+                    "--host",
+                    self.bind_host,
+                ],
                 cwd=RP_DIR,
+                env=self._env(),
                 stdout=self._log,
                 stderr=subprocess.STDOUT,
+                # `npm run dev` is only a wrapper: vite runs as its child.
+                # Terminating npm alone leaves vite alive and holding the port,
+                # so give the pair its own process group and signal the group.
+                start_new_session=True,
             )
             self._wait_until_ready(timeout)
         except BaseException:
@@ -82,13 +150,29 @@ class RpServer:
             raise
         return self
 
+    def _env(self):
+        """The child environment: the inherited one plus the RP's own config."""
+        env = os.environ.copy()
+        # Vite refuses requests whose Host header it does not recognise, so a
+        # non-localhost hostname has to be allow-listed explicitly.
+        env["RP_ALLOWED_HOSTS"] = self.host
+        if self.tls_cert:
+            env["RP_TLS_CERT"] = str(self.tls_cert)
+            env["RP_TLS_KEY"] = str(self.tls_key)
+        if self.isolate_build:
+            # Relative to the RP project directory; both are gitignored.
+            env["RP_OUT_DIR"] = f".svelte-kit-{self.port}"
+            env["RP_CACHE_DIR"] = f".vite-{self.port}"
+        env.update(self.extra_env)
+        return env
+
     def _wait_until_ready(self, timeout):
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
             if self._proc.poll() is not None:
                 raise RuntimeError(f"RP process exited early:\n{self.read_log()}")
             try:
-                if requests.get(self.base_url, timeout=2).status_code == 200:
+                if poll(self.base_url).status_code == 200:
                     return
             except requests.RequestException:
                 # Connection errors/timeouts are expected until the dev server is
@@ -106,14 +190,22 @@ class RpServer:
 
     def stop(self):
         if self._proc and self._proc.poll() is None:
-            self._proc.terminate()
+            self._signal_group(signal.SIGTERM)
             try:
                 self._proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
-                self._proc.kill()
+                self._signal_group(signal.SIGKILL)
                 self._proc.wait(timeout=10)
         if self._log:
             self._log.close()
+
+    def _signal_group(self, sig):
+        """Signal the whole npm+vite process group, falling back to the wrapper."""
+        try:
+            os.killpg(os.getpgid(self._proc.pid), sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            # The group is already gone, or the platform would not give us one.
+            self._proc.send_signal(sig)
 
     def __enter__(self):
         return self.start()

--- a/tests/e2e/helpers/tls.py
+++ b/tests/e2e/helpers/tls.py
@@ -1,0 +1,60 @@
+"""
+Generate an ephemeral self-signed certificate for the cross-site browser layer.
+
+The third-party-cookie probe needs the OP session cookie to carry
+``SameSite=None``, browsers only honour ``SameSite=None`` alongside ``Secure``,
+and ``Secure`` requires a secure context. Plain HTTP on ``idp.test`` /
+``rp.test`` therefore cannot express the behaviour under test at all, so both
+servers are run over TLS with a throwaway certificate whose errors Playwright is
+told to ignore.
+
+``cryptography`` is already installed as a hard dependency of ``jwcrypto``.
+"""
+
+import datetime
+import ipaddress
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+
+def generate_self_signed_cert(directory, hostnames, ip_addresses=("127.0.0.1",)):
+    """Write a SAN certificate + key covering ``hostnames`` into ``directory``.
+
+    Returns ``(cert_path, key_path)``. An EC/P-256 key keeps generation
+    instantaneous; the certificate is valid for a day, far longer than any test
+    session, and never leaves the temporary directory it is written to.
+    """
+    directory = Path(directory)
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, hostnames[0])])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    san = [x509.DNSName(host) for host in hostnames]
+    san += [x509.IPAddress(ipaddress.ip_address(ip)) for ip in ip_addresses]
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=5))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.SubjectAlternativeName(san), critical=False)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    cert_path = directory / "e2e-cert.pem"
+    key_path = directory / "e2e-key.pem"
+    cert_path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
+    key_path.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        )
+    )
+    key_path.chmod(0o600)
+    return cert_path, key_path

--- a/tests/e2e/oidc_core/test_oidc_core.py
+++ b/tests/e2e/oidc_core/test_oidc_core.py
@@ -41,6 +41,33 @@ def test_hybrid_flow_returns_code_and_id_token(oauth, user_session, issuer):
     assert token_resp.status_code == 200
 
 
+@pytest.mark.compliance("OpenID Connect Core 1.0", "3.1.2.1", "prompt=none with an authenticated End-User")
+def test_prompt_none_returns_code_for_an_authenticated_end_user(oauth, user_session):
+    """An authenticated ``prompt=none`` request is answered without any UI.
+
+    The unauthenticated half of this contract (``error=login_required``) is
+    covered by the unit suite; this pins the *successful* half, which is what
+    the browser layer's cross-site probe measures. Keeping it here, over plain
+    HTTP with no browser involved, means a failure there can be attributed to
+    cookie policy rather than to the authorization server.
+    """
+    result = oauth.authorize(
+        user_session,
+        client_id=c.PUBLIC_PKCE_CLIENT_ID,
+        response_type="code",
+        redirect_uri=c.REDIRECT_URI,
+        scope="openid",
+        state="silent-state",
+        code_challenge="E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+        code_challenge_method="S256",
+        extra={"prompt": "none"},
+    )
+    assert result.status_code == 302
+    assert result.query_params["code"], "an authenticated prompt=none request MUST return a code"
+    assert result.query_params["state"] == "silent-state"
+    assert "error" not in result.query_params
+
+
 @pytest.mark.compliance("OpenID Connect Core 1.0", "5.3.2", "UserInfo Response")
 def test_userinfo_returns_claims_for_granted_scopes(oauth, user_session):
     result = oauth.authorize(

--- a/tox.ini
+++ b/tox.ini
@@ -211,6 +211,12 @@ commands =
 # automatically when Node/Playwright are unavailable). Emits a JUnit report and
 # a compliance matrix under tests/e2e/reports/.
 #
+# The cross-site layer additionally runs the IdP and RP on two distinct
+# registrable domains over TLS, in both Chromium and Firefox, to pin how
+# third-party-cookie policy affects silent login. It needs idp.test and rp.test
+# mapped to loopback and skips when they are not:
+#   echo "127.0.0.1 idp.test rp.test" | sudo tee -a /etc/hosts
+#
 # Run the whole suite:            tox -e e2e
 # One specification:              tox -e e2e -- -m spec_rfc7636
 # Skip deprecated/browser flows:  tox -e e2e -- -m "not deprecated and not browser"
@@ -222,6 +228,11 @@ deps =
     django-environ
     django-cors-headers
     whitenoise
+    # The cross-site browser layer serves the IdP over TLS; runserver cannot,
+    # so it runs the same project through uvicorn against idp.asgi. cryptography
+    # (already a jwcrypto dependency) generates the throwaway certificate.
+    uvicorn
+    cryptography
 setenv =
     PYTHONPATH = {toxinidir}
     COMPLIANCE_MATRIX_DIR = {env:COMPLIANCE_MATRIX_DIR:{toxinidir}/tests/e2e/reports}
@@ -229,6 +240,7 @@ passenv =
     PLAYWRIGHT_BROWSERS_PATH
     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD
     E2E_CHROMIUM_PATH
+    E2E_FIREFOX_PATH
     E2E_REQUIRE_BROWSER
 allowlist_externals =
     npm
@@ -238,7 +250,7 @@ commands_pre =
     # Best-effort browser + RP setup; ignore failures so the protocol suite
     # still runs where a browser/Node toolchain is unavailable (browser tests
     # then skip themselves).
-    - python -m playwright install --with-deps chromium
+    - python -m playwright install --with-deps chromium firefox
     - npm install --prefix tests/app/rp
 commands =
     pytest tests/e2e --confcutdir=tests/e2e -o addopts= --junitxml={env:COMPLIANCE_MATRIX_DIR:{toxinidir}/tests/e2e/reports}/junit-e2e.xml {posargs}


### PR DESCRIPTION
## Description of the Change

This PR adds a comprehensive end-to-end browser test layer that validates OIDC silent login (`prompt=none`) behavior across different third-party cookie policies. The new `browser_cross_site` test package runs the IdP and RP on genuinely distinct registrable domains (`idp.test` and `rp.test`) over HTTPS, allowing measurement of how browser cookie policies affect silent authentication.

### Key Changes

**New Test Infrastructure:**
- `tests/e2e/browser_cross_site/conftest.py`: Session-scoped fixtures for cross-site IdP/RP servers with TLS, host resolution validation, and multi-engine browser launches (Chromium, Firefox with/without Total Cookie Protection)
- `tests/e2e/browser_cross_site/test_silent_login_cross_site.py`: Four compliance tests covering silent login outcomes under different cookie policies
- `tests/e2e/helpers/tls.py`: Self-signed certificate generation for ephemeral HTTPS servers
- `tests/e2e/helpers/local_http.py`: Proxy-aware HTTP polling for server readiness checks

**RP Enhancements:**
- `tests/app/rp/src/routes/silent/+page.svelte`: New silent login probe page that frames the OP's authorization endpoint with `prompt=none` and reports whether the OP session cookie reaches the iframe
- `tests/app/rp/static/silent-callback.html`: Callback handler that posts authorization response back to parent window
- `vite.config.ts`: Optional TLS and host allowlist support for cross-site testing
- `svelte.config.js`: Per-server build/cache isolation for concurrent dev servers
- Runtime configuration via `PUBLIC_RP_*` environment variables (issuer, client ID, origin)

**IdP Enhancements:**
- `idp/oauth.py`: Fixed `validate_silent_login()` to handle missing Cookie headers (third-party iframe case) and return `login_required` instead of raising
- `idp/settings.py`: Environment-driven cookie/CSRF configuration (`SESSION_COOKIE_SAMESITE`, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `CSRF_TRUSTED_ORIGINS`)

**Test Helpers:**
- `tests/e2e/helpers/rp_process.py`: Extended `RpServer` with TLS support, per-port logging, isolated builds, and Firefox executable detection
- `tests/e2e/helpers/idp_process.py`: Extended `IdpServer` with TLS support and cookie/CSRF configuration
- `tests/e2e/helpers/browser.py`: Extracted `skip_or_fail()` utility for consistent E2E_REQUIRE_BROWSER handling

**Documentation & Configuration:**
- Updated `tests/e2e/README.md` with cross-site layer explanation and setup instructions
- Updated `tests/app/rp/README.md` with runtime configuration table
- Added GitHub Actions step to map `idp.test` and `rp.test` to loopback in CI
- Updated `tox.ini` with cross-site layer documentation
- Updated `pyproject.toml` with `spec_browser_cross_site` marker

### Why This Matters

Silent login (authorization with `prompt=none`) is a critical OIDC feature for seamless session refresh, but its success depends entirely on whether the browser's third-party cookie policy allows the OP's session cookie to reach the iframe. This test layer:

1. **Validates real-world behavior**: Tests against actual browser engines (Chromium, Firefox) with their real cookie policies, not mocks
2. **Covers the cookie policy spectrum**: Chromium (third-party cookies allowed) returns `code`; Firefox with Total Cookie Protection returns `login_required`; both outcomes are correct
3. **Prepares for future specs**: OIDC Session Management and Front-Channel Logout depend on the same cross-site cookie mechanism, so this harness is foundational

### Test Coverage

- `test_chromium_silent_login_returns_code`: Validates that Chromium allows third-party cookies and returns authorization code
- `test_silent_login_without_an

https://claude.ai/code/session_0171dxY6XNdrdHuCpQZKNthT