### PR TITLE
Add OAuth2 throttling classes for DRF and Django Ninja

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 ### Added
+* #984 New throttle classes for the Django REST Framework and Django Ninja integrations,
+  `OAuth2ClientRateThrottle` and `OAuth2UserOrClientRateThrottle`, that key rate limits on the
+  OAuth2 credentials a request was made with. A `client_credentials` token has no user, so the
+  per-user throttles those frameworks ship with fall through to keying machine-to-machine clients
+  by IP address, putting every client behind a shared egress address into one bucket; these key on
+  the client application instead. Buckets are keyed on primary keys rather than on the token, so
+  rotating a token does not reset the limit. See "Throttling" in the Django REST Framework and
+  Django Ninja documentation.
 * #483 `ACCESS_TOKEN_EXPIRE_SECONDS` now accepts a `datetime.timedelta`, or a callable taking the
   oauthlib request and returning a number of seconds or a `timedelta`, in addition to a plain number
   of seconds. This makes the access token lifetime vary per client, grant type, scope or session

--- a/docs/ninja.rst
+++ b/docs/ninja.rst
@@ -160,3 +160,10 @@ Ninja has no built-in default rate for either scope, so pass one to the construc
 above, or add ``oauth2_client`` / ``oauth2`` keys to the ``NINJA_DEFAULT_THROTTLE_RATES``
 setting. Throttle state lives in Django's cache, so a cache shared by every process
 serving the API is what makes the limit a limit.
+
+.. note:: Both classes read the access token from ``request.auth``. If you subclass
+    ``HttpOAuth2`` and return something else from ``authenticate``, as `Custom
+    Authorization Behavior`_ allows, they can no longer identify the client:
+    ``OAuth2ClientRateThrottle`` stops throttling those requests altogether, and
+    ``OAuth2UserOrClientRateThrottle`` falls back to the IP address. Keep returning the
+    access token itself when you use these throttles.

--- a/docs/ninja.rst
+++ b/docs/ninja.rst
@@ -121,3 +121,42 @@ For example:
             return access_token
 
     api = NinjaAPI(auth=StaffOnlyOAuth2())
+
+
+Throttling
+----------
+``OAuth2ClientRateThrottle`` and ``OAuth2UserOrClientRateThrottle`` key `Ninja's rate
+limiting <https://django-ninja.dev/guides/throttling/>`_ on the OAuth2 credentials a
+request was made with.
+
+They exist because a token issued through the ``client_credentials`` grant has no user
+attached to it -- there is no resource owner in that flow, only a client acting on its
+own behalf. Ninja's ``UserRateThrottle`` therefore falls through to keying such requests
+by IP address, which puts every machine-to-machine client behind a shared egress address
+into a single bucket, while its ``AuthRateThrottle`` keys on ``str(request.auth)`` and so
+gives each *token* its own bucket -- a client that can mint a fresh token can mint a
+fresh allowance with it. These classes key on the client application's primary key
+instead, which is stable across token rotation:
+
+.. code-block:: python
+
+    from ninja import NinjaAPI
+    from oauth2_provider.contrib.ninja import HttpOAuth2, OAuth2ClientRateThrottle
+
+    api = NinjaAPI()
+
+    @api.get("/songs", auth=HttpOAuth2(), throttle=[OAuth2ClientRateThrottle("10000/day")])
+    def songs_endpoint(request):
+        ...
+
+``OAuth2UserOrClientRateThrottle`` keys on the user when the token has one, and on the
+client application otherwise, which is what an API serving both interactive and
+machine-to-machine clients usually wants. Requests that were not authenticated with an
+OAuth2 access token are left alone by ``OAuth2ClientRateThrottle``, so it can be
+combined with the throttles covering the rest of an operation's traffic, and are keyed
+by user or IP address by ``OAuth2UserOrClientRateThrottle``.
+
+Ninja has no built-in default rate for either scope, so pass one to the constructor as
+above, or add ``oauth2_client`` / ``oauth2`` keys to the ``NINJA_DEFAULT_THROTTLE_RATES``
+setting. Throttle state lives in Django's cache, so a cache shared by every process
+serving the API is what makes the limit a limit.

--- a/docs/package_layout.rst
+++ b/docs/package_layout.rst
@@ -92,8 +92,8 @@ Package map
                                 server (see Naming above)
         client_assertions (RFC 7523 assertion *building*)
       contrib/                  third-party framework integrations (see below)
-        rest_framework/         DRF authentication + scope permissions
-        ninja/                  Django Ninja bearer-token security
+        rest_framework/         DRF authentication + scope permissions + throttling
+        ninja/                  Django Ninja bearer-token security + throttling
       settings.py, models.py, generators.py, validators.py, oauth2_validators.py
                                 stay at the top level (see below)
 
