### PR TITLE
fix(rfc9207): add iss to authorization error redirects too

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -150,3 +150,4 @@ Apoorv Darshan
 Wojtek
 Rafa Audibert
 ArockiaRajamanickam
+nityanand123gupta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is unchanged in every case, only subclassing and patching are affected.
 
 ### Fixed
+* #1846 The `iss` authorization-response parameter (RFC 9207, gated by
+  `COMPLIANT_BCP_RFC9700_AUTHZ_RESPONSE_ISS`) is now added to error redirects as well as
+  successful ones. RFC 9207 §2 requires it on every authorization response, but it was only
+  ever added on the success path in `create_authorization_response`; an error redirect (e.g.
+  the resource owner denying access) built its `Location` header directly in
+  `AuthorizationServerViewMixin.error_response` with no `iss` injection at all.
 * #1828 Two resource-server paths no longer log at the wrong level. A non-200 introspection
   response is an ordinary response, not an exception, so it is logged with `log.warning` instead
   of `log.exception` — the latter appended a meaningless `NoneType: None` line to every such

--- a/oauth2_provider/authorization_server/views/mixins.py
+++ b/oauth2_provider/authorization_server/views/mixins.py
@@ -8,8 +8,10 @@ endpoints. It builds on the shared
 
 from django.http import HttpRequest
 
+from oauth2_provider.core.backends_oauthlib import _add_iss_to_redirect
 from oauth2_provider.core.exceptions import FatalClientError
 from oauth2_provider.core.views import OAuthLibCoreMixin
+from oauth2_provider.settings import oauth2_settings
 
 
 class AuthorizationServerViewMixin(OAuthLibCoreMixin):
@@ -95,9 +97,21 @@ class AuthorizationServerViewMixin(OAuthLibCoreMixin):
         redirect_uri = oauthlib_error.redirect_uri or ""
         separator = "&" if "?" in redirect_uri else "?"
 
+        url = redirect_uri + separator + oauthlib_error.urlencoded
+
+        # RFC 9207 §2 requires `iss` on *every* authorization response, including error
+        # responses -- not just successful ones (see _add_iss_to_redirect's other call
+        # site in backends_oauthlib.create_authorization_response). Only add it when
+        # there's an actual redirect_uri to redirect to: a FatalClientError has none (it
+        # renders an error page instead of redirecting, since the redirect_uri itself
+        # couldn't be trusted), and there's nothing to add `iss` to in that case.
+        if redirect_uri and oauth2_settings.COMPLIANT_BCP_RFC9700_AUTHZ_RESPONSE_ISS:
+            issuer = oauth2_settings.oauth2_authorization_server_issuer(self.request)
+            url = _add_iss_to_redirect(url, issuer)
+
         error_response = {
             "error": oauthlib_error,
-            "url": redirect_uri + separator + oauthlib_error.urlencoded,
+            "url": url,
         }
         error_response.update(kwargs)
 

--- a/tests/test_bcp_rfc9700.py
+++ b/tests/test_bcp_rfc9700.py
@@ -182,6 +182,42 @@ class TestPkcePlainGate(TestCase):
         # RFC 9207: the issuer (matching the metadata issuer) is echoed on the redirect.
         self.assertIn("iss=http%3A%2F%2Ftestserver%2Fo", response["Location"])
 
+    def test_iss_added_to_authorization_error_redirect(self):
+        # RFC 9207 §2 requires `iss` on error responses too, not just successful ones.
+        self.oauth2_settings.COMPLIANT_BCP_RFC9700_AUTHZ_RESPONSE_ISS = True
+        self.client.login(username="co", password="123456")
+        response = self.client.post(
+            reverse("oauth2_provider:authorize"),
+            data={
+                "client_id": self.application.client_id,
+                "response_type": "code",
+                "redirect_uri": "https://example.org/cb",
+                "scope": "read",
+                "state": "abc",
+                "allow": False,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("error=access_denied", response["Location"])
+        self.assertIn("iss=http%3A%2F%2Ftestserver%2Fo", response["Location"])
+
+    def test_iss_omitted_from_authorization_error_redirect_by_default(self):
+        self.client.login(username="co", password="123456")
+        response = self.client.post(
+            reverse("oauth2_provider:authorize"),
+            data={
+                "client_id": self.application.client_id,
+                "response_type": "code",
+                "redirect_uri": "https://example.org/cb",
+                "scope": "read",
+                "state": "abc",
+                "allow": False,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("error=access_denied", response["Location"])
+        self.assertNotIn("iss=", response["Location"])
+
     def test_iss_omitted_by_default(self):
         self.client.login(username="co", password="123456")
         response = self.client.post(


### PR DESCRIPTION
Fixes #1846

## Description of the Change

[RFC 9207 §2](https://www.rfc-editor.org/rfc/rfc9207.txt) requires the `iss` authorization-response parameter on **every** authorization response, including error responses — but it was only ever added on the success path.

`OAuthLibCore.create_authorization_response` calls `_add_iss_to_redirect` after a successful `Location` header is built, gated by `COMPLIANT_BCP_RFC9700_AUTHZ_RESPONSE_ISS`. `AuthorizationServerViewMixin.error_response`, however, builds its redirect URL directly (`redirect_uri + separator + oauthlib_error.urlencoded`) with no `iss` injection at all — so e.g. a resource owner denying access produces an error redirect missing `iss`, even with the setting enabled.

The fix reuses the same `_add_iss_to_redirect` helper in `error_response`, under the same setting gate, only when there's an actual `redirect_uri` to redirect to (a `FatalClientError` has none — it renders an error page instead of redirecting, since the `redirect_uri` itself couldn't be trusted, so there's nothing to add `iss` to in that case).

## Checklist

- [x] PR only contains one change
- [x] unit-test added
- [ ] documentation updated (no docs describe `error_response`'s URL-building directly; the existing RFC 9207 docs already describe the general behavior this now correctly extends to errors)
- [x] `CHANGELOG.md` updated
- [x] author name in `AUTHORS`
- [ ] tests/app/idp updated (not a new feature, no IdP demo app changes needed)
- [ ] tests/app/rp updated (same as above)

## Testing

- Added `test_iss_added_to_authorization_error_redirect` and `test_iss_omitted_from_authorization_error_redirect_by_default` to `tests/test_bcp_rfc9700.py`, mirroring the existing success-path tests but with `allow=False` (user denies) to hit the error-redirect path.
- Verified the new "added" test fails without the fix (`git stash` on `mixins.py` alone) and passes with it restored.
- Full suite: `pytest tests/` → 1522 passed, 3 skipped (3 known pre-existing failures unrelated to this change — timezone/import-compat flakiness confirmed present on a clean checkout before my change too).
- `ruff check` and `ruff format --check` are clean on the changed files.