@@ -136,8 +136,9 @@ Framework integrations (``contrib/``)
 
 ``oauth2_provider/contrib/`` holds optional integrations with **third-party web
 frameworks** — Django REST Framework (``contrib/rest_framework``: the
-``OAuth2Authentication`` authenticators and the ``TokenHasScope`` family of
-permissions) and Django Ninja (``contrib/ninja``: bearer-token security). By
+``OAuth2Authentication`` authenticators, the ``TokenHasScope`` family of
+permissions and the OAuth2-aware rate throttles) and Django Ninja
+(``contrib/ninja``: bearer-token security and the same throttles). By
 *role* these are all **Resource Server** functionality — they let a DRF/Ninja app
 act as an OAuth2-protected resource server — and their internal imports use the
 canonical resource-server / core paths.

--- a/docs/rest-framework/rest-framework.rst
+++ b/docs/rest-framework/rest-framework.rst
@@ -6,3 +6,4 @@ Django Rest Framework
 
     getting_started
     permissions
+    throttling

--- a/docs/rest-framework/throttling.rst
+++ b/docs/rest-framework/throttling.rst
@@ -1,0 +1,95 @@
+Throttling
+==========
+
+Django OAuth Toolkit provides throttle classes that key rate limits on the OAuth2
+credentials a request was made with, for use with `Django REST Framework's throttling
+<https://www.django-rest-framework.org/api-guide/throttling/>`_.
+
+They exist because a token issued through the ``client_credentials`` grant has no user
+attached to it -- there is no resource owner in that flow, only a client acting on its
+own behalf. DRF's ``UserRateThrottle`` therefore falls through to keying such requests
+by IP address, which puts every machine-to-machine client behind a shared egress
+address into a single bucket, and ``AnonRateThrottle`` treats them as anonymous
+traffic. The classes below key on the client application instead, so each client gets
+the bucket it deserves.
+
+Buckets are keyed on primary keys, never on the token itself, so a client cannot buy
+itself a fresh allowance by asking for a fresh token.
+
+OAuth2ClientRateThrottle
+------------------------
+Limits the rate of API calls made by a given OAuth2 client application, whether or not
+the token carries a user.
+
+Requests that were not authenticated with an OAuth2 access token are not throttled by
+this class at all, so it can be combined with whatever throttles cover the rest of a
+view's traffic:
+
+.. code-block:: python
+
+    from rest_framework.throttling import UserRateThrottle
+    from oauth2_provider.contrib.rest_framework import (
+        OAuth2Authentication,
+        OAuth2ClientRateThrottle,
+        TokenHasScope,
+    )
+
+    class SongView(views.APIView):
+        authentication_classes = [OAuth2Authentication]
+        permission_classes = [TokenHasScope]
+        throttle_classes = [OAuth2ClientRateThrottle, UserRateThrottle]
+        required_scopes = ["music"]
+
+Its rate is configured under the ``oauth2_client`` scope:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        "DEFAULT_THROTTLE_RATES": {
+            "oauth2_client": "10000/day",
+        }
+    }
+
+OAuth2UserOrClientRateThrottle
+------------------------------
+Limits the rate of API calls made by a given user, or -- for ``client_credentials``
+tokens, which have no user -- by the client application the token was issued to. This
+is the drop-in replacement for ``UserRateThrottle`` on an API that serves both kinds of
+client:
+
+.. code-block:: python
+
+    REST_FRAMEWORK = {
+        "DEFAULT_THROTTLE_CLASSES": [
+            "oauth2_provider.contrib.rest_framework.OAuth2UserOrClientRateThrottle",
+        ],
+        "DEFAULT_THROTTLE_RATES": {
+            "oauth2": "1000/day",
+        },
+    }
+
+Requests that were not authenticated with an OAuth2 access token keep
+``UserRateThrottle``'s behavior: they are keyed by user when one is authenticated, and
+by IP address otherwise.
+
+Per-application rates
+---------------------
+Both classes take their rate from the DRF settings, which makes it the same for every
+client. To vary it -- a partner with a negotiated quota, say -- override ``get_rate``
+or ``allow_request`` on a subclass. Because ``SimpleRateThrottle`` parses its rate in
+``__init__``, before there is a request to inspect, a per-request rate has to be
+re-parsed in ``allow_request``, the way DRF's own ``ScopedRateThrottle`` does:
+
+.. code-block:: python
+
+    class PerApplicationRateThrottle(OAuth2ClientRateThrottle):
+        def allow_request(self, request, view):
+            application = getattr(request.auth, "application", None)
+            # `rate_limit` here is a field on a custom application model.
+            rate = getattr(application, "rate_limit", None) or self.get_rate()
+            self.rate = rate
+            self.num_requests, self.duration = self.parse_rate(rate)
+            return super().allow_request(request, view)
+
+Note that throttle state lives in Django's cache, so a cache shared by every process
+serving the API is what makes the limit a limit.

--- a/docs/rest-framework/throttling.rst
+++ b/docs/rest-framework/throttling.rst
@@ -27,18 +27,25 @@ view's traffic:
 
 .. code-block:: python
 
-    from rest_framework.throttling import UserRateThrottle
+    from rest_framework.views import APIView
     from oauth2_provider.contrib.rest_framework import (
         OAuth2Authentication,
         OAuth2ClientRateThrottle,
         TokenHasScope,
     )
 
-    class SongView(views.APIView):
+    class SongView(APIView):
         authentication_classes = [OAuth2Authentication]
         permission_classes = [TokenHasScope]
-        throttle_classes = [OAuth2ClientRateThrottle, UserRateThrottle]
+        throttle_classes = [OAuth2ClientRateThrottle]
         required_scopes = ["music"]
+
+.. note:: DRF evaluates **every** throttle in ``throttle_classes``, and this class
+    declining a request does not excuse the others. Listing ``UserRateThrottle`` or
+    ``AnonRateThrottle`` beside it puts ``client_credentials`` requests back into an
+    IP-keyed bucket through those classes -- the very behavior this page exists to
+    avoid. When one view serves both interactive and machine-to-machine clients, reach
+    for :ref:`oauth2-user-or-client-rate-throttle` instead of them.
 
 Its rate is configured under the ``oauth2_client`` scope:
 
@@ -49,6 +56,8 @@ Its rate is configured under the ``oauth2_client`` scope:
             "oauth2_client": "10000/day",
         }
     }
+
+.. _oauth2-user-or-client-rate-throttle:
 
 OAuth2UserOrClientRateThrottle
 ------------------------------

--- a/oauth2_provider/contrib/ninja/__init__.py
+++ b/oauth2_provider/contrib/ninja/__init__.py
@@ -1,4 +1,5 @@
 from .security import HttpOAuth2
+from .throttling import OAuth2ClientRateThrottle, OAuth2UserOrClientRateThrottle
 
 
-__all__ = ["HttpOAuth2"]
+__all__ = ["HttpOAuth2", "OAuth2ClientRateThrottle", "OAuth2UserOrClientRateThrottle"]

--- a/oauth2_provider/contrib/ninja/throttling.py
+++ b/oauth2_provider/contrib/ninja/throttling.py
@@ -1,0 +1,58 @@
+from django.http import HttpRequest
+from ninja.throttling import SimpleRateThrottle
+
+from ...core.throttling import USER_IDENT_PREFIX, get_client_ident, get_user_or_client_ident
+
+
+class OAuth2ClientRateThrottle(SimpleRateThrottle):
+    """
+    Limit the rate of API calls made by a given OAuth2 client application.
+
+    The primary key of the application the access token was issued to is used as the
+    cache key, so every client gets its own bucket regardless of whether the token
+    carries a user. Requests that were not authenticated with an OAuth2 access token
+    are not throttled by this class at all, which lets it be combined with the throttles
+    that cover the rest of an operation's traffic.
+
+    Ninja has no default rate for this throttle's scope, so pass one to the constructor
+    (``OAuth2ClientRateThrottle("1000/day")``) or add an ``oauth2_client`` key to the
+    ``NINJA_DEFAULT_THROTTLE_RATES`` setting.
+    """
+
+    scope = "oauth2_client"
+
+    def get_cache_key(self, request: HttpRequest) -> str | None:
+        ident = get_client_ident(getattr(request, "auth", None))
+        if ident is None:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class OAuth2UserOrClientRateThrottle(SimpleRateThrottle):
+    """
+    Limit the rate of API calls made by a given user, or -- for ``client_credentials``
+    tokens, which have no user -- by the client application the token was issued to.
+
+    This is the throttle to reach for instead of Ninja's ``UserRateThrottle``, which
+    keys userless tokens by IP address, or its ``AuthRateThrottle``, which keys on
+    ``str(request.auth)`` and so gives each *token* its own bucket -- a client that can
+    mint a fresh token can mint a fresh allowance with it. Requests that were not
+    authenticated with an OAuth2 access token keep ``UserRateThrottle``'s behavior:
+    keyed by user when one is authenticated, by IP address otherwise.
+
+    Ninja has no default rate for this throttle's scope, so pass one to the constructor
+    (``OAuth2UserOrClientRateThrottle("1000/day")``) or add an ``oauth2`` key to the
+    ``NINJA_DEFAULT_THROTTLE_RATES`` setting.
+    """
+
+    scope = "oauth2"
+
+    def get_cache_key(self, request: HttpRequest) -> str:
+        ident = get_user_or_client_ident(getattr(request, "auth", None))
+        if ident is None:
+            user = getattr(request, "user", None)
+            if user is not None and user.is_authenticated:
+                ident = "{prefix}-{pk}".format(prefix=USER_IDENT_PREFIX, pk=user.pk)
+            else:
+                ident = self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}

--- a/oauth2_provider/contrib/rest_framework/__init__.py
+++ b/oauth2_provider/contrib/rest_framework/__init__.py
@@ -7,3 +7,4 @@ from .permissions import (
     TokenHasScope,
     TokenMatchesOASRequirements,
 )
+from .throttling import OAuth2ClientRateThrottle, OAuth2UserOrClientRateThrottle

--- a/oauth2_provider/contrib/rest_framework/throttling.py
+++ b/oauth2_provider/contrib/rest_framework/throttling.py
@@ -1,0 +1,56 @@
+from rest_framework.request import Request
+from rest_framework.throttling import SimpleRateThrottle
+from rest_framework.views import APIView
+
+from ...core.throttling import USER_IDENT_PREFIX, get_client_ident, get_user_or_client_ident
+
+
+class OAuth2ClientRateThrottle(SimpleRateThrottle):
+    """
+    Limit the rate of API calls made by a given OAuth2 client application.
+
+    The primary key of the application the access token was issued to is used as the
+    cache key, so every client gets its own bucket regardless of whether the token
+    carries a user. Requests that were not authenticated with an OAuth2 access token
+    are not throttled by this class at all, which lets it be combined with the throttles
+    that cover the rest of a view's traffic.
+
+    Configure its rate under the ``oauth2_client`` key of DRF's
+    ``DEFAULT_THROTTLE_RATES`` setting, or set ``rate`` on a subclass.
+    """
+
+    scope = "oauth2_client"
+
+    def get_cache_key(self, request: Request, view: APIView) -> str | None:
+        ident = get_client_ident(getattr(request, "auth", None))
+        if ident is None:
+            return None
+        return self.cache_format % {"scope": self.scope, "ident": ident}
+
+
+class OAuth2UserOrClientRateThrottle(SimpleRateThrottle):
+    """
+    Limit the rate of API calls made by a given user, or -- for ``client_credentials``
+    tokens, which have no user -- by the client application the token was issued to.
+
+    This is the drop-in replacement for DRF's ``UserRateThrottle`` on an API that serves
+    machine-to-machine clients: ``UserRateThrottle`` keys those requests by IP address,
+    which lumps every client behind a shared egress address into one bucket. Requests
+    that were not authenticated with an OAuth2 access token keep ``UserRateThrottle``'s
+    behavior: keyed by user when one is authenticated, by IP address otherwise.
+
+    Configure its rate under the ``oauth2`` key of DRF's ``DEFAULT_THROTTLE_RATES``
+    setting, or set ``rate`` on a subclass.
+    """
+
+    scope = "oauth2"
+
+    def get_cache_key(self, request: Request, view: APIView) -> str:
+        ident = get_user_or_client_ident(getattr(request, "auth", None))
+        if ident is None:
+            user = getattr(request, "user", None)
+            if user is not None and user.is_authenticated:
+                ident = "{prefix}-{pk}".format(prefix=USER_IDENT_PREFIX, pk=user.pk)
+            else:
+                ident = self.get_ident(request)
+        return self.cache_format % {"scope": self.scope, "ident": ident}

--- a/oauth2_provider/core/throttling.py
+++ b/oauth2_provider/core/throttling.py
@@ -1,0 +1,53 @@
+"""
+Request identities used to key rate limits on OAuth2-authenticated requests.
+
+Both framework integrations in :mod:`oauth2_provider.contrib` build their throttle
+classes on their own framework's throttling machinery, but "who is this request
+from?" has a single OAuth2 answer, so it is answered once here.
+
+Tokens issued through the ``client_credentials`` grant have no user -- see
+``OAuth2Validator._create_access_token`` -- so the per-user throttles that ship with
+those frameworks fall through to keying every machine-to-machine client by IP
+address. Keying on the client application the token was issued to instead gives each
+client its own bucket, which is what a machine client actually is.
+
+The identities below are derived from primary keys, never from the token itself: a
+throttle bucket must survive the client rotating its tokens, and cache keys are not a
+place to put credentials.
+"""
+
+from ..models import AbstractAccessToken
+
+
+CLIENT_IDENT_PREFIX = "client"
+USER_IDENT_PREFIX = "user"
+
+
+def get_client_ident(access_token: object) -> str | None:
+    """
+    Identify the client application ``access_token`` was issued to.
+
+    Returns ``None`` when the request was not authenticated with an OAuth2 access
+    token, or when the token is not tied to an application, so that callers can leave
+    such requests to whatever throttles handle the rest of their traffic.
+    """
+    if not isinstance(access_token, AbstractAccessToken):
+        return None
+    if access_token.application_id is None:
+        return None
+    return "{prefix}-{pk}".format(prefix=CLIENT_IDENT_PREFIX, pk=access_token.application_id)
+
+
+def get_user_or_client_ident(access_token: object) -> str | None:
+    """
+    Identify the resource owner ``access_token`` was issued for, falling back to the
+    client application for tokens with no user (``client_credentials``).
+
+    The two are prefixed apart: without that, user #5 and application #5 would share a
+    single bucket. Returns ``None`` under the same conditions as :func:`get_client_ident`.
+    """
+    if not isinstance(access_token, AbstractAccessToken):
+        return None
+    if access_token.user_id is not None:
+        return "{prefix}-{pk}".format(prefix=USER_IDENT_PREFIX, pk=access_token.user_id)
+    return get_client_ident(access_token)

--- a/tests/test_ninja_throttling.py
+++ b/tests/test_ninja_throttling.py
@@ -176,3 +176,18 @@ class TestNinjaThrottling(TestCase):
 
         response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.6")
         self.assertEqual(response.status_code, 200)
+
+    def test_user_or_client_throttle_falls_back_to_session_user(self):
+        """A session-authenticated request has no token, but still has an identity."""
+        self.client.force_login(self.test_user)
+        for _ in range(2):
+            response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.5")
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.5")
+        self.assertEqual(response.status_code, 429)
+
+        # Same address, different user: keyed by user rather than by IP.
+        self.client.force_login(self.other_user)
+        response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.5")
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_ninja_throttling.py
+++ b/tests/test_ninja_throttling.py
@@ -1,0 +1,178 @@
+from datetime import timedelta
+
+import pytest
+from django.conf.urls import include
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.test.utils import override_settings
+from django.urls import path
+from django.utils import timezone
+from ninja import NinjaAPI
+
+from oauth2_provider.contrib.ninja import (
+    HttpOAuth2,
+    OAuth2ClientRateThrottle,
+    OAuth2UserOrClientRateThrottle,
+)
+from oauth2_provider.models import get_access_token_model, get_application_model
+
+from .common_testing import OAuth2ProviderTestCase as TestCase
+
+
+Application = get_application_model()
+AccessToken = get_access_token_model()
+UserModel = get_user_model()
+
+api = NinjaAPI()
+
+
+@api.get("/client-throttled", auth=HttpOAuth2(), throttle=[OAuth2ClientRateThrottle("2/min")])
+def client_throttled_endpoint(request):
+    return {"message": "throttled per client application"}
+
+
+@api.get(
+    "/user-or-client-throttled",
+    auth=HttpOAuth2(),
+    throttle=[OAuth2UserOrClientRateThrottle("2/min")],
+)
+def user_or_client_throttled_endpoint(request):
+    return {"message": "throttled per user, or per client for client_credentials"}
+
+
+@api.get("/open-client-throttled", throttle=[OAuth2ClientRateThrottle("2/min")])
+def open_client_throttled_endpoint(request):
+    return {"message": "not OAuth2 authenticated"}
+
+
+@api.get("/open-user-or-client-throttled", throttle=[OAuth2UserOrClientRateThrottle("2/min")])
+def open_user_or_client_throttled_endpoint(request):
+    return {"message": "not OAuth2 authenticated"}
+
+
+urlpatterns = [
+    path("oauth2/", include("oauth2_provider.urls")),
+    path("api/", api.urls),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_throttle_cache():
+    """Throttle history lives in Django's cache; isolate it per test."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.nologinrequiredmiddleware
+@pytest.mark.usefixtures("oauth2_settings")
+class TestNinjaThrottling(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.other_user = UserModel.objects.create_user("other_user", "other@example.com", "123456")
+
+        cls.application = Application.objects.create(
+            name="Machine Client",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        cls.other_application = Application.objects.create(
+            name="Other Machine Client",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+
+        # `client_credentials` tokens have no user: OAuth2Validator._create_access_token
+        # sets `request.user = None` for that grant.
+        cls.client_token = cls._create_token("client-credentials-token", None, cls.application)
+        cls.rotated_client_token = cls._create_token("rotated-token", None, cls.application)
+        cls.other_client_token = cls._create_token("other-client-token", None, cls.other_application)
+        cls.user_token = cls._create_token("user-token", cls.test_user, cls.application)
+        cls.other_user_token = cls._create_token("other-user-token", cls.other_user, cls.application)
+
+    @classmethod
+    def _create_token(cls, token, user, application):
+        return AccessToken.objects.create(
+            user=user,
+            scope="read write",
+            expires=timezone.now() + timedelta(seconds=300),
+            token=token,
+            application=application,
+        )
+
+    def _get(self, url, token=None, remote_addr="127.0.0.1"):
+        extra = {"REMOTE_ADDR": remote_addr}
+        if token is not None:
+            extra["HTTP_AUTHORIZATION"] = "Bearer {0}".format(token)
+        return self.client.get(url, **extra)
+
+    def test_client_credentials_requests_are_throttled(self):
+        for _ in range(2):
+            response = self._get("/api/client-throttled", self.client_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/client-throttled", self.client_token.token)
+        self.assertEqual(response.status_code, 429)
+
+    def test_each_client_gets_its_own_bucket_behind_a_shared_address(self):
+        for _ in range(2):
+            response = self._get("/api/client-throttled", self.client_token.token, "203.0.113.7")
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/client-throttled", self.client_token.token, "203.0.113.7")
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/api/client-throttled", self.other_client_token.token, "203.0.113.7")
+        self.assertEqual(response.status_code, 200)
+
+    def test_rotating_the_token_does_not_reset_the_bucket(self):
+        """Unlike Ninja's AuthRateThrottle, which keys on str(request.auth)."""
+        for _ in range(2):
+            response = self._get("/api/client-throttled", self.client_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/client-throttled", self.rotated_client_token.token)
+        self.assertEqual(response.status_code, 429)
+
+    def test_client_throttle_ignores_non_oauth2_requests(self):
+        for _ in range(3):
+            response = self._get("/api/open-client-throttled")
+            self.assertEqual(response.status_code, 200)
+
+    def test_user_or_client_throttle_keys_user_tokens_by_user(self):
+        for _ in range(2):
+            response = self._get("/api/user-or-client-throttled", self.user_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/user-or-client-throttled", self.user_token.token)
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/api/user-or-client-throttled", self.other_user_token.token)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_or_client_throttle_keys_client_credentials_by_client(self):
+        for _ in range(2):
+            response = self._get("/api/user-or-client-throttled", self.client_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/user-or-client-throttled", self.client_token.token)
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/api/user-or-client-throttled", self.other_client_token.token)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_or_client_throttle_falls_back_to_ip_when_unauthenticated(self):
+        for _ in range(2):
+            response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.5")
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.5")
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/api/open-user-or-client-throttled", remote_addr="198.51.100.6")
+        self.assertEqual(response.status_code, 200)

--- a/tests/test_rest_framework_throttling.py
+++ b/tests/test_rest_framework_throttling.py
@@ -1,0 +1,242 @@
+from datetime import timedelta
+
+import pytest
+from django.conf.urls import include
+from django.contrib.auth import get_user_model
+from django.core.cache import cache
+from django.http import HttpResponse
+from django.test.utils import override_settings
+from django.urls import path
+from django.utils import timezone
+from rest_framework import permissions
+from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from oauth2_provider.contrib.rest_framework import (
+    OAuth2Authentication,
+    OAuth2ClientRateThrottle,
+    OAuth2UserOrClientRateThrottle,
+    TokenHasScope,
+)
+from oauth2_provider.core.throttling import get_client_ident, get_user_or_client_ident
+from oauth2_provider.models import get_access_token_model, get_application_model
+
+from . import presets
+from .common_testing import OAuth2ProviderTestCase as TestCase
+
+
+Application = get_application_model()
+AccessToken = get_access_token_model()
+UserModel = get_user_model()
+
+
+class TwoPerMinuteClientThrottle(OAuth2ClientRateThrottle):
+    rate = "2/min"
+
+
+class TwoPerMinuteUserOrClientThrottle(OAuth2UserOrClientRateThrottle):
+    rate = "2/min"
+
+
+class MockView(APIView):
+    authentication_classes = [OAuth2Authentication]
+    permission_classes = [TokenHasScope]
+    required_scopes = ["read"]
+
+    def get(self, request):
+        return HttpResponse({"a": 1, "b": 2, "c": 3})
+
+
+class ClientThrottledView(MockView):
+    throttle_classes = [TwoPerMinuteClientThrottle]
+
+
+class UserOrClientThrottledView(MockView):
+    throttle_classes = [TwoPerMinuteUserOrClientThrottle]
+
+
+class OpenClientThrottledView(ClientThrottledView):
+    permission_classes = [permissions.AllowAny]
+
+
+class OpenUserOrClientThrottledView(UserOrClientThrottledView):
+    permission_classes = [permissions.AllowAny]
+
+
+urlpatterns = [
+    path("oauth2/", include("oauth2_provider.urls")),
+    path("oauth2-client-throttled/", ClientThrottledView.as_view()),
+    path("oauth2-user-or-client-throttled/", UserOrClientThrottledView.as_view()),
+    path("open-client-throttled/", OpenClientThrottledView.as_view()),
+    path("open-user-or-client-throttled/", OpenUserOrClientThrottledView.as_view()),
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_throttle_cache():
+    """Throttle history lives in Django's cache; isolate it per test."""
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.nologinrequiredmiddleware
+@pytest.mark.usefixtures("oauth2_settings")
+@pytest.mark.oauth2_settings(presets.REST_FRAMEWORK_SCOPES)
+class TestOAuth2Throttling(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
+        cls.test_user = UserModel.objects.create_user("test_user", "test@example.com", "123456")
+        cls.other_user = UserModel.objects.create_user("other_user", "other@example.com", "123456")
+
+        cls.application = Application.objects.create(
+            name="Machine Client",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+        cls.other_application = Application.objects.create(
+            name="Other Machine Client",
+            user=cls.dev_user,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            authorization_grant_type=Application.GRANT_CLIENT_CREDENTIALS,
+        )
+
+        # `client_credentials` tokens have no user: OAuth2Validator._create_access_token
+        # sets `request.user = None` for that grant.
+        cls.client_token = cls._create_token("client-credentials-token", None, cls.application)
+        cls.rotated_client_token = cls._create_token("rotated-token", None, cls.application)
+        cls.other_client_token = cls._create_token("other-client-token", None, cls.other_application)
+        cls.user_token = cls._create_token("user-token", cls.test_user, cls.application)
+        cls.other_user_token = cls._create_token("other-user-token", cls.other_user, cls.application)
+
+    @classmethod
+    def _create_token(cls, token, user, application):
+        return AccessToken.objects.create(
+            user=user,
+            scope="read write",
+            expires=timezone.now() + timedelta(seconds=300),
+            token=token,
+            application=application,
+        )
+
+    def _drf_request(self, user=None, auth=None, remote_addr="127.0.0.1"):
+        """A DRF request with authentication already resolved, as a throttle sees it."""
+        request = Request(APIRequestFactory().get("/", REMOTE_ADDR=remote_addr))
+        request.user = user
+        request.auth = auth
+        return request
+
+    def _get(self, url, token=None, remote_addr="127.0.0.1"):
+        extra = {"REMOTE_ADDR": remote_addr}
+        if token is not None:
+            extra["HTTP_AUTHORIZATION"] = "Bearer {0}".format(token)
+        return self.client.get(url, **extra)
+
+    def test_client_credentials_requests_are_throttled(self):
+        """A userless token is throttled at all, rather than sliding into the IP bucket."""
+        for _ in range(2):
+            response = self._get("/oauth2-client-throttled/", self.client_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/oauth2-client-throttled/", self.client_token.token)
+        self.assertEqual(response.status_code, 429)
+
+    def test_each_client_gets_its_own_bucket_behind_a_shared_address(self):
+        """The point of #984: two machine clients on one egress address do not share a bucket."""
+        for _ in range(2):
+            response = self._get("/oauth2-client-throttled/", self.client_token.token, "203.0.113.7")
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/oauth2-client-throttled/", self.client_token.token, "203.0.113.7")
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/oauth2-client-throttled/", self.other_client_token.token, "203.0.113.7")
+        self.assertEqual(response.status_code, 200)
+
+    def test_rotating_the_token_does_not_reset_the_bucket(self):
+        """The bucket follows the client, not the token, so re-issuing one buys nothing."""
+        for _ in range(2):
+            response = self._get("/oauth2-client-throttled/", self.client_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/oauth2-client-throttled/", self.rotated_client_token.token)
+        self.assertEqual(response.status_code, 429)
+
+    def test_client_throttle_ignores_non_oauth2_requests(self):
+        """Unthrottled here, so the class can be combined with whatever covers the rest."""
+        response = self._get("/open-client-throttled/")
+        self.assertEqual(response.status_code, 200)
+
+        request = self._drf_request(user=self.test_user)
+        self.assertIsNone(TwoPerMinuteClientThrottle().get_cache_key(request, OpenClientThrottledView()))
+
+    def test_user_or_client_throttle_keys_user_tokens_by_user(self):
+        """Two users of one application are throttled apart, matching UserRateThrottle."""
+        for _ in range(2):
+            response = self._get("/oauth2-user-or-client-throttled/", self.user_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/oauth2-user-or-client-throttled/", self.user_token.token)
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/oauth2-user-or-client-throttled/", self.other_user_token.token)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_or_client_throttle_keys_client_credentials_by_client(self):
+        for _ in range(2):
+            response = self._get("/oauth2-user-or-client-throttled/", self.client_token.token)
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/oauth2-user-or-client-throttled/", self.client_token.token)
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/oauth2-user-or-client-throttled/", self.other_client_token.token)
+        self.assertEqual(response.status_code, 200)
+
+    def test_user_and_client_idents_do_not_collide(self):
+        """A user and an application that share a primary key must not share a bucket."""
+        token_with_user = AccessToken(user_id=5, application_id=9)
+        userless_token = AccessToken(user_id=None, application_id=5)
+
+        self.assertEqual(get_user_or_client_ident(token_with_user), "user-5")
+        self.assertEqual(get_user_or_client_ident(userless_token), "client-5")
+        self.assertEqual(get_client_ident(token_with_user), "client-9")
+
+    def test_idents_are_none_for_non_oauth2_credentials(self):
+        """`request.auth` set by some other authentication class is left alone."""
+        self.assertIsNone(get_client_ident(None))
+        self.assertIsNone(get_user_or_client_ident(None))
+        self.assertIsNone(get_client_ident("some-other-tokens-value"))
+        self.assertIsNone(get_user_or_client_ident("some-other-tokens-value"))
+
+    def test_user_or_client_throttle_falls_back_to_session_user(self):
+        request = self._drf_request(user=self.test_user)
+
+        key = TwoPerMinuteUserOrClientThrottle().get_cache_key(request, OpenUserOrClientThrottledView())
+        self.assertEqual(key, "throttle_oauth2_user-{0}".format(self.test_user.pk))
+
+    def test_user_or_client_throttle_falls_back_to_ip_when_unauthenticated(self):
+        for _ in range(2):
+            response = self._get("/open-user-or-client-throttled/", remote_addr="198.51.100.5")
+            self.assertEqual(response.status_code, 200)
+
+        response = self._get("/open-user-or-client-throttled/", remote_addr="198.51.100.5")
+        self.assertEqual(response.status_code, 429)
+
+        response = self._get("/open-user-or-client-throttled/", remote_addr="198.51.100.6")
+        self.assertEqual(response.status_code, 200)
+
+    def test_token_without_application_is_not_client_throttled(self):
+        """AccessToken.application is nullable; such a token has no client to key on."""
+        orphan_token = self._create_token("orphan-token", None, None)
+        request = self._drf_request(auth=orphan_token)
+
+        self.assertIsNone(TwoPerMinuteClientThrottle().get_cache_key(request, OpenClientThrottledView()))
+        self.assertEqual(
+            TwoPerMinuteUserOrClientThrottle().get_cache_key(request, OpenUserOrClientThrottledView()),
+            "throttle_oauth2_127.0.0.1",
+        )


### PR DESCRIPTION
Fixes #984

## Description of the Change

Adds throttle classes that key rate limits on the OAuth2 credentials a request was made with, for both the Django REST Framework and Django Ninja integrations.

### Problem

A token issued through the `client_credentials` grant has no user — `OAuth2Validator._create_access_token` sets `request.user = None` for that grant — so the per-user throttles both frameworks ship with fall through to keying those requests by IP address. Verified against `master`:

| Token | `request.user` | DRF `UserRateThrottle` key | DRF `AnonRateThrottle` key |
|---|---|---|---|
| `client_credentials` | `None` | `throttle_user_1.2.3.4` | `throttle_anon_1.2.3.4` |
| `authorization_code` | `<User: test_user>` | `throttle_user_2` | `None` (not throttled) |

Nothing crashes — DRF guards with `if request.user and request.user.is_authenticated` — it silently degrades, with three consequences:

- Every machine client behind one NAT/egress gateway shares a single bucket, so one noisy client starves the rest and per-client quotas are impossible.
- `AnonRateThrottle` applies its (typically low) anonymous rate to fully authenticated service traffic.
- On the Ninja side, `AuthRateThrottle` keys on `sha256(str(request.auth))`, and `AccessToken.__str__` is `"AccessToken #<pk>"` — so the bucket is per token row. A client credentials client can mint a fresh token in one HTTP call and get a clean bucket, which makes that limit bypassable.

The information needed to do this correctly is already on the request: `request.auth.application` is populated.

### Solution

Two classes, added to both integrations:

1. **`OAuth2ClientRateThrottle`** — keys on the client application's primary key, so every client gets its own bucket whether or not the token carries a user. Returns no key for requests that were not authenticated with an OAuth2 access token, so it composes with the throttles covering the rest of a view's traffic (the same reasoning as `TokenHasScope` declining foreign `request.auth`, #1169).
2. **`OAuth2UserOrClientRateThrottle`** — keys on the user when the token has one, on the client application otherwise. The drop-in replacement for `UserRateThrottle` on an API serving both interactive and machine-to-machine clients; non-OAuth2 requests keep `UserRateThrottle`'s user-or-IP behavior.

Three details worth review attention:

- **Identities are prefixed apart** (`user-5` vs `client-5`). Without that, user #5 and application #5 would share one bucket.
- **`AccessToken.application` is nullable**, so a token with no application falls back rather than raising.
- **Keys come from primary keys, never the token** — rotating a token does not reset the limit. There is a test for this, and it is what closes the Ninja `AuthRateThrottle` bypass above.

Both integrations delegate to one shared identity helper, `oauth2_provider/core/throttling.py`, so the keying rule is written once.

Per-application rates (a negotiated quota for one partner) are documented as a subclass hook rather than shipped: `SimpleRateThrottle` parses its rate in `__init__`, before there is a request to inspect, so a per-request rate must be re-parsed in `allow_request` the way DRF's own `ScopedRateThrottle` does.

### Verification

- 18 new tests (11 DRF, 7 Ninja). The central regression test fails on the stock throttles: substituting DRF's `UserRateThrottle` makes `test_each_client_gets_its_own_bucket_behind_a_shared_address` fail `429 != 200`, i.e. the second client on the shared address starved by the first.
- Full suite: 1515 passed. Two failures — `test_settings.py::TestAccessTokenExpiresIn::test_invalid_static_value_is_rejected` and `test_django_checks.py::AccessTokenExpiryConfigurationCheckTestCase::test_valid_values_pass` — reproduce identically on the base commit under xdist and pass in isolation, so they are pre-existing ordering flakes unrelated to this change and were left alone.
- `ruff check` + `ruff format --check` clean, `sphinx-lint docs/` clean, `make html` builds with only pre-existing warnings.

## Checklist

- [x] PR only contains one change (considered splitting up PR)
- [x] unit-test added
- [x] documentation updated
- [x] `CHANGELOG.md` updated (only for user relevant changes)
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated to demonstrate new features
- [ ] tests/app/rp updated to demonstrate new features

The last two are not applicable: neither demo app uses DRF or Django Ninja, so demonstrating these classes there would mean adding a framework dependency to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TS9Vmn8q2FqGVdSsAy1tR6